### PR TITLE
Categorical data columns now have dropdowns for test input 

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -3,18 +3,25 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import train from "../train";
-import { setTestData } from "../redux";
+import {
+  setTestData,
+  getSelectedContinuousColumns,
+  getSelectedCategoricalColumns,
+  getUniqueOptionsByColumn
+} from "../redux";
 
 class Predict extends Component {
   static propTypes = {
     showPredict: PropTypes.bool,
-    selectedFeatures: PropTypes.array,
+    selectedCategoricalColumns: PropTypes.array,
+    selectedContinuousColumns: PropTypes.array,
+    uniqueOptionsByColumn: PropTypes.object,
     testData: PropTypes.object,
     setTestData: PropTypes.func.isRequired,
     prediction: PropTypes.object
   };
 
-  handleInput = (event, feature) => {
+  handleChange = (event, feature) => {
     const testData = this.props.testData;
     testData[feature] = event.target.value;
     this.props.setTestData(testData);
@@ -31,20 +38,49 @@ class Predict extends Component {
           <div>
             <h2>Test the Model</h2>
             <form>
-              {this.props.selectedFeatures.map((feature, index) => {
+              {this.props.selectedContinuousColumns.map((feature, index) => {
                 return (
                   <span key={index}>
                     <label>
                       {feature}:
                       <input
                         type="text"
-                        onChange={event => this.handleInput(event, feature)}
+                        onChange={event => this.handleChange(event, feature)}
                       />
                     </label>
                   </span>
                 );
               })}
             </form>
+            <br />
+            <br />
+            <form>
+              {this.props.selectedCategoricalColumns.map((feature, index) => {
+                return (
+                  <span key={index}>
+                    <label>
+                      {feature}:
+                      <select
+                        onChange={event => this.handleChange(event, feature)}
+                      >
+                        <option>{""}</option>
+                        {this.props.uniqueOptionsByColumn[feature].map(
+                          (option, index) => {
+                            return (
+                              <option key={index} value={option}>
+                                {option}
+                              </option>
+                            );
+                          }
+                        )}
+                      </select>
+                    </label>
+                  </span>
+                );
+              })}
+            </form>
+            <br />
+            <br />
             <button type="button" onClick={this.onClickPredict}>
               Predict!
             </button>
@@ -67,9 +103,11 @@ class Predict extends Component {
 export default connect(
   state => ({
     showPredict: state.showPredict,
-    selectedFeatures: state.selectedFeatures,
     testData: state.testData,
-    prediction: state.prediction
+    prediction: state.prediction,
+    selectedContinuousColumns: getSelectedContinuousColumns(state),
+    selectedCategoricalColumns: getSelectedCategoricalColumns(state),
+    uniqueOptionsByColumn: getUniqueOptionsByColumn(state)
   }),
   dispatch => ({
     setTestData(testData) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -129,6 +129,20 @@ export function getCategoricalColumns(state) {
   return filterColumnsByType(state, ColumnTypes.CATEGORICAL);
 }
 
+export function getSelectedCategoricalColumns(state) {
+  let intersection = getCategoricalColumns(state).filter(x =>
+    state.selectedFeatures.includes(x)
+  );
+  return intersection;
+}
+
+export function getSelectedContinuousColumns(state) {
+  let intersection = getContinuousColumns(state).filter(x =>
+    state.selectedFeatures.includes(x)
+  );
+  return intersection;
+}
+
 export function getContinuousColumns(state) {
   return filterColumnsByType(state, ColumnTypes.CONTINUOUS);
 }
@@ -138,6 +152,18 @@ export function getSelectableFeatures(state) {
     getContinuousColumns(state).concat(getCategoricalColumns(state)),
     state.labelColumn
   );
+}
+
+function getUniqueOptions(state, column) {
+  return Array.from(new Set(state.data.map(row => row[column])));
+}
+
+export function getUniqueOptionsByColumn(state) {
+  let uniqueOptionsByColumn = {};
+  getSelectedCategoricalColumns(state).map(
+    column => (uniqueOptionsByColumn[column] = getUniqueOptions(state, column))
+  );
+  return uniqueOptionsByColumn;
 }
 
 export const ColumnTypes = {


### PR DESCRIPTION
[STAR-1269](https://codedotorg.atlassian.net/browse/STAR-1269)

As a way to support error handling for test data input, I made dropdowns for categorical data columns. Not only will this increase the likelihood of a successful test run of the trained model, it allows students to see any discrepancies in the categories in their test data (e.g. "female" versus "Female" counted as separate categories when they didn't expect them to be). Continuous data columns are still input boxes and "other" data columns are removed from the test inputs because they don't affect the model's prediction.
 
![dropdown-input-for-categorical-test-data](https://user-images.githubusercontent.com/12300669/94727683-16735180-032d-11eb-8562-43e7f37a51dc.gif)
