### PR TITLE
Datatype only for selected columns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import CSVReaderWrapper from "./UIComponents/CSVReaderWrapper";
 import DataDisplay from "./UIComponents/DataDisplay";
+import SelectFeatures from "./UIComponents/SelectFeatures";
 import SelectTrainer from "./UIComponents/SelectTrainer";
 import TrainModel from "./UIComponents/TrainModel";
 import Predict from "./UIComponents/Predict";
@@ -11,6 +12,7 @@ export default class App extends Component {
       <div>
         <CSVReaderWrapper />
         <DataDisplay />
+        <SelectFeatures />
         <SelectTrainer />
         <TrainModel />
         <Predict />

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import CSVReaderWrapper from "./UIComponents/CSVReaderWrapper";
 import DataDisplay from "./UIComponents/DataDisplay";
 import SelectFeatures from "./UIComponents/SelectFeatures";
+import ColumnInspector from "./UIComponents/ColumnInspector";
 import SelectTrainer from "./UIComponents/SelectTrainer";
 import TrainModel from "./UIComponents/TrainModel";
 import Predict from "./UIComponents/Predict";
@@ -13,6 +14,7 @@ export default class App extends Component {
         <CSVReaderWrapper />
         <DataDisplay />
         <SelectFeatures />
+        <ColumnInspector />
         <SelectTrainer />
         <TrainModel />
         <Predict />

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -1,156 +1,29 @@
-/* React component to handle setting datatype for selected columns and displaying an overview of column contents. */
+/* React component to handle setting datatype for selected columns. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import {
-  setLabelColumn,
-  setSelectedFeatures,
-  setShowPredict,
-  setColumnsByDataType,
-  getFeatures,
-  getSelectableFeatures,
-  getSelectableLabels
-} from "../redux";
+import { getSelectedColumns, setColumnsByDataType } from "../redux";
 import { ColumnTypes } from "../constants.js";
 
-class DataDisplay extends Component {
+class ColumnInspector extends Component {
   static propTypes = {
-    data: PropTypes.array,
-    features: PropTypes.array,
-    labelColumn: PropTypes.string,
-    setLabelColumn: PropTypes.func.isRequired,
-    selectedFeatures: PropTypes.array,
-    setSelectedFeatures: PropTypes.func.isRequired,
-    setShowPredict: PropTypes.func.isRequired,
+    getSelectedColumns: PropTypes.func,
+    selectedColumns: PropTypes.array,
     columnsByDataType: PropTypes.object,
-    setColumnsByDataType: PropTypes.func.isRequired,
-    selectableFeatures: PropTypes.array,
-    selectableLabels: PropTypes.array
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showRawData: true
-    };
-  }
-
-  toggleRawData = () => {
-    this.setState({
-      showRawData: !this.state.showRawData
-    });
+    setColumnsByDataType: PropTypes.func.isRequired
   };
 
   handleChangeDataType = (event, feature) => {
     event.preventDefault();
     this.props.setColumnsByDataType(feature, event.target.value);
-    this.resetSelections(event.target.value, feature);
-  };
-
-  resetSelections = (dataType, feature) => {
-    if (
-      dataType !== ColumnTypes.CATEGORICAL &&
-      this.props.labelColumn === feature
-    ) {
-      this.props.setLabelColumn("");
-    }
-    if (
-      dataType === ColumnTypes.OTHER &&
-      this.props.selectedFeatures.includes(feature)
-    ) {
-      let remainingSelectedFeatures = this.props.selectedFeatures.filter(
-        selectedFeature => selectedFeature !== feature
-      );
-      this.props.setSelectedFeatures(remainingSelectedFeatures);
-    }
-  };
-
-  handleChangeSelect = event => {
-    this.props.setLabelColumn(event.target.value);
-    this.props.setShowPredict(false);
-  };
-
-  handleChangeMultiSelect = event => {
-    this.props.setSelectedFeatures(
-      Array.from(event.target.selectedOptions, item => item.value)
-    );
-    this.props.setShowPredict(false);
   };
 
   render() {
     return (
       <div>
-        {this.props.data.length > 0 && (
+        {this.props.selectedColumns.length > 0 && (
           <div>
-            <h2>Imported Data</h2>
-            {this.state.showRawData && (
-              <div>
-                <p onClick={this.toggleRawData}>hide data</p>
-                {JSON.stringify(this.props.data)}
-              </div>
-            )}
-            {!this.state.showRawData && (
-              <p onClick={this.toggleRawData}>show data</p>
-            )}
-            {this.props.selectableLabels.length > 0 && (
-              <form>
-                <label>
-                  <h2>Which column contains the labels for your dataset?</h2>
-                  <h3>Classification requires categorical labels.</h3>
-                  <p>
-                    If you select a categorical label, the model will be trained
-                    to predict which category from the label column an example
-                    (a set of attributes or features) is most likely to belong
-                    to.
-                  </p>
-                  <h3>Regression requires continuous labels.</h3>
-                  <p>
-                    If you select a continuous label, the model will be trained
-                    to predict a numerical value that is most likely to fit with
-                    an example's features or attributes.
-                  </p>
-                  <select
-                    value={this.props.labelColumn}
-                    onChange={this.handleChangeSelect}
-                  >
-                    <option>{""}</option>
-                    {this.props.selectableLabels.map((feature, index) => {
-                      return (
-                        <option key={index} value={feature}>
-                          {feature}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </label>
-              </form>
-            )}
-            {this.props.selectableFeatures.length > 0 && (
-              <form>
-                <label>
-                  <h2>Which features are you interested in training on?</h2>
-                  <p>
-                    Features are the attributes the model will use to make a
-                    prediction. Features can be categorical or continuous.
-                  </p>
-                  <select
-                    multiple={true}
-                    value={this.props.selectedFeatures}
-                    onChange={this.handleChangeMultiSelect}
-                  >
-                    {this.props.selectableFeatures.map((feature, index) => {
-                      return (
-                        <option key={index} value={feature}>
-                          {feature}
-                        </option>
-                      );
-                    })}
-                  </select>
-                </label>
-              </form>
-            )}
-            <h2>Describe the data in each of your columns</h2>
+            <h2>Describe the data in each of your selected columns</h2>
             <p>
               Categorical columns contain a fixed number of possible values that
               indicate a group. For example, the column "Size" might contain
@@ -163,22 +36,22 @@ class DataDisplay extends Component {
               "11.25" and "9.07".{" "}
             </p>
             <p>
-              Select "other" if the column contains anything other than
-              categorical or continuous data. This is the best choice for "name"
-              or "id" columns, for example.
+              If the column contains anything other than categorical or
+              continuous data, it's not going to work for training this type of
+              machine learning model.
             </p>
             <form>
-              {this.props.features.map((feature, index) => {
+              {this.props.selectedColumns.map((column, index) => {
                 return (
                   <div key={index}>
-                    {this.props.columnsByDataType[feature] && (
+                    {this.props.columnsByDataType[column] && (
                       <label>
-                        {feature}:
+                        {column}:
                         <select
                           onChange={event =>
-                            this.handleChangeDataType(event, feature)
+                            this.handleChangeDataType(event, column)
                           }
-                          value={this.props.columnsByDataType[feature]}
+                          value={this.props.columnsByDataType[column]}
                         >
                           {Object.values(ColumnTypes).map((option, index) => {
                             return (
@@ -205,26 +78,15 @@ class DataDisplay extends Component {
 
 export default connect(
   state => ({
-    data: state.data,
-    labelColumn: state.labelColumn,
-    selectedFeatures: state.selectedFeatures,
-    features: getFeatures(state),
-    columnsByDataType: state.columnsByDataType,
-    selectableFeatures: getSelectableFeatures(state),
-    selectableLabels: getSelectableLabels(state)
+    selectedColumns: getSelectedColumns(state),
+    columnsByDataType: state.columnsByDataType
   }),
   dispatch => ({
     setColumnsByDataType(column, dataType) {
       dispatch(setColumnsByDataType(column, dataType));
     },
-    setSelectedFeatures(selectedFeatures) {
-      dispatch(setSelectedFeatures(selectedFeatures));
-    },
-    setLabelColumn(labelColumn) {
-      dispatch(setLabelColumn(labelColumn));
-    },
     setShowPredict(showPredict) {
       dispatch(setShowPredict(showPredict));
     }
   })
-)(DataDisplay);
+)(ColumnInspector);

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -1,4 +1,4 @@
-/* React component to handle displaying imported data. */
+/* React component to handle setting datatype for selected columns and displaying an overview of column contents. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
@@ -92,6 +92,63 @@ class DataDisplay extends Component {
             )}
             {!this.state.showRawData && (
               <p onClick={this.toggleRawData}>show data</p>
+            )}
+            {this.props.selectableLabels.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which column contains the labels for your dataset?</h2>
+                  <h3>Classification requires categorical labels.</h3>
+                  <p>
+                    If you select a categorical label, the model will be trained
+                    to predict which category from the label column an example
+                    (a set of attributes or features) is most likely to belong
+                    to.
+                  </p>
+                  <h3>Regression requires continuous labels.</h3>
+                  <p>
+                    If you select a continuous label, the model will be trained
+                    to predict a numerical value that is most likely to fit with
+                    an example's features or attributes.
+                  </p>
+                  <select
+                    value={this.props.labelColumn}
+                    onChange={this.handleChangeSelect}
+                  >
+                    <option>{""}</option>
+                    {this.props.selectableLabels.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
+            )}
+            {this.props.selectableFeatures.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which features are you interested in training on?</h2>
+                  <p>
+                    Features are the attributes the model will use to make a
+                    prediction. Features can be categorical or continuous.
+                  </p>
+                  <select
+                    multiple={true}
+                    value={this.props.selectedFeatures}
+                    onChange={this.handleChangeMultiSelect}
+                  >
+                    {this.props.selectableFeatures.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
             )}
             <h2>Describe the data in each of your columns</h2>
             <p>

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -84,9 +84,6 @@ export default connect(
   dispatch => ({
     setColumnsByDataType(column, dataType) {
       dispatch(setColumnsByDataType(column, dataType));
-    },
-    setShowPredict(showPredict) {
-      dispatch(setShowPredict(showPredict));
     }
   })
 )(ColumnInspector);

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,30 +2,10 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import {
-  setLabelColumn,
-  setSelectedFeatures,
-  setShowPredict,
-  setColumnsByDataType,
-  getFeatures,
-  getSelectableFeatures,
-  getSelectableLabels
-} from "../redux";
-import { ColumnTypes } from "../constants.js";
 
 class DataDisplay extends Component {
   static propTypes = {
-    data: PropTypes.array,
-    features: PropTypes.array,
-    labelColumn: PropTypes.string,
-    setLabelColumn: PropTypes.func.isRequired,
-    selectedFeatures: PropTypes.array,
-    setSelectedFeatures: PropTypes.func.isRequired,
-    setShowPredict: PropTypes.func.isRequired,
-    columnsByDataType: PropTypes.object,
-    setColumnsByDataType: PropTypes.func.isRequired,
-    selectableFeatures: PropTypes.array,
-    selectableLabels: PropTypes.array
+    data: PropTypes.array
   };
 
   constructor(props) {
@@ -40,42 +20,6 @@ class DataDisplay extends Component {
     this.setState({
       showRawData: !this.state.showRawData
     });
-  };
-
-  handleChangeDataType = (event, feature) => {
-    event.preventDefault();
-    this.props.setColumnsByDataType(feature, event.target.value);
-    this.resetSelections(event.target.value, feature);
-  };
-
-  resetSelections = (dataType, feature) => {
-    if (
-      dataType !== ColumnTypes.CATEGORICAL &&
-      this.props.labelColumn === feature
-    ) {
-      this.props.setLabelColumn("");
-    }
-    if (
-      dataType === ColumnTypes.OTHER &&
-      this.props.selectedFeatures.includes(feature)
-    ) {
-      let remainingSelectedFeatures = this.props.selectedFeatures.filter(
-        selectedFeature => selectedFeature !== feature
-      );
-      this.props.setSelectedFeatures(remainingSelectedFeatures);
-    }
-  };
-
-  handleChangeSelect = event => {
-    this.props.setLabelColumn(event.target.value);
-    this.props.setShowPredict(false);
-  };
-
-  handleChangeMultiSelect = event => {
-    this.props.setSelectedFeatures(
-      Array.from(event.target.selectedOptions, item => item.value)
-    );
-    this.props.setShowPredict(false);
   };
 
   render() {
@@ -93,52 +37,6 @@ class DataDisplay extends Component {
             {!this.state.showRawData && (
               <p onClick={this.toggleRawData}>show data</p>
             )}
-            <h2>Describe the data in each of your columns</h2>
-            <p>
-              Categorical columns contain a fixed number of possible values that
-              indicate a group. For example, the column "Size" might contain
-              categorical data such as "small", "medium" and "large".{" "}
-            </p>
-            <p>
-              Continuous columns contain a range of possible numerical values
-              that could fall anywhere on a continuum. For example, the column
-              "Height in inches" might contain continuous data such as "12",
-              "11.25" and "9.07".{" "}
-            </p>
-            <p>
-              Select "other" if the column contains anything other than
-              categorical or continuous data. This is the best choice for "name"
-              or "id" columns, for example.
-            </p>
-            <form>
-              {this.props.features.map((feature, index) => {
-                return (
-                  <div key={index}>
-                    {this.props.columnsByDataType[feature] && (
-                      <label>
-                        {feature}:
-                        <select
-                          onChange={event =>
-                            this.handleChangeDataType(event, feature)
-                          }
-                          value={this.props.columnsByDataType[feature]}
-                        >
-                          {Object.values(ColumnTypes).map((option, index) => {
-                            return (
-                              <option key={index} value={option}>
-                                {option}
-                              </option>
-                            );
-                          })}
-                        </select>
-                      </label>
-                    )}
-                    <br />
-                    <br />
-                  </div>
-                );
-              })}
-            </form>
           </div>
         )}
       </div>
@@ -146,28 +44,6 @@ class DataDisplay extends Component {
   }
 }
 
-export default connect(
-  state => ({
-    data: state.data,
-    labelColumn: state.labelColumn,
-    selectedFeatures: state.selectedFeatures,
-    features: getFeatures(state),
-    columnsByDataType: state.columnsByDataType,
-    selectableFeatures: getSelectableFeatures(state),
-    selectableLabels: getSelectableLabels(state)
-  }),
-  dispatch => ({
-    setColumnsByDataType(column, dataType) {
-      dispatch(setColumnsByDataType(column, dataType));
-    },
-    setSelectedFeatures(selectedFeatures) {
-      dispatch(setSelectedFeatures(selectedFeatures));
-    },
-    setLabelColumn(labelColumn) {
-      dispatch(setLabelColumn(labelColumn));
-    },
-    setShowPredict(showPredict) {
-      dispatch(setShowPredict(showPredict));
-    }
-  })
-)(DataDisplay);
+export default connect(state => ({
+  data: state.data
+}))(DataDisplay);

--- a/src/UIComponents/SelectFeatures.jsx
+++ b/src/UIComponents/SelectFeatures.jsx
@@ -1,0 +1,118 @@
+/* React component to handle selecting features and label columns. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import {
+  isDataUploaded,
+  setLabelColumn,
+  setSelectedFeatures,
+  setShowPredict,
+  getSelectableFeatures,
+  getSelectableLabels
+} from "../redux";
+
+class SelectFeatures extends Component {
+  static propTypes = {
+    isDataUploaded: PropTypes.bool,
+    features: PropTypes.array,
+    labelColumn: PropTypes.string,
+    setLabelColumn: PropTypes.func.isRequired,
+    selectedFeatures: PropTypes.array,
+    setSelectedFeatures: PropTypes.func.isRequired,
+    setShowPredict: PropTypes.func.isRequired,
+    selectableFeatures: PropTypes.array,
+    selectableLabels: PropTypes.array
+  };
+
+  handleChangeSelect = event => {
+    this.props.setLabelColumn(event.target.value);
+    this.props.setShowPredict(false);
+  };
+
+  handleChangeMultiSelect = event => {
+    this.props.setSelectedFeatures(
+      Array.from(event.target.selectedOptions, item => item.value)
+    );
+    this.props.setShowPredict(false);
+  };
+
+  render() {
+    return (
+      <div>
+        {this.props.isDataUploaded && (
+          <div>
+            {this.props.selectableLabels.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which column contains the labels for your dataset?</h2>
+                  <p>
+                    The label is the column you'd like to train the model to
+                    predict.
+                  </p>
+                  <select
+                    value={this.props.labelColumn}
+                    onChange={this.handleChangeSelect}
+                  >
+                    <option>{""}</option>
+                    {this.props.selectableLabels.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
+            )}
+            {this.props.selectableFeatures.length > 0 && (
+              <form>
+                <label>
+                  <h2>Which features are you interested in training on?</h2>
+                  <p>
+                    Features are the attributes the model will use to make a
+                    prediction.
+                  </p>
+                  <select
+                    multiple={true}
+                    value={this.props.selectedFeatures}
+                    onChange={this.handleChangeMultiSelect}
+                  >
+                    {this.props.selectableFeatures.map((feature, index) => {
+                      return (
+                        <option key={index} value={feature}>
+                          {feature}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </form>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    isDataUploaded: isDataUploaded(state),
+    labelColumn: state.labelColumn,
+    selectedFeatures: state.selectedFeatures,
+    selectableFeatures: getSelectableFeatures(state),
+    selectableLabels: getSelectableLabels(state)
+  }),
+  dispatch => ({
+    setSelectedFeatures(selectedFeatures) {
+      dispatch(setSelectedFeatures(selectedFeatures));
+    },
+    setLabelColumn(labelColumn) {
+      dispatch(setLabelColumn(labelColumn));
+    },
+    setShowPredict(showPredict) {
+      dispatch(setShowPredict(showPredict));
+    }
+  })
+)(SelectFeatures);

--- a/src/redux.js
+++ b/src/redux.js
@@ -269,15 +269,11 @@ export function getContinuousColumns(state) {
 }
 
 export function getSelectableFeatures(state) {
-  return getContinuousColumns(state)
-    .concat(getCategoricalColumns(state))
-    .filter(column => column !== state.labelColumn);
+  return getFeatures(state).filter(column => column !== state.labelColumn);
 }
 
 export function getSelectableLabels(state) {
-  const eligibleColumns = getContinuousColumns(state).concat(
-    getCategoricalColumns(state)
-  );
+  const eligibleColumns = getFeatures(state);
   let labelsRestrictedByTrainer;
   switch (true) {
     case availableTrainers[state.selectedTrainer] &&
@@ -403,6 +399,10 @@ export function validationMessages(state) {
     successString: "The label datatype and training algorithm are compatible."
   });
   return validationMessages;
+}
+
+export function isDataUploaded(state) {
+  return state.data.length > 0;
 }
 
 export function readyToTrain(state) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -8,6 +8,7 @@ import {
   minOneFeatureSelected,
   oneLabelSelected,
   uniqLabelFeaturesSelected,
+  selectedColumnsHaveDatatype,
   trainerSelected,
   compatibleLabelAndTrainer
 } from "./validate.js";
@@ -250,6 +251,12 @@ export function getCategoricalColumns(state) {
   return filterColumnsByType(state, ColumnTypes.CATEGORICAL);
 }
 
+export function getSelectedColumns(state) {
+  return state.selectedFeatures
+    .concat(state.labelColumn)
+    .filter(column => column !== undefined && column !== "");
+}
+
 export function getSelectedCategoricalColumns(state) {
   let intersection = getCategoricalColumns(state).filter(x =>
     state.selectedFeatures.includes(x)
@@ -386,6 +393,13 @@ export function validationMessages(state) {
     errorString:
       "A column can not be selected as a both a feature and a label.",
     successString: "Label and feature(s) columns are unique."
+  });
+  validationMessages.push({
+    readyToTrain: selectedColumnsHaveDatatype(state),
+    errorString:
+      "Feature and label columns must contain only continuous or categorical data.",
+    successString:
+      "Selected features and label contain continiuous or categorical data"
   });
   validationMessages.push({
     readyToTrain: trainerSelected(state),

--- a/src/redux.js
+++ b/src/redux.js
@@ -399,7 +399,7 @@ export function validationMessages(state) {
     errorString:
       "Feature and label columns must contain only continuous or categorical data.",
     successString:
-      "Selected features and label contain continiuous or categorical data"
+      "Selected features and label contain continuous or categorical data"
   });
   validationMessages.push({
     readyToTrain: trainerSelected(state),

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,6 +1,7 @@
 /* Validation checks to determine if app set up is ready for machine learning training */
 
 import { availableTrainers } from "./train.js";
+import { ColumnTypes } from "./constants.js";
 
 export function minOneFeatureSelected(state) {
   return state.selectedFeatures.length !== 0;
@@ -16,6 +17,23 @@ export function uniqLabelFeaturesSelected(state) {
     oneLabelSelected(state) &&
     !state.selectedFeatures.includes(state.labelColumn)
   );
+}
+
+// Check that each feature column and the label column contain continuous or
+// categorical data, not "Other".
+// @return {boolean}
+export function selectedColumnsHaveDatatype(state) {
+  const selectedColumns = state.selectedFeatures
+    .concat(state.labelColumn)
+    .filter(column => column !== undefined && column !== "");
+  let columnTypesOk = true;
+  for (const column of selectedColumns) {
+    if (state.columnsByDataType[column] === ColumnTypes.OTHER) {
+      columnTypesOk = false;
+      return columnTypesOk;
+    }
+  }
+  return selectedColumns.length > 0 && columnTypesOk;
 }
 
 export function trainerSelected(state) {


### PR DESCRIPTION
Jira: AI-54 

Flipped the flow around  based on a [conversation](https://codedotorg.slack.com/archives/C016VGH1BT6/p1603911454105500) with the curriculum team that there's no need to designate a datatype for columns that won't be used for training.  I did a little refactoring along the way to extract 2 smaller components from `DataDisplay`: `SelectFeatures` and `ColumnInspector` to keep things more compartmentalized and in anticipation of future work.  Lastly, I added a validation check that all selected columns have a datatype of "categorical" or "continuous".

![datatype-only-for-selected-columns](https://user-images.githubusercontent.com/12300669/97592039-9ba66080-19d6-11eb-994d-81a9ff3d782c.gif)
