### PR TITLE
Reverse lookup predicted labels to output human readable prediction

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -7,18 +7,21 @@ import {
   setTestData,
   getSelectedContinuousColumns,
   getSelectedCategoricalColumns,
-  getUniqueOptionsByColumn
+  getUniqueOptionsByColumn,
+  getConvertedPredictedLabel
 } from "../redux";
 
 class Predict extends Component {
   static propTypes = {
     showPredict: PropTypes.bool,
+    labelColumn: PropTypes.string,
     selectedCategoricalColumns: PropTypes.array,
     selectedContinuousColumns: PropTypes.array,
     uniqueOptionsByColumn: PropTypes.object,
     testData: PropTypes.object,
     setTestData: PropTypes.func.isRequired,
-    prediction: PropTypes.object
+    predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    confidence: PropTypes.number
   };
 
   handleChange = (event, feature) => {
@@ -84,13 +87,13 @@ class Predict extends Component {
             <button type="button" onClick={this.onClickPredict}>
               Predict!
             </button>
-            {this.props.prediction && (
+            {this.props.predictedLabel && (
               <div>
                 <h2> The Machine Learning model predicts... </h2>
                 <span>
-                  {this.props.prediction.predictedLabel}
-                  {this.props.prediction.confidence && (
-                    <p>Confidence: {this.props.prediction.confidence}</p>
+                  {this.props.labelColumn}: {this.props.predictedLabel}
+                  {this.props.confidence && (
+                    <p>Confidence: {this.props.confidence}</p>
                   )}
                 </span>
               </div>
@@ -106,7 +109,9 @@ export default connect(
   state => ({
     showPredict: state.showPredict,
     testData: state.testData,
-    prediction: state.prediction,
+    predictedLabel: getConvertedPredictedLabel(state),
+    confidence: state.prediction.confidence,
+    labelColumn: state.labelColumn,
     selectedContinuousColumns: getSelectedContinuousColumns(state),
     selectedCategoricalColumns: getSelectedCategoricalColumns(state),
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state)

--- a/src/redux.js
+++ b/src/redux.js
@@ -87,7 +87,7 @@ const initialState = {
   trainingLabels: [],
   showPredict: false,
   testData: {},
-  prediction: undefined
+  prediction: {}
 };
 
 // Reducer
@@ -226,6 +226,30 @@ export function getUniqueOptionsByColumn(state) {
     column => (uniqueOptionsByColumn[column] = getUniqueOptions(state, column))
   );
   return uniqueOptionsByColumn;
+}
+
+function getKeyByValue(object, value) {
+  return Object.keys(object).find(key => object[key] === value);
+}
+
+function isEmpty(object) {
+  return Object.keys(object).length === 0;
+}
+
+export function getConvertedPredictedLabel(state) {
+  if (
+    state.labelColumn &&
+    !isEmpty(state.featureNumberKey) &&
+    !isEmpty(state.prediction)
+  ) {
+    const label = getCategoricalColumns(state).includes(state.labelColumn)
+      ? getKeyByValue(
+          state.featureNumberKey[state.labelColumn],
+          state.prediction.predictedLabel
+        )
+      : state.prediction.predictedLabel;
+    return label;
+  }
 }
 
 export const ColumnTypes = {


### PR DESCRIPTION
Jira: [AI-1](https://codedotorg.atlassian.net/browse/AI-1)

Previously categorical predictions would show the number spit out by the algorithm, which isn't very meaningful to the user.  This adds a reverse lookup in the `featureNumberKey` to find the human readable label (or at least the corresponding value from the data table). 

<img width="534" alt="Screen Shot 2020-10-19 at 7 48 10 PM" src="https://user-images.githubusercontent.com/12300669/96523643-3a4af880-1244-11eb-9e2e-c6390ff6f251.png">
