### PR TITLE
Reset state if a different dataset is selected

### DIFF
--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -3,11 +3,17 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import { setImportedData, setColumnsByDataType, ColumnTypes } from "../redux";
+import {
+  resetState,
+  setImportedData,
+  setColumnsByDataType,
+  ColumnTypes
+} from "../redux";
 import { availableDatasets } from "../datasetManifest";
 
 class CSVReaderWrapper extends Component {
   static propTypes = {
+    resetState: PropTypes.func.isRequired,
     setImportedData: PropTypes.func.isRequired,
     setColumnsByDataType: PropTypes.func.isRequired
   };
@@ -23,6 +29,7 @@ class CSVReaderWrapper extends Component {
   }
 
   handleChange = event => {
+    this.props.resetState();
     this.setState({
       csvfile: event.target.files[0],
       download: false
@@ -30,6 +37,7 @@ class CSVReaderWrapper extends Component {
   };
 
   handleChangeSelect = event => {
+    this.props.resetState();
     this.setState({
       csvfile: event.target.value,
       download: true
@@ -101,6 +109,9 @@ class CSVReaderWrapper extends Component {
 export default connect(
   state => ({}),
   dispatch => ({
+    resetState() {
+      dispatch(resetState());
+    },
     setImportedData(data) {
       dispatch(setImportedData(data));
     },

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,6 +1,7 @@
 import { availableTrainers } from "./train.js";
 // Action types
 
+const RESET_STATE = "RESET_STATE";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_SELECTED_TRAINER = "SET_SELECTED_TRAINER";
 const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
@@ -74,6 +75,10 @@ export function setTestData(testData) {
 
 export function setPrediction(prediction) {
   return { type: SET_PREDICTION, prediction };
+}
+
+export function resetState() {
+  return { type: RESET_STATE };
 }
 
 const initialState = {
@@ -160,6 +165,11 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       prediction: action.prediction
+    };
+  }
+  if (action.type === RESET_STATE) {
+    return {
+      ...initialState
     };
   }
   return state;


### PR DESCRIPTION
Jira: [AI-28](https://codedotorg.atlassian.net/browse/AI-28)

Previously, you could get in a strange state where, upon changing the dataset, you would still see selected features and labels for the previous dataset. 

BEFORE: 

![before-reset](https://user-images.githubusercontent.com/12300669/96527629-8d29ad80-124e-11eb-87b1-256635bb2434.gif)


Now, when the dataset selected changes, we reset the state so this confusing stale state doesn't show up.

AFTER:

![after-reset](https://user-images.githubusercontent.com/12300669/96527622-88fd9000-124e-11eb-82f8-4be81107895e.gif)

