### PR TITLE
Have user indicate what kind of data - continuous or categorical - is in each column

### DIFF
--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import { setImportedData, setMetaDataByColumn } from "../redux";
+import { setImportedData, setMetaDataByColumn, ColumnTypes } from "../redux";
 
 class CSVReaderWrapper extends Component {
   static propTypes = {
@@ -42,7 +42,7 @@ class CSVReaderWrapper extends Component {
 
   updateMetaData = data => {
     Object.keys(data[0]).map(column =>
-      this.props.setMetaDataByColumn(column, "dataType", "other")
+      this.props.setMetaDataByColumn(column, "dataType", ColumnTypes.OTHER)
     );
   };
 

--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -3,11 +3,12 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import { setImportedData } from "../redux";
+import { setImportedData, setMetaDataByColumn } from "../redux";
 
 class CSVReaderWrapper extends Component {
   static propTypes = {
-    setImportedData: PropTypes.func.isRequired
+    setImportedData: PropTypes.func.isRequired,
+    setMetaDataByColumn: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -36,6 +37,13 @@ class CSVReaderWrapper extends Component {
   updateData = result => {
     var data = result.data;
     this.props.setImportedData(data);
+    this.updateMetaData(data);
+  };
+
+  updateMetaData = data => {
+    Object.keys(data[0]).map(column =>
+      this.props.setMetaDataByColumn(column, "dataType", "other")
+    );
   };
 
   render() {
@@ -66,6 +74,9 @@ export default connect(
   dispatch => ({
     setImportedData(data) {
       dispatch(setImportedData(data));
+    },
+    setMetaDataByColumn(column, metadataField, value) {
+      dispatch(setMetaDataByColumn(column, metadataField, value));
     }
   })
 )(CSVReaderWrapper);

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -7,7 +7,8 @@ import {
   setSelectedFeatures,
   setShowPredict,
   setMetaDataByColumn,
-  getFeatures
+  getFeatures,
+  ColumnTypes
 } from "../redux";
 
 class DataDisplay extends Component {
@@ -55,8 +56,6 @@ class DataDisplay extends Component {
   };
 
   render() {
-    const COLUMN_TYPES = ["categorical", "continuous", "other"];
-
     return (
       <div>
         {this.props.data.length > 0 && (
@@ -103,7 +102,7 @@ class DataDisplay extends Component {
                             this.props.metaDataByColumn[feature]["dataType"]
                           }
                         >
-                          {COLUMN_TYPES.map((option, index) => {
+                          {Object.values(ColumnTypes).map((option, index) => {
                             return (
                               <option key={index} value={option}>
                                 {option}

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,16 +2,25 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { setLabelColumn, setSelectedFeatures, setShowPredict } from "../redux";
+import {
+  setLabelColumn,
+  setSelectedFeatures,
+  setShowPredict,
+  setMetaDataByColumn,
+  getFeatures
+} from "../redux";
 
 class DataDisplay extends Component {
   static propTypes = {
     data: PropTypes.array,
+    features: PropTypes.array,
     labelColumn: PropTypes.string,
     setLabelColumn: PropTypes.func.isRequired,
     selectedFeatures: PropTypes.array,
     setSelectedFeatures: PropTypes.func.isRequired,
-    setShowPredict: PropTypes.func.isRequired
+    setShowPredict: PropTypes.func.isRequired,
+    metaDataByColumn: PropTypes.object,
+    setMetaDataByColumn: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -28,6 +37,11 @@ class DataDisplay extends Component {
     });
   };
 
+  handleChangeDataType = (event, feature) => {
+    event.preventDefault();
+    this.props.setMetaDataByColumn(feature, "dataType", event.target.value);
+  };
+
   handleChangeSelect = event => {
     this.props.setLabelColumn(event.target.value);
     this.props.setShowPredict(false);
@@ -40,14 +54,12 @@ class DataDisplay extends Component {
     this.props.setShowPredict(false);
   };
 
-  getFeatures = () => {
-    return Object.keys(this.props.data[0]);
-  };
-
   render() {
+    const COLUMN_TYPES = ["categorical", "continuous", "other"];
+
     return (
       <div>
-        {this.props.data && (
+        {this.props.data.length > 0 && (
           <div>
             <h2>Imported Data</h2>
             {this.state.showRawData && (
@@ -59,14 +71,67 @@ class DataDisplay extends Component {
             {!this.state.showRawData && (
               <p onClick={this.toggleRawData}>show data</p>
             )}
+            <h2>Describe the data in each of your columns</h2>
+            <p>
+              Categorical columns contain a fixed number of possible values that
+              indicate a group. For example, the column "Size" might contain
+              categorical data such as "small", "medium" and "large".{" "}
+            </p>
+            <p>
+              Continuous columns contain a range of possible numerical values
+              that could fall anywhere on a continuum. For example, the column
+              "Height in inches" might contain continuous data such as "12",
+              "11.25" and "9.07".{" "}
+            </p>
+            <p>
+              Select "other" if the column contains anything other than
+              categorical or continuous data. This is the best choice for "name"
+              or "id" columns, for example.
+            </p>
+            <form>
+              {this.props.features.map((feature, index) => {
+                return (
+                  <div key={index}>
+                    {this.props.metaDataByColumn[feature] && (
+                      <label>
+                        {feature}:
+                        <select
+                          onChange={event =>
+                            this.handleChangeDataType(event, feature)
+                          }
+                          value={
+                            this.props.metaDataByColumn[feature]["dataType"]
+                          }
+                        >
+                          {COLUMN_TYPES.map((option, index) => {
+                            return (
+                              <option key={index} value={option}>
+                                {option}
+                              </option>
+                            );
+                          })}
+                        </select>
+                      </label>
+                    )}
+                    <br />
+                    <br />
+                  </div>
+                );
+              })}
+            </form>
             <form>
               <label>
                 <h2>Which column contains the labels for your dataset?</h2>
+                <p>
+                  The model will be trained to predict which catgegory from the
+                  label column an example (a set of attributes or features) is
+                  most likely to belong to.
+                </p>
                 <select
                   value={this.props.labelColumn}
                   onChange={this.handleChangeSelect}
                 >
-                  {this.getFeatures().map((feature, index) => {
+                  {this.props.features.map((feature, index) => {
                     return (
                       <option key={index} value={feature}>
                         {feature}
@@ -79,12 +144,16 @@ class DataDisplay extends Component {
             <form>
               <label>
                 <h2>Which features are you interested in training on?</h2>
+                <p>
+                  Features are the attributes the model will use to make a
+                  prediction.
+                </p>
                 <select
                   multiple={true}
                   value={this.props.selectedFeatures}
                   onChange={this.handleChangeMultiSelect}
                 >
-                  {this.getFeatures().map((feature, index) => {
+                  {this.props.features.map((feature, index) => {
                     return (
                       <option key={index} value={feature}>
                         {feature}
@@ -105,9 +174,14 @@ export default connect(
   state => ({
     data: state.data,
     labelColumn: state.labelColumn,
-    selectedFeatures: state.selectedFeatures
+    selectedFeatures: state.selectedFeatures,
+    features: getFeatures(state),
+    metaDataByColumn: state.metaDataByColumn
   }),
   dispatch => ({
+    setMetaDataByColumn(column, metadataField, value) {
+      dispatch(setMetaDataByColumn(column, metadataField, value));
+    },
     setSelectedFeatures(selectedFeatures) {
       dispatch(setSelectedFeatures(selectedFeatures));
     },

--- a/src/redux.js
+++ b/src/redux.js
@@ -61,9 +61,6 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_METADATA_BY_COLUMN) {
-    const prevMetaData = state.metaDataByColumn[action.column]
-      ? state.metaDataByColumn[action.column][action.metadataField]
-      : {};
     return {
       ...state,
       metaDataByColumn: {
@@ -111,3 +108,9 @@ export default function rootReducer(state = initialState, action) {
 export function getFeatures(state) {
   return state.data.length > 0 ? Object.keys(state.data[0]) : [];
 }
+
+export const ColumnTypes = {
+  CATEGORICAL: "categorical",
+  CONTINUOUS: "continuous",
+  OTHER: "other"
+};

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,6 +1,7 @@
 // Action types
 
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
+const SET_METADATA_BY_COLUMN = "SET_METADATA_BY_COLUMN";
 const SET_SELECTED_FEATURES = "SET_SELECTED_FEATURES";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_SHOW_PREDICT = "SET_SHOW_PREDICT";
@@ -12,6 +13,13 @@ const SET_PREDICTION = "SET_PREDICTION";
 export function setImportedData(data) {
   return { type: SET_IMPORTED_DATA, data };
 }
+
+export const setMetaDataByColumn = (column, metadataField, value) => ({
+  type: SET_METADATA_BY_COLUMN,
+  column,
+  metadataField,
+  value
+});
 
 export function setSelectedFeatures(selectedFeatures) {
   return { type: SET_SELECTED_FEATURES, selectedFeatures };
@@ -34,7 +42,8 @@ export function setPrediction(prediction) {
 }
 
 const initialState = {
-  data: undefined,
+  data: [],
+  metaDataByColumn: {},
   selectedFeatures: [],
   labelColumn: undefined,
   showPredict: false,
@@ -49,6 +58,21 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       data: action.data
+    };
+  }
+  if (action.type === SET_METADATA_BY_COLUMN) {
+    const prevMetaData = state.metaDataByColumn[action.column]
+      ? state.metaDataByColumn[action.column][action.metadataField]
+      : {};
+    return {
+      ...state,
+      metaDataByColumn: {
+        ...state.metaDataByColumn,
+        [action.column]: {
+          ...state.metaDataByColumn[action.column],
+          [action.metadataField]: action.value
+        }
+      }
     };
   }
   if (action.type === SET_SELECTED_FEATURES) {
@@ -82,4 +106,8 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   return state;
+}
+
+export function getFeatures(state) {
+  return state.data.length > 0 ? Object.keys(state.data[0]) : [];
 }


### PR DESCRIPTION
[STAR-1285](https://codedotorg.atlassian.net/browse/STAR-1285)

The bulk of the work here is to allow the user to indicate what kind of data - categorical, continuous or other - is stored in each of the columns of their imported dataset. Having the user provide this info 1.) sets us up to do the conversion of string categories to numerical categories for categorical data more easily 2.) sets us up to exclude columns that don't make sense for labels and features to train on 3.) eventually, potentially sets us up to recommend algorithms based on the type of data in the dataset.

<img width="1005" alt="Screen Shot 2020-09-29 at 8 42 51 PM" src="https://user-images.githubusercontent.com/12300669/94631339-25f38b80-0296-11eb-913a-5b3240dd75a2.png">

I accomplished this by setting up a new piece of state `metaDataByColumn` which includes a field for dataType. Next I'll expand that piece of state to include information about unique values stored in each categorical column and their numerical keys. 

Also included is [Star-1270](https://codedotorg.atlassian.net/browse/STAR-1270) - placeholder explanations of label and feature to increase usability of the prototype .