### PR TITLE
Show column stats

### DIFF
--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -45,7 +45,8 @@ class CSVReaderWrapper extends Component {
     Papa.parse(csvfile, {
       complete: this.updateData,
       header: true,
-      download: download
+      download: download,
+      skipEmptyLines: true
     });
   };
 

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -5,9 +5,10 @@ import { connect } from "react-redux";
 import {
   getSelectedColumns,
   setColumnsByDataType,
-  getUniqueOptionsByColumn
+  getUniqueOptionsByColumn,
+  getRangesByColumn
 } from "../redux";
-import { ColumnTypes } from "../constants.js";
+import { ColumnTypes, styles } from "../constants.js";
 
 class ColumnInspector extends Component {
   static propTypes = {
@@ -16,7 +17,9 @@ class ColumnInspector extends Component {
     columnsByDataType: PropTypes.object,
     setColumnsByDataType: PropTypes.func.isRequired,
     getUniqueOptionsByColumn: PropTypes.func,
-    uniqueOptionsByColumn: PropTypes.object
+    uniqueOptionsByColumn: PropTypes.object,
+    getRangesByColumn: PropTypes.func,
+    rangesByColumn: PropTypes.object
   };
 
   handleChangeDataType = (event, feature) => {
@@ -83,6 +86,25 @@ class ColumnInspector extends Component {
                         )}
                       </div>
                     )}
+                    {this.props.columnsByDataType[column] ===
+                      ColumnTypes.CONTINUOUS && (
+                      <div>
+                        {this.props.rangesByColumn[column] && (
+                          <div>
+                            {isNaN(this.props.rangesByColumn[column].min) && (
+                              <p style={styles.error}>
+                                Continuous columns should contain only numbers.
+                              </p>
+                            )}
+                            <br />
+                            min: {this.props.rangesByColumn[column].min}
+                            <br />
+                            <br />
+                            max: {this.props.rangesByColumn[column].max}
+                          </div>
+                        )}
+                      </div>
+                    )}
                     <br />
                     <br />
                   </div>
@@ -100,7 +122,8 @@ export default connect(
   state => ({
     selectedColumns: getSelectedColumns(state),
     columnsByDataType: state.columnsByDataType,
-    uniqueOptionsByColumn: getUniqueOptionsByColumn(state)
+    uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
+    rangesByColumn: getRangesByColumn(state)
   }),
   dispatch => ({
     setColumnsByDataType(column, dataType) {

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -2,7 +2,11 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getSelectedColumns, setColumnsByDataType } from "../redux";
+import {
+  getSelectedColumns,
+  setColumnsByDataType,
+  getUniqueOptionsByColumn
+} from "../redux";
 import { ColumnTypes } from "../constants.js";
 
 class ColumnInspector extends Component {
@@ -10,7 +14,9 @@ class ColumnInspector extends Component {
     getSelectedColumns: PropTypes.func,
     selectedColumns: PropTypes.array,
     columnsByDataType: PropTypes.object,
-    setColumnsByDataType: PropTypes.func.isRequired
+    setColumnsByDataType: PropTypes.func.isRequired,
+    getUniqueOptionsByColumn: PropTypes.func,
+    uniqueOptionsByColumn: PropTypes.object
   };
 
   handleChangeDataType = (event, feature) => {
@@ -63,6 +69,20 @@ class ColumnInspector extends Component {
                         </select>
                       </label>
                     )}
+                    {this.props.columnsByDataType[column] ===
+                      ColumnTypes.CATEGORICAL && (
+                      <div>
+                        <p>
+                          {this.props.uniqueOptionsByColumn[column].length}{" "}
+                          unique values for {column}:{" "}
+                        </p>
+                        {this.props.uniqueOptionsByColumn[column].map(
+                          (option, index) => {
+                            return <div key={index}>{option}</div>;
+                          }
+                        )}
+                      </div>
+                    )}
                     <br />
                     <br />
                   </div>
@@ -79,7 +99,8 @@ class ColumnInspector extends Component {
 export default connect(
   state => ({
     selectedColumns: getSelectedColumns(state),
-    columnsByDataType: state.columnsByDataType
+    columnsByDataType: state.columnsByDataType,
+    uniqueOptionsByColumn: getUniqueOptionsByColumn(state)
   }),
   dispatch => ({
     setColumnsByDataType(column, dataType) {

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -10,16 +10,7 @@ import {
   readyToTrain,
   validationMessages
 } from "../redux";
-import { TRAINING_DATA_PERCENTS } from "../constants";
-
-const styles = {
-  error: {
-    color: "red"
-  },
-  ready: {
-    color: "green"
-  }
-};
+import { TRAINING_DATA_PERCENTS, styles } from "../constants";
 
 class TrainModel extends Component {
   static propTypes = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,3 +10,12 @@ export const MLTypes = {
 };
 
 export const TRAINING_DATA_PERCENTS = [0, 5, 10, 15, 20];
+
+export const styles = {
+  error: {
+    color: "red"
+  },
+  ready: {
+    color: "green"
+  }
+};

--- a/src/redux.js
+++ b/src/redux.js
@@ -14,7 +14,7 @@ import {
   compatibleLabelAndTrainer
 } from "./validate.js";
 
-import { MLTypes, ColumnTypes } from "./constants.js";
+import { ColumnTypes } from "./constants.js";
 
 // Action types
 const RESET_STATE = "RESET_STATE";

--- a/src/redux.js
+++ b/src/redux.js
@@ -9,6 +9,7 @@ import {
   oneLabelSelected,
   uniqLabelFeaturesSelected,
   selectedColumnsHaveDatatype,
+  continuousColumnsHaveOnlyNumbers,
   trainerSelected,
   compatibleLabelAndTrainer
 } from "./validate.js";
@@ -265,8 +266,8 @@ export function getSelectedCategoricalColumns(state) {
 }
 
 export function getSelectedContinuousColumns(state) {
-  let intersection = getContinuousColumns(state).filter(x =>
-    state.selectedFeatures.includes(x)
+  let intersection = getContinuousColumns(state).filter(
+    x => state.selectedFeatures.includes(x) || x === state.labelColumn
   );
   return intersection;
 }
@@ -295,6 +296,21 @@ export function getUniqueOptionsByColumn(state) {
     column => (uniqueOptionsByColumn[column] = getUniqueOptions(state, column))
   );
   return uniqueOptionsByColumn;
+}
+
+export function getRangesByColumn(state) {
+  let rangesByColumn = {};
+  getSelectedContinuousColumns(state).map(
+    column => (rangesByColumn[column] = getRange(state, column))
+  );
+  return rangesByColumn;
+}
+
+export function getRange(state, column) {
+  let range = {};
+  range.max = Math.max(...state.data.map(row => parseFloat(row[column])));
+  range.min = Math.min(...state.data.map(row => parseFloat(row[column])));
+  return range;
 }
 
 function getKeyByValue(object, value) {
@@ -374,6 +390,11 @@ export function validationMessages(state) {
       "Feature and label columns must contain only continuous or categorical data.",
     successString:
       "Selected features and label contain continuous or categorical data"
+  });
+  validationMessages.push({
+    readyToTrain: continuousColumnsHaveOnlyNumbers(state),
+    errorString: "Continuous columns should contain only numbers.",
+    successString: "Continuous columns contain only numbers."
   });
   validationMessages.push({
     readyToTrain: trainerSelected(state),

--- a/src/redux.js
+++ b/src/redux.js
@@ -258,8 +258,8 @@ export function getSelectedColumns(state) {
 }
 
 export function getSelectedCategoricalColumns(state) {
-  let intersection = getCategoricalColumns(state).filter(x =>
-    state.selectedFeatures.includes(x)
+  let intersection = getCategoricalColumns(state).filter(
+    x => state.selectedFeatures.includes(x) || x === state.labelColumn
   );
   return intersection;
 }
@@ -280,33 +280,7 @@ export function getSelectableFeatures(state) {
 }
 
 export function getSelectableLabels(state) {
-  const eligibleColumns = getFeatures(state);
-  let labelsRestrictedByTrainer;
-  switch (true) {
-    case availableTrainers[state.selectedTrainer] &&
-      availableTrainers[state.selectedTrainer].mlType ===
-        MLTypes.CLASSIFICATION &&
-      availableTrainers[state.selectedTrainer].binary:
-      labelsRestrictedByTrainer = getCategoricalColumns(state).filter(
-        column => getUniqueOptions(state, column).length === 2
-      );
-      break;
-    case availableTrainers[state.selectedTrainer] &&
-      availableTrainers[state.selectedTrainer].mlType ===
-        MLTypes.CLASSIFICATION:
-      labelsRestrictedByTrainer = getCategoricalColumns(state);
-      break;
-    case availableTrainers[state.selectedTrainer] &&
-      availableTrainers[state.selectedTrainer].mlType === MLTypes.REGRESSION:
-      labelsRestrictedByTrainer = getContinuousColumns(state);
-      break;
-    default:
-      labelsRestrictedByTrainer = eligibleColumns;
-  }
-  const selectableLabels = labelsRestrictedByTrainer.filter(
-    x => !state.selectedFeatures.includes(x)
-  );
-  return selectableLabels;
+  return getFeatures(state).filter(x => !state.selectedFeatures.includes(x));
 }
 
 export function getUniqueOptions(state, column) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -2,6 +2,7 @@
 
 import { availableTrainers } from "./train.js";
 import { ColumnTypes } from "./constants.js";
+import { getSelectedContinuousColumns } from "./redux.js";
 
 export function minOneFeatureSelected(state) {
   return state.selectedFeatures.length !== 0;
@@ -34,6 +35,22 @@ export function selectedColumnsHaveDatatype(state) {
     }
   }
   return selectedColumns.length > 0 && columnTypesOk;
+}
+
+// Check that selected continuous columns only contain numbers.
+// @return {boolean}
+export function continuousColumnsHaveOnlyNumbers(state) {
+  const columns = getSelectedContinuousColumns(state);
+  let allNumbers = true;
+  state.data.forEach(function(row, i) {
+    for (const column of columns) {
+      if (isNaN(parseFloat(row[column]))) {
+        allNumbers = false;
+        return allNumbers;
+      }
+    }
+  });
+  return columns.length > 0 && allNumbers;
 }
 
 export function trainerSelected(state) {


### PR DESCRIPTION
Jira: AI-38, AI-57

Students are going to need to be able to "inspect" their data to check for errors in preparation for training. 

For categorical columns, we now show the number of unique values in the column and what those values are. For continuous columns, we now validate that the column only contains numerical values and show the max and min values in the column.

<img width="211" alt="Screen Shot 2020-10-29 at 1 40 06 PM" src="https://user-images.githubusercontent.com/12300669/97617699-77f21300-19f4-11eb-8784-9afb06197518.png">

This will help students identify when they have more categories than anticipated, for example: 
<img width="282" alt="Screen Shot 2020-10-29 at 1 17 11 PM" src="https://user-images.githubusercontent.com/12300669/97617780-92c48780-19f4-11eb-89c7-db5ea63808d1.png">

If they've mis-identified the datatype stored in a column or if this there is a string lurking in a column that should only contain numbers, for example: 
<img width="347" alt="Screen Shot 2020-10-29 at 2 40 31 PM" src="https://user-images.githubusercontent.com/12300669/97617917-bf789f00-19f4-11eb-93c6-3ad0bff3cbb5.png">
