### PR TITLE
Constrain which columns can be selected based on data type 

### DIFF
--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -3,12 +3,12 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import { setImportedData, setMetaDataByColumn, ColumnTypes } from "../redux";
+import { setImportedData, setColumnsByDataType, ColumnTypes } from "../redux";
 
 class CSVReaderWrapper extends Component {
   static propTypes = {
     setImportedData: PropTypes.func.isRequired,
-    setMetaDataByColumn: PropTypes.func.isRequired
+    setColumnsByDataType: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -37,12 +37,12 @@ class CSVReaderWrapper extends Component {
   updateData = result => {
     var data = result.data;
     this.props.setImportedData(data);
-    this.updateMetaData(data);
+    this.setDefaultColumnDataType(data);
   };
 
-  updateMetaData = data => {
+  setDefaultColumnDataType = data => {
     Object.keys(data[0]).map(column =>
-      this.props.setMetaDataByColumn(column, "dataType", ColumnTypes.OTHER)
+      this.props.setColumnsByDataType(column, ColumnTypes.OTHER)
     );
   };
 
@@ -75,8 +75,8 @@ export default connect(
     setImportedData(data) {
       dispatch(setImportedData(data));
     },
-    setMetaDataByColumn(column, metadataField, value) {
-      dispatch(setMetaDataByColumn(column, metadataField, value));
+    setColumnsByDataType(column, dataType) {
+      dispatch(setColumnsByDataType(column, dataType));
     }
   })
 )(CSVReaderWrapper);

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -122,50 +122,56 @@ class DataDisplay extends Component {
                 );
               })}
             </form>
-            <form>
-              <label>
-                <h2>Which column contains the labels for your dataset?</h2>
-                <p>
-                  The model will be trained to predict which catgegory from the
-                  label column an example (a set of attributes or features) is
-                  most likely to belong to. Labels are categorical.
-                </p>
-                <select
-                  value={this.props.labelColumn}
-                  onChange={this.handleChangeSelect}
-                >
-                  {this.props.categoricalColumns.map((feature, index) => {
-                    return (
-                      <option key={index} value={feature}>
-                        {feature}
-                      </option>
-                    );
-                  })}
-                </select>
-              </label>
-            </form>
-            <form>
-              <label>
-                <h2>Which features are you interested in training on?</h2>
-                <p>
-                  Features are the attributes the model will use to make a
-                  prediction. Features can be categorical or continuous.
-                </p>
-                <select
-                  multiple={true}
-                  value={this.props.selectedFeatures}
-                  onChange={this.handleChangeMultiSelect}
-                >
-                  {this.props.selectableFeatures.map((feature, index) => {
-                    return (
-                      <option key={index} value={feature}>
-                        {feature}
-                      </option>
-                    );
-                  })}
-                </select>
-              </label>
-            </form>
+            {this.props.categoricalColumns.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which column contains the labels for your dataset?</h2>
+                  <p>
+                    The model will be trained to predict which catgegory from
+                    the label column an example (a set of attributes or
+                    features) is most likely to belong to. Labels are
+                    categorical.
+                  </p>
+                  <select
+                    value={this.props.labelColumn}
+                    onChange={this.handleChangeSelect}
+                  >
+                    <option>{""}</option>
+                    {this.props.categoricalColumns.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
+            )}
+            {this.props.selectableFeatures.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which features are you interested in training on?</h2>
+                  <p>
+                    Features are the attributes the model will use to make a
+                    prediction. Features can be categorical or continuous.
+                  </p>
+                  <select
+                    multiple={true}
+                    value={this.props.selectedFeatures}
+                    onChange={this.handleChangeMultiSelect}
+                  >
+                    {this.props.selectableFeatures.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
+            )}
           </div>
         )}
       </div>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -45,6 +45,25 @@ class DataDisplay extends Component {
   handleChangeDataType = (event, feature) => {
     event.preventDefault();
     this.props.setColumnsByDataType(feature, event.target.value);
+    this.resetSelections(event.target.value, feature);
+  };
+
+  resetSelections = (dataType, feature) => {
+    if (
+      dataType !== ColumnTypes.CATEGORICAL &&
+      this.props.labelColumn === feature
+    ) {
+      this.props.setLabelColumn("");
+    }
+    if (
+      dataType === ColumnTypes.OTHER &&
+      this.props.selectedFeatures.includes(feature)
+    ) {
+      let remainingSelectedFeatures = this.props.selectedFeatures.filter(
+        selectedFeature => selectedFeature !== feature
+      );
+      this.props.setSelectedFeatures(remainingSelectedFeatures);
+    }
   };
 
   handleChangeSelect = event => {

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -6,7 +6,7 @@ import {
   setLabelColumn,
   setSelectedFeatures,
   setShowPredict,
-  setMetaDataByColumn,
+  setColumnsByDataType,
   getFeatures,
   ColumnTypes,
   getCategoricalColumns,
@@ -22,8 +22,8 @@ class DataDisplay extends Component {
     selectedFeatures: PropTypes.array,
     setSelectedFeatures: PropTypes.func.isRequired,
     setShowPredict: PropTypes.func.isRequired,
-    metaDataByColumn: PropTypes.object,
-    setMetaDataByColumn: PropTypes.func.isRequired,
+    columnsByDataType: PropTypes.object,
+    setColumnsByDataType: PropTypes.func.isRequired,
     categoricalColumns: PropTypes.array,
     selectableFeatures: PropTypes.array
   };
@@ -44,7 +44,7 @@ class DataDisplay extends Component {
 
   handleChangeDataType = (event, feature) => {
     event.preventDefault();
-    this.props.setMetaDataByColumn(feature, "dataType", event.target.value);
+    this.props.setColumnsByDataType(feature, event.target.value);
   };
 
   handleChangeSelect = event => {
@@ -95,16 +95,14 @@ class DataDisplay extends Component {
               {this.props.features.map((feature, index) => {
                 return (
                   <div key={index}>
-                    {this.props.metaDataByColumn[feature] && (
+                    {this.props.columnsByDataType[feature] && (
                       <label>
                         {feature}:
                         <select
                           onChange={event =>
                             this.handleChangeDataType(event, feature)
                           }
-                          value={
-                            this.props.metaDataByColumn[feature]["dataType"]
-                          }
+                          value={this.props.columnsByDataType[feature]}
                         >
                           {Object.values(ColumnTypes).map((option, index) => {
                             return (
@@ -185,13 +183,13 @@ export default connect(
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
     features: getFeatures(state),
-    metaDataByColumn: state.metaDataByColumn,
+    columnsByDataType: state.columnsByDataType,
     categoricalColumns: getCategoricalColumns(state),
     selectableFeatures: getSelectableFeatures(state)
   }),
   dispatch => ({
-    setMetaDataByColumn(column, metadataField, value) {
-      dispatch(setMetaDataByColumn(column, metadataField, value));
+    setColumnsByDataType(column, dataType) {
+      dispatch(setColumnsByDataType(column, dataType));
     },
     setSelectedFeatures(selectedFeatures) {
       dispatch(setSelectedFeatures(selectedFeatures));

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -8,7 +8,9 @@ import {
   setShowPredict,
   setMetaDataByColumn,
   getFeatures,
-  ColumnTypes
+  ColumnTypes,
+  getCategoricalColumns,
+  getSelectableFeatures
 } from "../redux";
 
 class DataDisplay extends Component {
@@ -21,7 +23,9 @@ class DataDisplay extends Component {
     setSelectedFeatures: PropTypes.func.isRequired,
     setShowPredict: PropTypes.func.isRequired,
     metaDataByColumn: PropTypes.object,
-    setMetaDataByColumn: PropTypes.func.isRequired
+    setMetaDataByColumn: PropTypes.func.isRequired,
+    categoricalColumns: PropTypes.array,
+    selectableFeatures: PropTypes.array
   };
 
   constructor(props) {
@@ -124,13 +128,13 @@ class DataDisplay extends Component {
                 <p>
                   The model will be trained to predict which catgegory from the
                   label column an example (a set of attributes or features) is
-                  most likely to belong to.
+                  most likely to belong to. Labels are categorical.
                 </p>
                 <select
                   value={this.props.labelColumn}
                   onChange={this.handleChangeSelect}
                 >
-                  {this.props.features.map((feature, index) => {
+                  {this.props.categoricalColumns.map((feature, index) => {
                     return (
                       <option key={index} value={feature}>
                         {feature}
@@ -145,14 +149,14 @@ class DataDisplay extends Component {
                 <h2>Which features are you interested in training on?</h2>
                 <p>
                   Features are the attributes the model will use to make a
-                  prediction.
+                  prediction. Features can be categorical or continuous.
                 </p>
                 <select
                   multiple={true}
                   value={this.props.selectedFeatures}
                   onChange={this.handleChangeMultiSelect}
                 >
-                  {this.props.features.map((feature, index) => {
+                  {this.props.selectableFeatures.map((feature, index) => {
                     return (
                       <option key={index} value={feature}>
                         {feature}
@@ -175,7 +179,9 @@ export default connect(
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
     features: getFeatures(state),
-    metaDataByColumn: state.metaDataByColumn
+    metaDataByColumn: state.metaDataByColumn,
+    categoricalColumns: getCategoricalColumns(state),
+    selectableFeatures: getSelectableFeatures(state)
   }),
   dispatch => ({
     setMetaDataByColumn(column, metadataField, value) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 // Action types
 
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
-const SET_METADATA_BY_COLUMN = "SET_METADATA_BY_COLUMN";
+const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
 const SET_SELECTED_FEATURES = "SET_SELECTED_FEATURES";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_SHOW_PREDICT = "SET_SHOW_PREDICT";
@@ -16,11 +16,10 @@ export function setImportedData(data) {
   return { type: SET_IMPORTED_DATA, data };
 }
 
-export const setMetaDataByColumn = (column, metadataField, value) => ({
-  type: SET_METADATA_BY_COLUMN,
+export const setColumnsByDataType = (column, dataType) => ({
+  type: SET_COLUMNS_BY_DATA_TYPE,
   column,
-  metadataField,
-  value
+  dataType
 });
 
 export function setSelectedFeatures(selectedFeatures) {
@@ -45,7 +44,7 @@ export function setPrediction(prediction) {
 
 const initialState = {
   data: [],
-  metaDataByColumn: {},
+  columnsByDataType: {},
   selectedFeatures: [],
   labelColumn: undefined,
   showPredict: false,
@@ -62,15 +61,12 @@ export default function rootReducer(state = initialState, action) {
       data: action.data
     };
   }
-  if (action.type === SET_METADATA_BY_COLUMN) {
+  if (action.type === SET_COLUMNS_BY_DATA_TYPE) {
     return {
       ...state,
-      metaDataByColumn: {
-        ...state.metaDataByColumn,
-        [action.column]: {
-          ...state.metaDataByColumn[action.column],
-          [action.metadataField]: action.value
-        }
+      columnsByDataType: {
+        ...state.columnsByDataType,
+        [action.column]: action.dataType
       }
     };
   }
@@ -112,17 +108,9 @@ export function getFeatures(state) {
 }
 
 function filterColumnsByType(state, columnType) {
-  let columnsOfType = [];
-  if (!_.isEmpty(state.metaDataByColumn)) {
-    var filteredObject = _.pickBy(state.metaDataByColumn, function(
-      columnMetaData,
-      column
-    ) {
-      return columnMetaData["dataType"] === columnType;
-    });
-    columnsOfType = Object.keys(filteredObject);
-  }
-  return columnsOfType;
+  return Object.keys(state.columnsByDataType).filter(
+    column => state.columnsByDataType[column] === columnType
+  );
 }
 
 export function getCategoricalColumns(state) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 // Action types
 
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
@@ -122,10 +120,9 @@ export function getContinuousColumns(state) {
 }
 
 export function getSelectableFeatures(state) {
-  return _.pull(
-    getContinuousColumns(state).concat(getCategoricalColumns(state)),
-    state.labelColumn
-  );
+  return getContinuousColumns(state)
+    .concat(getCategoricalColumns(state))
+    .filter(column => column !== state.labelColumn);
 }
 
 export const ColumnTypes = {

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 // Action types
 
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
@@ -107,6 +109,35 @@ export default function rootReducer(state = initialState, action) {
 
 export function getFeatures(state) {
   return state.data.length > 0 ? Object.keys(state.data[0]) : [];
+}
+
+function filterColumnsByType(state, columnType) {
+  let columnsOfType = [];
+  if (!_.isEmpty(state.metaDataByColumn)) {
+    var filteredObject = _.pickBy(state.metaDataByColumn, function(
+      columnMetaData,
+      column
+    ) {
+      return columnMetaData["dataType"] === columnType;
+    });
+    columnsOfType = Object.keys(filteredObject);
+  }
+  return columnsOfType;
+}
+
+export function getCategoricalColumns(state) {
+  return filterColumnsByType(state, ColumnTypes.CATEGORICAL);
+}
+
+export function getContinuousColumns(state) {
+  return filterColumnsByType(state, ColumnTypes.CONTINUOUS);
+}
+
+export function getSelectableFeatures(state) {
+  return _.pull(
+    getContinuousColumns(state).concat(getCategoricalColumns(state)),
+    state.labelColumn
+  );
 }
 
 export const ColumnTypes = {


### PR DESCRIPTION
[STAR-1264](https://codedotorg.atlassian.net/browse/STAR-1264)
[STAR-1265](https://codedotorg.atlassian.net/browse/STAR-1265)

Now that have metadata about which columns contain which data types - continuous, categorical or other. I used that information to constrain selections for training to guide users to more reliably being able to train the model. The constraints I implemented are: 
- Only continuous and categorical columns can be selected as feature columns.
- Only categorical columns can be selected as the label column. 
- If a column is selected as the label column, it can't also be selected as a feature column.  

![constrain-dropdowns-by-datatype](https://user-images.githubusercontent.com/12300669/94714235-dd7db180-0319-11eb-8a5e-e4173cc421fc.gif)


