### PR TITLE
Strings to numbers for svm

### DIFF
--- a/src/SVMTrainer.js
+++ b/src/SVMTrainer.js
@@ -51,7 +51,15 @@ export default class SVMTrainer {
   }
 
   extractLabels = row => {
-    return this.convertValue(this.state.labelColumn, row);
+    const updatedState = store.getState();
+    const currentValues = Object.values(
+      updatedState.featureNumberKey[this.state.labelColumn]
+    );
+    // Right now the model only supports binary classification and labels must be 1 or -1.
+    const converter = {};
+    converter[currentValues[0]] = 1;
+    converter[currentValues[1]] = -1;
+    return converter[row[this.state.labelColumn]];
   };
 
   convertValue = (feature, row) => {

--- a/src/SVMTrainer.js
+++ b/src/SVMTrainer.js
@@ -1,4 +1,5 @@
-/* Training and prediction using a binary SVM machine learning model from (https://github.com/karpathy/svmjs) */
+/* Training and prediction using a binary SVM machine learning model from
+(https://github.com/karpathy/svmjs) */
 
 /* eslint-env node */
 const svmjs = require("svm");
@@ -23,7 +24,8 @@ export default class SVMTrainer {
     this.buildOptionNumberKeysByFeature(state);
   }
 
-  /* Builds a hash that maps a feature's categorical options to numbers because this implementation of the SVM algorithm only accepts numerical inputs.
+  /* Builds a hash that maps a feature's categorical options to numbers because
+  this implementation of the SVM algorithm only accepts numerical inputs.
   @param {string} - feature name
   @return {
     option1 : 0,
@@ -41,7 +43,8 @@ export default class SVMTrainer {
     return optionsMappedToNumbers;
   };
 
-  /* Builds a hash that maps selected categorical features to their option-number keys and dispatches that hash to the Redux store.
+  /* Builds a hash that maps selected categorical features to their option-
+  number keys and dispatches that hash to the Redux store.
   @return {
     feature1: {
       option1 : 0,
@@ -70,7 +73,10 @@ export default class SVMTrainer {
     store.dispatch(setFeatureNumberKey(optionsMappedToNumbersByFeature));
   }
 
-  /* Builds a hash that maps the options in the label column to -1 and 1, because right now the model only supports binary classification with those specific values. Returns the row's specific option's value in that reference hash.
+  /* Builds a hash that maps the options in the label column to -1 and 1,
+  because right now the model only supports binary classification with those
+  specific values. Returns the row's specific option's value in that reference
+  hash.
   @param {object} row, entry from the dataset
   {
     labelColumn: option,
@@ -92,7 +98,10 @@ export default class SVMTrainer {
     return converter[row[this.state.labelColumn]];
   };
 
-  /* For feature columns that store categorical data, looks up the value associated with a row's specific option for a given feature; otherwise returns the option converted to an integer for feature columns that store continuous data.
+  /* For feature columns that store categorical data, looks up the value
+  associated with a row's specific option for a given feature; otherwise
+  returns the option converted to an integer for feature columns that store
+  continuous data.
   @param {object} row, entry from the dataset
   {
     labelColumn: option,
@@ -110,7 +119,8 @@ export default class SVMTrainer {
       : parseInt(row[feature]);
   };
 
-  /* Builds an array containing integer values associated with each feature's specific option in a given row.
+  /* Builds an array containing integer values associated with each feature's
+  specific option in a given row.
   @param {object} row, entry from the dataset
   {
     labelColumn: option,

--- a/src/SVMTrainer.js
+++ b/src/SVMTrainer.js
@@ -98,7 +98,7 @@ export default class SVMTrainer {
   prepareTestData() {
     let testValues = [];
     this.state.selectedFeatures.forEach(feature =>
-      testValues.push(parseInt(this.state.testData[feature]))
+      testValues.push(this.convertValue(feature, this.state.testData))
     );
     return testValues;
   }

--- a/src/SVMTrainer.js
+++ b/src/SVMTrainer.js
@@ -6,6 +6,7 @@ import { store } from "./index.js";
 import {
   setPrediction,
   getUniqueOptions,
+  getCategoricalColumns,
   getSelectedCategoricalColumns,
   setFeatureNumberKey
 } from "./redux";
@@ -37,7 +38,10 @@ export default class SVMTrainer {
 
   buildFeatureToNumberKey(state) {
     let optionsMappedToNumbersByFeature = {};
-    getSelectedCategoricalColumns(state).forEach(
+    const categoricalColumnsToConvert = getSelectedCategoricalColumns(
+      state
+    ).concat(this.state.labelColumn);
+    categoricalColumnsToConvert.forEach(
       feature =>
         (optionsMappedToNumbersByFeature[
           feature
@@ -47,12 +51,12 @@ export default class SVMTrainer {
   }
 
   extractLabels = row => {
-    return parseInt(row[this.state.labelColumn]);
+    return this.convertValue(this.state.labelColumn, row);
   };
 
   convertValue = (feature, row) => {
     const updatedState = store.getState();
-    return getSelectedCategoricalColumns(updatedState).includes(feature)
+    return getCategoricalColumns(updatedState).includes(feature)
       ? updatedState.featureNumberKey[feature][row[feature]]
       : parseInt(row[feature]);
   };

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -9,8 +9,8 @@ import {
   setColumnsByDataType,
   getFeatures,
   ColumnTypes,
-  getCategoricalColumns,
-  getSelectableFeatures
+  getSelectableFeatures,
+  getSelectableLabels
 } from "../redux";
 
 class DataDisplay extends Component {
@@ -24,8 +24,8 @@ class DataDisplay extends Component {
     setShowPredict: PropTypes.func.isRequired,
     columnsByDataType: PropTypes.object,
     setColumnsByDataType: PropTypes.func.isRequired,
-    categoricalColumns: PropTypes.array,
-    selectableFeatures: PropTypes.array
+    selectableFeatures: PropTypes.array,
+    selectableLabels: PropTypes.array
   };
 
   constructor(props) {
@@ -139,7 +139,7 @@ class DataDisplay extends Component {
                 );
               })}
             </form>
-            {this.props.categoricalColumns.length > 0 && (
+            {this.props.selectableLabels.length > 0 && (
               <form>
                 <label>
                   <h2>Which column contains the labels for your dataset?</h2>
@@ -149,12 +149,13 @@ class DataDisplay extends Component {
                     features) is most likely to belong to. Labels are
                     categorical.
                   </p>
+                  <p>The current model only supports binary classification.</p>
                   <select
                     value={this.props.labelColumn}
                     onChange={this.handleChangeSelect}
                   >
                     <option>{""}</option>
-                    {this.props.categoricalColumns.map((feature, index) => {
+                    {this.props.selectableLabels.map((feature, index) => {
                       return (
                         <option key={index} value={feature}>
                           {feature}
@@ -203,8 +204,8 @@ export default connect(
     selectedFeatures: state.selectedFeatures,
     features: getFeatures(state),
     columnsByDataType: state.columnsByDataType,
-    categoricalColumns: getCategoricalColumns(state),
-    selectableFeatures: getSelectableFeatures(state)
+    selectableFeatures: getSelectableFeatures(state),
+    selectableLabels: getSelectableLabels(state)
   }),
   dispatch => ({
     setColumnsByDataType(column, dataType) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -151,6 +151,13 @@ export function getSelectableFeatures(state) {
     .filter(column => column !== state.labelColumn);
 }
 
+// Right the SVM model we're using only supports binary classification.
+export function getSelectableLabels(state) {
+  return getCategoricalColumns(state).filter(
+    column => getUniqueOptions(state, column).length === 2
+  );
+}
+
 export function getUniqueOptions(state, column) {
   return Array.from(new Set(state.data.map(row => row[column])));
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -4,6 +4,7 @@ const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
 const SET_SELECTED_FEATURES = "SET_SELECTED_FEATURES";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
+const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
 const SET_SHOW_PREDICT = "SET_SHOW_PREDICT";
 const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
@@ -28,6 +29,10 @@ export function setLabelColumn(labelColumn) {
   return { type: SET_LABEL_COLUMN, labelColumn };
 }
 
+export function setFeatureNumberKey(featureNumberKey) {
+  return { type: SET_FEATURE_NUMBER_KEY, featureNumberKey };
+}
+
 export function setShowPredict(showPredict) {
   return { type: SET_SHOW_PREDICT, showPredict };
 }
@@ -45,6 +50,7 @@ const initialState = {
   columnsByDataType: {},
   selectedFeatures: [],
   labelColumn: undefined,
+  featureNumberKey: {},
   showPredict: false,
   testData: {},
   prediction: undefined
@@ -78,6 +84,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       labelColumn: action.labelColumn
+    };
+  }
+  if (action.type === SET_FEATURE_NUMBER_KEY) {
+    return {
+      ...state,
+      featureNumberKey: action.featureNumberKey
     };
   }
   if (action.type === SET_SHOW_PREDICT) {
@@ -139,7 +151,7 @@ export function getSelectableFeatures(state) {
     .filter(column => column !== state.labelColumn);
 }
 
-function getUniqueOptions(state, column) {
+export function getUniqueOptions(state, column) {
   return Array.from(new Set(state.data.map(row => row[column])));
 }
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -29,6 +29,21 @@ export function setLabelColumn(labelColumn) {
   return { type: SET_LABEL_COLUMN, labelColumn };
 }
 
+/* featureNumberKey maps feature names to a hash of category options mapped to integers.
+  {
+    feature1: {
+      option1 : 0,
+      option2 : 1,
+      option3: 2,
+      ...
+    },
+    feature2: {
+      option1 : 0,
+      option2 : 1,
+      ...
+    }
+  }
+*/
 export function setFeatureNumberKey(featureNumberKey) {
   return { type: SET_FEATURE_NUMBER_KEY, featureNumberKey };
 }
@@ -151,7 +166,7 @@ export function getSelectableFeatures(state) {
     .filter(column => column !== state.labelColumn);
 }
 
-// Right the SVM model we're using only supports binary classification.
+// Right now the SVM model we're using only supports binary classification.
 export function getSelectableLabels(state) {
   return getCategoricalColumns(state).filter(
     column => getUniqueOptions(state, column).length === 2


### PR DESCRIPTION
This sets it up so that categorical string data can be converted into numbers for training and testing using the current binary classification SVM model. 

_Some notes on the terminology I used:_ 

Column headers are the names of features, thus "**column**" and "**feature**" are interchangeable. For example, in the Titanic dataset, "survived", "sex", "pclass" etc are features aka columns. 

**options** refers to the categories within a column. For example, the "options" for the "pclass" feature column in the Titanic dataset has options: 1, 2, and 3 to indicate which class the passenger traveled in. 

An example of `state.featureNumberKey` for a string-based categorical dataset might look like:
 
```
 state.featureNumberKey = {
   sex: { male: 0, female: 1 },
  favoriteColor: {green: 0, blue: 1, yellow: 2, red: 3},
  birthMonth: {january: 0, february: 1, march: 2 ... } 
}
```
