### PR TITLE
Toggle to show/hide empty cell row and column details

### DIFF
--- a/public/datasets/erin_candy_preferences.csv
+++ b/public/datasets/erin_candy_preferences.csv
@@ -84,3 +84,4 @@ Warheads,0,1,0,0,0,0,1,0,0,1
 Welch's Fruit Snacks,0,1,0,0,0,0,0,0,1,-1
 Werther's Original Caramel,0,0,1,0,0,0,1,0,0,-1
 Whoppers,1,0,0,0,0,1,0,0,1,1
+Fake,1,1,1,1,1,1,1,1,1

--- a/public/datasets/erin_candy_preferences.csv
+++ b/public/datasets/erin_candy_preferences.csv
@@ -84,4 +84,3 @@ Warheads,0,1,0,0,0,0,1,0,0,1
 Welch's Fruit Snacks,0,1,0,0,0,0,0,0,1,-1
 Werther's Original Caramel,0,0,1,0,0,0,1,0,0,-1
 Whoppers,1,0,0,0,0,1,0,0,1,1
-Fake,1,1,1,1,1,1,1,1,1

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,23 +2,32 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { getEmptyCellDetails } from "../redux";
 
 class DataDisplay extends Component {
   static propTypes = {
-    data: PropTypes.array
+    data: PropTypes.array,
+    emptyCellDetails: PropTypes.array
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      showRawData: true
+      showRawData: true,
+      showEmptyCellDetails: false
     };
   }
 
   toggleRawData = () => {
     this.setState({
       showRawData: !this.state.showRawData
+    });
+  };
+
+  toggleEmptyCellDetails = () => {
+    this.setState({
+      showEmptyCellDetails: !this.state.showEmptyCellDetails
     });
   };
 
@@ -37,6 +46,23 @@ class DataDisplay extends Component {
             {!this.state.showRawData && (
               <p onClick={this.toggleRawData}>show data</p>
             )}
+            <h3>There are {this.props.data.length} rows of data.</h3>
+            <h3>There are {this.props.emptyCellDetails.length} empty cells.</h3>
+            {this.state.showEmptyCellDetails && (
+              <div>
+                <p onClick={this.toggleEmptyCellDetails}>
+                  hide empty cell details
+                </p>
+                {this.props.emptyCellDetails.map((cellDetails, i) => {
+                  return <p key={i}>{cellDetails}</p>;
+                })}
+              </div>
+            )}
+            {!this.state.showEmptyCellDetails && (
+              <p onClick={this.toggleEmptyCellDetails}>
+                show empty cell details
+              </p>
+            )}
           </div>
         )}
       </div>
@@ -45,5 +71,6 @@ class DataDisplay extends Component {
 }
 
 export default connect(state => ({
-  data: state.data
+  data: state.data,
+  emptyCellDetails: getEmptyCellDetails(state)
 }))(DataDisplay);

--- a/src/redux.js
+++ b/src/redux.js
@@ -8,6 +8,7 @@ import {
   datasetUploaded,
   uniqueColumnNames,
   noEmptyCells,
+  emptyCellFinder,
   minOneFeatureSelected,
   oneLabelSelected,
   uniqLabelFeaturesSelected,
@@ -440,4 +441,11 @@ export function isDataUploaded(state) {
 
 export function readyToTrain(state) {
   return uniqLabelFeaturesSelected(state) && compatibleLabelAndTrainer(state);
+}
+
+export function getEmptyCellDetails(state) {
+  const emptyCellLocations = emptyCellFinder(state).map(cellDetails => {
+    return `Column: ${cellDetails.column} Row: ${cellDetails.row}`;
+  });
+  return emptyCellLocations;
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -52,7 +52,7 @@ export function emptyCellFinder(state) {
   state.data.forEach(function(row, i) {
     columns.forEach(function(column) {
       if (row[column] === "" || row[column] === undefined) {
-        emptyCells.push({ row: i, column: column });
+        emptyCells.push({ row: i + 1, column: column });
       }
     });
   });


### PR DESCRIPTION
Upon uploading data, users will now get high level information about the number of rows and number of empty cells.  They can also optionally view column and row information about each empty cell to allow for better data clean up. 

![empty-cell-details](https://user-images.githubusercontent.com/12300669/98126764-f1ba4e80-1e83-11eb-8911-b115ca921473.gif)
