### PR TITLE
Custom accuracy check percent

### DIFF
--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -5,10 +5,12 @@ import { connect } from "react-redux";
 import train, { availableTrainers } from "../train";
 import {
   setShowPredict,
+  setPercentDataToReserve,
   getAccuracy,
   readyToTrain,
   validationMessages
 } from "../redux";
+import { TRAINING_DATA_PERCENTS } from "../constants";
 
 const styles = {
   error: {
@@ -27,6 +29,8 @@ class TrainModel extends Component {
     validationMessages: PropTypes.array,
     setShowPredict: PropTypes.func.isRequired,
     selectedTrainer: PropTypes.string,
+    percentDataToReserve: PropTypes.number,
+    setPercentDataToReserve: PropTypes.func,
     accuracy: PropTypes.string,
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array
@@ -39,6 +43,13 @@ class TrainModel extends Component {
       showAccuracy: false
     };
   }
+
+  handleChange = event => {
+    this.props.setPercentDataToReserve(parseInt(event.target.value));
+    this.setState({
+      showAccuracy: false
+    });
+  };
 
   onClickTrainModel = () => {
     train.init();
@@ -64,6 +75,25 @@ class TrainModel extends Component {
             </p>
           );
         })}
+        <h3>How much of the data would you like to reserve for testing?</h3>
+        <form>
+          <label>
+            Percent of dataset to reserve:
+            <select
+              value={this.props.percentDataToReserve}
+              onChange={this.handleChange}
+            >
+              {TRAINING_DATA_PERCENTS.map((percent, index) => {
+                return (
+                  <option key={index} value={percent}>
+                    {percent}
+                  </option>
+                );
+              })}
+            </select>
+          </label>
+        </form>
+
         {this.props.readyToTrain && (
           <div>
             <h2>Train the Model</h2>
@@ -80,35 +110,37 @@ class TrainModel extends Component {
             {this.state.showAccuracy && (
               <div>
                 <p>
-                  10% of the training data was reserved to test the accuracy of
-                  the newly trained model.
+                  {this.props.percentDataToReserve}% of the training data was
+                  reserved to test the accuracy of the newly trained model.
                 </p>
-                <div>
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Expected</th>
-                        <th>Predicted</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {this.props.accuracyCheckLabels.map((label, index) => {
-                        return (
-                          <tr key={index}>
-                            <td>{label}</td>
-                            <td>
-                              {this.props.accuracyCheckPredictedLabels[index]}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-                <div>
-                  <h3>The calculated accuracy of this model is:</h3>
-                  {this.props.accuracy}%
-                </div>
+                {this.props.percentDataToReserve > 0 && (
+                  <div>
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Expected</th>
+                          <th>Predicted</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {this.props.accuracyCheckLabels.map((label, index) => {
+                          return (
+                            <tr key={index}>
+                              <td>{label}</td>
+                              <td>
+                                {this.props.accuracyCheckPredictedLabels[index]}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                    <div>
+                      <h3>The calculated accuracy of this model is:</h3>
+                      {this.props.accuracy}%
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -127,11 +159,15 @@ export default connect(
     accuracyCheckLabels: state.accuracyCheckLabels,
     accuracyCheckPredictedLabels: state.accuracyCheckPredictedLabels,
     readyToTrain: readyToTrain(state),
-    validationMessages: validationMessages(state)
+    validationMessages: validationMessages(state),
+    percentDataToReserve: state.percentDataToReserve
   }),
   dispatch => ({
     setShowPredict(showPredict) {
       dispatch(setShowPredict(showPredict));
+    },
+    setPercentDataToReserve(percentDataToReserve) {
+      dispatch(setPercentDataToReserve(percentDataToReserve));
     }
   })
 )(TrainModel);

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -113,8 +113,6 @@ class TrainModel extends Component {
                   <h3>The calculated accuracy of this model is:</h3>
                   {this.props.accuracy}%
                 </div>
-                <h3>The calculated accuracy of this model is:</h3>
-                {this.props.accuracy}%
               </div>
             )}
           </div>

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -84,32 +84,28 @@ class TrainModel extends Component {
                   the newly trained model.
                 </p>
                 <div>
-                  <p>
-                    10% of the training data was reserved to test the accuracy
-                    of the newly trained model.
-                  </p>
-                  <div>
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Expected</th>
-                          <th>Predicted</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {this.props.accuracyCheckLabels.map((label, index) => {
-                          return (
-                            <tr key={index}>
-                              <td>{label}</td>
-                              <td>
-                                {this.props.accuracyCheckPredictedLabels[index]}
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Expected</th>
+                        <th>Predicted</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {this.props.accuracyCheckLabels.map((label, index) => {
+                        return (
+                          <tr key={index}>
+                            <td>{label}</td>
+                            <td>
+                              {this.props.accuracyCheckPredictedLabels[index]}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                <div>
                   <h3>The calculated accuracy of this model is:</h3>
                   {this.props.accuracy}%
                 </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,5 @@ export const MLTypes = {
   CLASSIFICATION: "classification",
   REGRESSION: "regression"
 };
+
+export const TRAINING_DATA_PERCENTS = [0, 5, 10, 15, 20];

--- a/src/redux.js
+++ b/src/redux.js
@@ -22,6 +22,7 @@ const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
 const SET_SELECTED_FEATURES = "SET_SELECTED_FEATURES";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
+const SET_PERCENT_DATA_TO_RESERVE = "SET_PERCENT_DATA_TO_RESERVE";
 const SET_ACCURACY_CHECK_EXAMPLES = "SET_ACCURACY_CHECK_EXAMPLES";
 const SET_ACCURACY_CHECK_LABELS = "SET_ACCURACY_CHECK_LABELS";
 const SET_ACCURACY_CHECK_PREDICTED_LABELS =
@@ -74,6 +75,10 @@ export function setFeatureNumberKey(featureNumberKey) {
   return { type: SET_FEATURE_NUMBER_KEY, featureNumberKey };
 }
 
+export function setPercentDataToReserve(percentDataToReserve) {
+  return { type: SET_PERCENT_DATA_TO_RESERVE, percentDataToReserve };
+}
+
 export function setAccuracyCheckExamples(accuracyCheckExamples) {
   return { type: SET_ACCURACY_CHECK_EXAMPLES, accuracyCheckExamples };
 }
@@ -119,6 +124,7 @@ const initialState = {
   featureNumberKey: {},
   trainingExamples: [],
   trainingLabels: [],
+  percentDataToReserve: 10,
   accuracyCheckExamples: [],
   accuracyCheckLabels: [],
   accuracyCheckPredictedLabels: [],
@@ -178,6 +184,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       trainingLabels: action.trainingLabels
+    };
+  }
+  if (action.type === SET_PERCENT_DATA_TO_RESERVE) {
+    return {
+      ...state,
+      percentDataToReserve: action.percentDataToReserve
     };
   }
   if (action.type === SET_ACCURACY_CHECK_EXAMPLES) {

--- a/src/train.js
+++ b/src/train.js
@@ -178,7 +178,8 @@ const prepareTrainingData = () => {
   // trained and saved to state separately to test the model's accuracy.
   const accuracyCheckExamples = [];
   const accuracyCheckLabels = [];
-  const numToReserve = parseInt(trainingExamples.length * 0.1);
+  const percent = updatedState.percentDataToReserve / 100;
+  const numToReserve = parseInt(trainingExamples.length * percent);
   let numReserved = 0;
   while (numReserved < numToReserve) {
     let randomIndex = getRandomInt(trainingExamples.length - 1);

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -10,7 +10,11 @@ export default class KNNTrainer {
     this.knn = new ML.KNN(state.trainingExamples, state.trainingLabels, {
       k: 5
     });
-    this.batchPredict(state.accuracyCheckExamples);
+    if (state.accuracyCheckExamples.length > 0) {
+      this.batchPredict(state.accuracyCheckExamples);
+    } else {
+      store.dispatch(setAccuracyCheckPredictedLabels([]));
+    }
   }
 
   batchPredict(accuracyCheckExamples) {

--- a/src/trainers/SVMTrainer.js
+++ b/src/trainers/SVMTrainer.js
@@ -47,7 +47,11 @@ export default class SVMTrainer {
       this.convertLabel(labelOption, state.featureNumberKey[state.labelColumn])
     );
     this.train(trainingExamples, trainingLabels);
-    this.batchPredict(state.accuracyCheckExamples);
+    if (state.accuracyCheckExamples.length > 0) {
+      this.batchPredict(state.accuracyCheckExamples);
+    } else {
+      store.dispatch(setAccuracyCheckPredictedLabels([]));
+    }
   }
 
   train(trainingExamples, trainingLabels) {


### PR DESCRIPTION
Jira: [AI-49](https://codedotorg.atlassian.net/browse/AI-49)

Allows the student to select the % of the dataset held back for the accuracy check from a range of reasonable amounts. This will be important both for iterating on dataset + algorithm combos and for supporting scenarios where the entire dataset needs to be part of the training set (i.e. when all categorical labels are unique; [example from this thread](https://codedotorg.slack.com/archives/C016VGH1BT6/p1603729610067100)). 
 
![select-percent-to-reserve](https://user-images.githubusercontent.com/12300669/97330315-7b4b9a00-184e-11eb-9e48-53aa2ab75c4e.gif)
