### PR TITLE
Extract CSV parsing from UI 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import CSVReaderWrapper from "./UIComponents/CSVReaderWrapper";
+import SelectDataset from "./UIComponents/SelectDataset";
 import DataDisplay from "./UIComponents/DataDisplay";
 import SelectFeatures from "./UIComponents/SelectFeatures";
 import ColumnInspector from "./UIComponents/ColumnInspector";
@@ -11,7 +11,7 @@ export default class App extends Component {
   render() {
     return (
       <div>
-        <CSVReaderWrapper />
+        <SelectDataset />
         <DataDisplay />
         <SelectFeatures />
         <ColumnInspector />

--- a/src/UIComponents/CSVReaderWrapper.jsx
+++ b/src/UIComponents/CSVReaderWrapper.jsx
@@ -3,12 +3,19 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import { resetState, setImportedData, setColumnsByDataType } from "../redux";
-import { availableDatasets } from "../datasetManifest";
+import {
+  setSelectedCSV,
+  resetState,
+  setImportedData,
+  setColumnsByDataType
+} from "../redux";
+import { allDatasets } from "../datasetManifest";
 import { ColumnTypes } from "../constants.js";
 
 class CSVReaderWrapper extends Component {
   static propTypes = {
+    setSelectedCSV: PropTypes.func.isRequired,
+    csvfilePath: PropTypes.string,
     resetState: PropTypes.func.isRequired,
     setImportedData: PropTypes.func.isRequired,
     setColumnsByDataType: PropTypes.func.isRequired
@@ -18,31 +25,30 @@ class CSVReaderWrapper extends Component {
     super(props);
 
     this.state = {
-      csvfile: undefined,
-      download: false,
-      data: undefined
+      download: false
     };
   }
 
   handleChange = event => {
     this.props.resetState();
+    this.props.setSelectedCSV(event.target.files[0]);
     this.setState({
-      csvfile: event.target.files[0],
       download: false
     });
   };
 
   handleChangeSelect = event => {
     this.props.resetState();
+    this.props.setSelectedCSV(event.target.value);
     this.setState({
-      csvfile: event.target.value,
       download: true
     });
   };
 
   importCSV = () => {
-    const { csvfile, download } = this.state;
-    Papa.parse(csvfile, {
+    const { csvfilePath } = this.props;
+    const { download } = this.state;
+    Papa.parse(csvfilePath, {
       complete: this.updateData,
       header: true,
       download: download,
@@ -73,7 +79,7 @@ class CSVReaderWrapper extends Component {
             <h2>Select a dataset from the collection</h2>
             <select onChange={this.handleChangeSelect}>
               <option>{""}</option>
-              {availableDatasets.map(dataset => {
+              {allDatasets.map(dataset => {
                 return (
                   <option
                     key={dataset["id"]}
@@ -109,10 +115,15 @@ class CSVReaderWrapper extends Component {
 }
 
 export default connect(
-  state => ({}),
+  state => ({
+    csvfilePath: state.csvfilePath
+  }),
   dispatch => ({
     resetState() {
       dispatch(resetState());
+    },
+    setSelectedCSV(csvfilePath) {
+      dispatch(setSelectedCSV(csvfilePath));
     },
     setImportedData(data) {
       dispatch(setImportedData(data));

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -3,22 +3,15 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Papa from "papaparse";
 import { connect } from "react-redux";
-import {
-  setSelectedCSV,
-  resetState,
-  setImportedData,
-  setColumnsByDataType
-} from "../redux";
+import { setSelectedCSV, resetState } from "../redux";
+import { parseCSV } from "../csvReaderWrapper";
 import { allDatasets } from "../datasetManifest";
-import { ColumnTypes } from "../constants.js";
 
-class CSVReaderWrapper extends Component {
+class SelectDataset extends Component {
   static propTypes = {
     setSelectedCSV: PropTypes.func.isRequired,
-    csvfilePath: PropTypes.string,
-    resetState: PropTypes.func.isRequired,
-    setImportedData: PropTypes.func.isRequired,
-    setColumnsByDataType: PropTypes.func.isRequired
+    csvfile: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    resetState: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -46,26 +39,7 @@ class CSVReaderWrapper extends Component {
   };
 
   importCSV = () => {
-    const { csvfilePath } = this.props;
-    const { download } = this.state;
-    Papa.parse(csvfilePath, {
-      complete: this.updateData,
-      header: true,
-      download: download,
-      skipEmptyLines: true
-    });
-  };
-
-  updateData = result => {
-    var data = result.data;
-    this.props.setImportedData(data);
-    this.setDefaultColumnDataType(data);
-  };
-
-  setDefaultColumnDataType = data => {
-    Object.keys(data[0]).map(column =>
-      this.props.setColumnsByDataType(column, ColumnTypes.OTHER)
-    );
+    parseCSV(this.props.csvfile, this.state.download);
   };
 
   render() {
@@ -116,7 +90,7 @@ class CSVReaderWrapper extends Component {
 
 export default connect(
   state => ({
-    csvfilePath: state.csvfilePath
+    csvfile: state.csvfile
   }),
   dispatch => ({
     resetState() {
@@ -132,4 +106,4 @@ export default connect(
       dispatch(setColumnsByDataType(column, dataType));
     }
   })
-)(CSVReaderWrapper);
+)(SelectDataset);

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -1,7 +1,6 @@
 /* React component to handle importing CSVs and pushing data to Redux store. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import Papa from "papaparse";
 import { connect } from "react-redux";
 import { setSelectedCSV, resetState } from "../redux";
 import { parseCSV } from "../csvReaderWrapper";
@@ -98,12 +97,6 @@ export default connect(
     },
     setSelectedCSV(csvfilePath) {
       dispatch(setSelectedCSV(csvfilePath));
-    },
-    setImportedData(data) {
-      dispatch(setImportedData(data));
-    },
-    setColumnsByDataType(column, dataType) {
-      dispatch(setColumnsByDataType(column, dataType));
     }
   })
 )(SelectDataset);

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -1,0 +1,25 @@
+import Papa from "papaparse";
+import { store } from "./index.js";
+import { setImportedData, setColumnsByDataType } from "./redux";
+import { ColumnTypes } from "./constants.js";
+
+export const parseCSV = (csvfile, download) => {
+  Papa.parse(csvfile, {
+    complete: updateData,
+    header: true,
+    download: download,
+    skipEmptyLines: true
+  });
+};
+
+const updateData = result => {
+  var data = result.data;
+  store.dispatch(setImportedData(data));
+  setDefaultColumnDataType(data);
+};
+
+const setDefaultColumnDataType = data => {
+  Object.keys(data[0]).map(column =>
+    store.dispatch(setColumnsByDataType(column, ColumnTypes.OTHER))
+  );
+};

--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -1,4 +1,4 @@
-export const availableDatasets = [
+export const allDatasets = [
   {
     id: 1,
     name: "Erin's Candy Preferences - all binary",

--- a/src/redux.js
+++ b/src/redux.js
@@ -40,9 +40,8 @@ const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
 
 // Action creators
-export function setSelectedCSV(csvfilePath) {
-  console.log("setSelectedCSV was called!");
-  return { type: SET_SELECTED_CSV, csvfilePath };
+export function setSelectedCSV(csvfile) {
+  return { type: SET_SELECTED_CSV, csvfile };
 }
 
 export function setImportedData(data) {
@@ -127,7 +126,7 @@ export function resetState() {
 }
 
 const initialState = {
-  csvfilePath: undefined,
+  csvfile: undefined,
   data: [],
   selectedTrainer: undefined,
   columnsByDataType: {},
@@ -148,10 +147,9 @@ const initialState = {
 // Reducer
 export default function rootReducer(state = initialState, action) {
   if (action.type === SET_SELECTED_CSV) {
-    console.log("in setSelectedCSV, csvfilePath", action.csvfilePath);
     return {
       ...state,
-      csvfilePath: action.csvfilePath
+      csvfile: action.csvfile
     };
   }
   if (action.type === SET_IMPORTED_DATA) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -21,6 +21,7 @@ import { ColumnTypes } from "./constants.js";
 
 // Action types
 const RESET_STATE = "RESET_STATE";
+const SET_SELECTED_CSV = "SET_SELECTED_CSV";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_SELECTED_TRAINER = "SET_SELECTED_TRAINER";
 const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
@@ -39,6 +40,11 @@ const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
 
 // Action creators
+export function setSelectedCSV(csvfilePath) {
+  console.log("setSelectedCSV was called!");
+  return { type: SET_SELECTED_CSV, csvfilePath };
+}
+
 export function setImportedData(data) {
   return { type: SET_IMPORTED_DATA, data };
 }
@@ -121,6 +127,7 @@ export function resetState() {
 }
 
 const initialState = {
+  csvfilePath: undefined,
   data: [],
   selectedTrainer: undefined,
   columnsByDataType: {},
@@ -140,6 +147,13 @@ const initialState = {
 
 // Reducer
 export default function rootReducer(state = initialState, action) {
+  if (action.type === SET_SELECTED_CSV) {
+    console.log("in setSelectedCSV, csvfilePath", action.csvfilePath);
+    return {
+      ...state,
+      csvfilePath: action.csvfilePath
+    };
+  }
   if (action.type === SET_IMPORTED_DATA) {
     return {
       ...state,


### PR DESCRIPTION
In preparation for parameterizing the tools for level building, I extracted the CSV parsing step from the UI and did a little refactoring along the way: 
- The UI component was renamed from `CSVReaderWrapper` to `SelectDataset`
- a new file, `csvReaderWrapper` now contains the helper functions to parse the CSV and set the data in the Redux store, along with default column types 
- `csvfile` is now a piece of state in the Redux store so it can be set both from the `SelectDataset` UI component and from elsewhere via upcoming parameterization
- Renamed `availableDatasets` to `allDatasets` since we'll likely need to take a subset of that list in future parameterization tasks; for example, if a level builder want to expose a limited number of datasets.