### PR TITLE
Fix a small bug with continuous data: parseInt -> parseFloat

### DIFF
--- a/src/train.js
+++ b/src/train.js
@@ -95,7 +95,7 @@ const buildOptionNumberKeysByFeature = state => {
 const convertValue = (state, feature, row) => {
   return getCategoricalColumns(state).includes(feature)
     ? state.featureNumberKey[feature][row[feature]]
-    : parseInt(row[feature]);
+    : parseFloat(row[feature]);
 };
 
 /* Builds an array containing integer values associated with each feature's


### PR DESCRIPTION
Jira: [AI-29](https://codedotorg.atlassian.net/browse/AI-29)

`parseInt` rounds numbers, which meant that continuous values were being rounded when converted from a string to a number in preparation to be fed to the algorithm. 
<img width="582" alt="Screen Shot 2020-10-19 at 8 07 22 PM" src="https://user-images.githubusercontent.com/12300669/96524822-4ab0a280-1247-11eb-9df9-66b6205709d0.png">

By contrast `parseInt` doesn't round numbers, so now our training and test data will have decimals. 
<img width="647" alt="Screen Shot 2020-10-19 at 8 08 55 PM" src="https://user-images.githubusercontent.com/12300669/96524818-497f7580-1247-11eb-9996-6fea02fba6b0.png">

