### PR TITLE
Expanded accuracy check information

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import SelectFeatures from "./UIComponents/SelectFeatures";
 import ColumnInspector from "./UIComponents/ColumnInspector";
 import SelectTrainer from "./UIComponents/SelectTrainer";
 import TrainModel from "./UIComponents/TrainModel";
+import Results from "./UIComponents/Results";
 import Predict from "./UIComponents/Predict";
 
 export default class App extends Component {
@@ -17,6 +18,7 @@ export default class App extends Component {
         <ColumnInspector />
         <SelectTrainer />
         <TrainModel />
+        <Results />
         <Predict />
       </div>
     );

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -5,8 +5,8 @@ import { connect } from "react-redux";
 import train from "../train";
 import {
   setTestData,
-  getSelectedContinuousColumns,
-  getSelectedCategoricalColumns,
+  getSelectedContinuousFeatures,
+  getSelectedCategoricalFeatures,
   getUniqueOptionsByColumn,
   getConvertedPredictedLabel
 } from "../redux";
@@ -15,8 +15,8 @@ class Predict extends Component {
   static propTypes = {
     showPredict: PropTypes.bool,
     labelColumn: PropTypes.string,
-    selectedCategoricalColumns: PropTypes.array,
-    selectedContinuousColumns: PropTypes.array,
+    selectedCategoricalFeatures: PropTypes.array,
+    selectedContinuousFeatures: PropTypes.array,
     uniqueOptionsByColumn: PropTypes.object,
     testData: PropTypes.object,
     setTestData: PropTypes.func.isRequired,
@@ -41,7 +41,7 @@ class Predict extends Component {
           <div>
             <h2>Test the Model</h2>
             <form>
-              {this.props.selectedContinuousColumns.map((feature, index) => {
+              {this.props.selectedContinuousFeatures.map((feature, index) => {
                 return (
                   <span key={index}>
                     <label>
@@ -58,7 +58,7 @@ class Predict extends Component {
             <br />
             <br />
             <form>
-              {this.props.selectedCategoricalColumns.map((feature, index) => {
+              {this.props.selectedCategoricalFeatures.map((feature, index) => {
                 return (
                   <span key={index}>
                     <label>
@@ -112,8 +112,8 @@ export default connect(
     predictedLabel: getConvertedPredictedLabel(state),
     confidence: state.prediction.confidence,
     labelColumn: state.labelColumn,
-    selectedContinuousColumns: getSelectedContinuousColumns(state),
-    selectedCategoricalColumns: getSelectedCategoricalColumns(state),
+    selectedContinuousFeatures: getSelectedContinuousFeatures(state),
+    selectedCategoricalFeatures: getSelectedCategoricalFeatures(state),
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state)
   }),
   dispatch => ({

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -1,0 +1,91 @@
+/* React component to handle displaying accuracy results. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getAccuracy, getConvertedLabels } from "../redux";
+
+class Results extends Component {
+  static propTypes = {
+    showPredict: PropTypes.bool,
+    selectedFeatures: PropTypes.array,
+    labelColumn: PropTypes.string,
+    percentDataToReserve: PropTypes.number,
+    accuracy: PropTypes.string,
+    accuracyCheckExamples: PropTypes.array,
+    accuracyCheckLabels: PropTypes.array,
+    accuracyCheckPredictedLabels: PropTypes.array
+  };
+
+  render() {
+    return (
+      <div>
+        {this.props.showPredict &&
+          this.props.percentDataToReserve > 0 &&
+          this.props.accuracyCheckExamples.length > 0 && (
+            <div>
+              <p>
+                {this.props.percentDataToReserve}% of the training data was
+                reserved to test the accuracy of the newly trained model.
+              </p>
+              <div>
+                <h3>The calculated accuracy of this model is:</h3>
+                {this.props.accuracy}%
+              </div>
+              <div>
+                <table>
+                  <thead>
+                    <tr>
+                      {this.props.selectedFeatures.map((feature, index) => {
+                        return <th key={index}>{feature}</th>;
+                      })}
+                      <th>Expected Label</th>
+                      <th>Predicted Label</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {this.props.accuracyCheckExamples.map((examples, index) => {
+                      return (
+                        <tr key={index}>
+                          {examples.map((example, i) => {
+                            return <td key={i}>{example}</td>;
+                          })}
+                          <td>{this.props.accuracyCheckLabels[index]}</td>
+                          <td>
+                            {this.props.accuracyCheckPredictedLabels[index]}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    showPredict: state.showPredict,
+    selectedFeatures: state.selectedFeatures,
+    labelColumn: state.labelColumn,
+    accuracy: getAccuracy(state),
+    accuracyCheckExamples: state.accuracyCheckExamples,
+    accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
+    accuracyCheckPredictedLabels: getConvertedLabels(
+      state,
+      state.accuracyCheckPredictedLabels
+    ),
+    percentDataToReserve: state.percentDataToReserve
+  }),
+  dispatch => ({
+    setShowPredict(showPredict) {
+      dispatch(setShowPredict(showPredict));
+    },
+    setPercentDataToReserve(percentDataToReserve) {
+      dispatch(setPercentDataToReserve(percentDataToReserve));
+    }
+  })
+)(Results);

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getAccuracy, getConvertedLabels } from "../redux";
+import { styles } from "../constants";
 
 class Results extends Component {
   static propTypes = {
@@ -53,6 +54,10 @@ class Results extends Component {
                           <td>
                             {this.props.accuracyCheckPredictedLabels[index]}
                           </td>
+                          {this.props.accuracyCheckLabels[index] ===
+                            this.props.accuracyCheckPredictedLabels[index] && (
+                            <td style={styles.ready}>&#x2713;</td>
+                          )}
                         </tr>
                       );
                     })}

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -71,26 +71,16 @@ class Results extends Component {
   }
 }
 
-export default connect(
-  state => ({
-    showPredict: state.showPredict,
-    selectedFeatures: state.selectedFeatures,
-    labelColumn: state.labelColumn,
-    accuracy: getAccuracy(state),
-    accuracyCheckExamples: state.accuracyCheckExamples,
-    accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
-    accuracyCheckPredictedLabels: getConvertedLabels(
-      state,
-      state.accuracyCheckPredictedLabels
-    ),
-    percentDataToReserve: state.percentDataToReserve
-  }),
-  dispatch => ({
-    setShowPredict(showPredict) {
-      dispatch(setShowPredict(showPredict));
-    },
-    setPercentDataToReserve(percentDataToReserve) {
-      dispatch(setPercentDataToReserve(percentDataToReserve));
-    }
-  })
-)(Results);
+export default connect(state => ({
+  showPredict: state.showPredict,
+  selectedFeatures: state.selectedFeatures,
+  labelColumn: state.labelColumn,
+  accuracy: getAccuracy(state),
+  accuracyCheckExamples: state.accuracyCheckExamples,
+  accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
+  accuracyCheckPredictedLabels: getConvertedLabels(
+    state,
+    state.accuracyCheckPredictedLabels
+  ),
+  percentDataToReserve: state.percentDataToReserve
+}))(Results);

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -7,6 +7,7 @@ import {
   setShowPredict,
   setPercentDataToReserve,
   getAccuracy,
+  getConvertedLabels,
   readyToTrain,
   validationMessages
 } from "../redux";
@@ -147,8 +148,11 @@ export default connect(
     labelColumn: state.labelColumn,
     selectedTrainer: state.selectedTrainer,
     accuracy: getAccuracy(state),
-    accuracyCheckLabels: state.accuracyCheckLabels,
-    accuracyCheckPredictedLabels: state.accuracyCheckPredictedLabels,
+    accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
+    accuracyCheckPredictedLabels: getConvertedLabels(
+      state,
+      state.accuracyCheckPredictedLabels
+    ),
     readyToTrain: readyToTrain(state),
     validationMessages: validationMessages(state),
     percentDataToReserve: state.percentDataToReserve

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -6,8 +6,6 @@ import train, { availableTrainers } from "../train";
 import {
   setShowPredict,
   setPercentDataToReserve,
-  getAccuracy,
-  getConvertedLabels,
   readyToTrain,
   validationMessages
 } from "../redux";
@@ -22,34 +20,18 @@ class TrainModel extends Component {
     setShowPredict: PropTypes.func.isRequired,
     selectedTrainer: PropTypes.string,
     percentDataToReserve: PropTypes.number,
-    setPercentDataToReserve: PropTypes.func,
-    accuracy: PropTypes.string,
-    accuracyCheckLabels: PropTypes.array,
-    accuracyCheckPredictedLabels: PropTypes.array
+    setPercentDataToReserve: PropTypes.func
   };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showAccuracy: false
-    };
-  }
 
   handleChange = event => {
     this.props.setPercentDataToReserve(parseInt(event.target.value));
-    this.setState({
-      showAccuracy: false
-    });
+    this.props.setShowPredict(false);
   };
 
   onClickTrainModel = () => {
     train.init();
     train.onClickTrain();
     this.props.setShowPredict(true);
-    this.setState({
-      showAccuracy: true
-    });
   };
 
   render() {
@@ -85,7 +67,6 @@ class TrainModel extends Component {
             </select>
           </label>
         </form>
-
         {this.props.readyToTrain && (
           <div>
             <h2>Train the Model</h2>
@@ -99,42 +80,6 @@ class TrainModel extends Component {
             <button type="button" onClick={this.onClickTrainModel}>
               Train model
             </button>
-            {this.state.showAccuracy && (
-              <div>
-                <p>
-                  {this.props.percentDataToReserve}% of the training data was
-                  reserved to test the accuracy of the newly trained model.
-                </p>
-                {this.props.percentDataToReserve > 0 && (
-                  <div>
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Expected</th>
-                          <th>Predicted</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {this.props.accuracyCheckLabels.map((label, index) => {
-                          return (
-                            <tr key={index}>
-                              <td>{label}</td>
-                              <td>
-                                {this.props.accuracyCheckPredictedLabels[index]}
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                    <div>
-                      <h3>The calculated accuracy of this model is:</h3>
-                      {this.props.accuracy}%
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
           </div>
         )}
       </div>
@@ -147,12 +92,6 @@ export default connect(
     selectedFeatures: state.selectedFeatures,
     labelColumn: state.labelColumn,
     selectedTrainer: state.selectedTrainer,
-    accuracy: getAccuracy(state),
-    accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
-    accuracyCheckPredictedLabels: getConvertedLabels(
-      state,
-      state.accuracyCheckPredictedLabels
-    ),
     readyToTrain: readyToTrain(state),
     validationMessages: validationMessages(state),
     percentDataToReserve: state.percentDataToReserve

--- a/src/redux.js
+++ b/src/redux.js
@@ -281,9 +281,23 @@ export function getSelectedCategoricalColumns(state) {
   return intersection;
 }
 
+export function getSelectedCategoricalFeatures(state) {
+  let intersection = getCategoricalColumns(state).filter(x =>
+    state.selectedFeatures.includes(x)
+  );
+  return intersection;
+}
+
 export function getSelectedContinuousColumns(state) {
   let intersection = getContinuousColumns(state).filter(
     x => state.selectedFeatures.includes(x) || x === state.labelColumn
+  );
+  return intersection;
+}
+
+export function getSelectedContinuousFeatures(state) {
+  let intersection = getContinuousColumns(state).filter(x =>
+    state.selectedFeatures.includes(x)
   );
   return intersection;
 }
@@ -337,20 +351,23 @@ function isEmpty(object) {
   return Object.keys(object).length === 0;
 }
 
-export function getConvertedPredictedLabel(state) {
-  if (
-    state.labelColumn &&
-    !isEmpty(state.featureNumberKey) &&
-    !isEmpty(state.prediction)
-  ) {
-    const label = getCategoricalColumns(state).includes(state.labelColumn)
-      ? getKeyByValue(
-          state.featureNumberKey[state.labelColumn],
-          state.prediction.predictedLabel
-        )
-      : state.prediction.predictedLabel;
-    return label;
+export function getConvertedLabel(state, rawLabel) {
+  if (state.labelColumn && !isEmpty(state.featureNumberKey)) {
+    const convertedLabel = getCategoricalColumns(state).includes(
+      state.labelColumn
+    )
+      ? getKeyByValue(state.featureNumberKey[state.labelColumn], rawLabel)
+      : rawLabel;
+    return convertedLabel;
   }
+}
+
+export function getConvertedPredictedLabel(state) {
+  return getConvertedLabel(state, state.prediction.predictedLabel);
+}
+
+export function getConvertedLabels(state, rawLabels) {
+  return rawLabels.map(label => getConvertedLabel(state, label));
 }
 
 export function getCompatibleTrainers(state) {


### PR DESCRIPTION
<img width="966" alt="Screen Shot 2020-11-04 at 4 39 00 PM" src="https://user-images.githubusercontent.com/12300669/98170714-745f0000-1ebc-11eb-9e1d-747913863437.png">

- extracted the accuracy information into `Results` component 
- fix a regression in test data input to now exclude the label column
- show data for all selected features, not just the label column in the accuracy results table 
- covert the expected and predicted labels back into human readable text if applicable
- ✓ as quick visual input if expected and predicted labels match