### PR TITLE
Initial work on parameterisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react": "7.14.3",
     "jest": "^23.6.0",
     "ml-knn": "^3.0.0",
+    "query-string": "4.1.0",
     "react": "~15.4.0",
     "react-dom": "~15.4.0",
     "react-papaparse": "^3.8.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,11 @@
     <title>ML Playground</title>
   </head>
   <body>
-  	<select onchange="location = '?mode=' + this.options[this.selectedIndex].value">
-			<option disabled selected value="/">Jump to mode...</option>
-			<option value="">Default</option>
-		  <option value="load_foods">Load Foods</option>
-		</select>
+    <select onchange="location = '?mode=' + this.options[this.selectedIndex].value">
+      <option disabled selected value="/">Jump to mode...</option>
+      <option value="">Default</option>
+      <option value="load_foods">Load Foods</option>
+    </select>
 
     <div id="root"></div>
     <script src="mainDev.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,12 @@
     <title>ML Playground</title>
   </head>
   <body>
+  	<select onchange="location = '?mode=' + this.options[this.selectedIndex].value">
+			<option disabled selected value="/">Jump to mode...</option>
+			<option value="">Default</option>
+		  <option value="load_foods">Load Foods</option>
+		</select>
+
     <div id="root"></div>
     <script src="mainDev.js"></script>
   </body>

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,9 @@ export default class App extends Component {
   render() {
     return (
       <div>
-        <SelectDataset />
+        {this.props.mode.id !== "load_dataset" && (
+          <SelectDataset />
+        )}
         <DataDisplay />
         <SelectFeatures />
         <ColumnInspector />

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import SelectDataset from "./UIComponents/SelectDataset";
 import DataDisplay from "./UIComponents/DataDisplay";
 import SelectFeatures from "./UIComponents/SelectFeatures";
@@ -9,10 +10,14 @@ import Results from "./UIComponents/Results";
 import Predict from "./UIComponents/Predict";
 
 export default class App extends Component {
+  static propTypes = {
+    mode: PropTypes.object
+  };
+
   render() {
     return (
       <div>
-        {this.props.mode.id !== "load_dataset" && (
+        {(!this.props.mode || this.props.mode.id !== "load_dataset") && (
           <SelectDataset />
         )}
         <DataDisplay />

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,33 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App.js";
 import { Provider } from "react-redux";
-import { createStore } from "redux";
-import rootReducer from "./redux";
+import { createStore} from "redux";
+import rootReducer, { setMode, setSelectedCSV } from "./redux";
+import { allDatasets } from "./datasetManifest";
+import { parseCSV } from "./csvReaderWrapper";
 
 export const store = createStore(rootReducer);
 
 export const initAll = function(options) {
+  const mode = options && options.mode;
+
+  setMode(mode);
+  processMode(mode);
+
   ReactDOM.render(
     <Provider store={store}>
-      <App />
+      <App mode={mode}/>
     </Provider>,
     document.getElementById("root")
   );
+};
+
+const processMode = mode => {
+  const assetPath = global.__ml_playground_asset_public_path__;
+
+  if (mode.id === "load_dataset") {
+    const path = allDatasets.filter(item => {return item.id === mode.setId})[0].path;
+    store.dispatch(setSelectedCSV(assetPath + path));
+    parseCSV(assetPath + path, true);
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@ import { parseCSV } from "./csvReaderWrapper";
 export const store = createStore(rootReducer);
 
 export const initAll = function(options) {
+  // Handle an optional mode.
   const mode = options && options.mode;
-
-  setMode(mode);
+  store.dispatch(setMode(mode));
   processMode(mode);
 
   ReactDOM.render(
@@ -23,12 +23,15 @@ export const initAll = function(options) {
   );
 };
 
+// Process an optional mode.
 const processMode = mode => {
   const assetPath = global.__ml_playground_asset_public_path__;
 
-  if (mode.id === "load_dataset") {
-    const path = allDatasets.filter(item => {return item.id === mode.setId})[0].path;
-    store.dispatch(setSelectedCSV(assetPath + path));
-    parseCSV(assetPath + path, true);
+  if (mode) {
+    if (mode.id === "load_dataset") {
+      const path = allDatasets.filter(item => {return item.id === mode.setId})[0].path;
+      store.dispatch(setSelectedCSV(assetPath + path));
+      parseCSV(assetPath + path, true);
+    }
   }
 };

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -4,7 +4,7 @@ import queryString from "query-string";
 
 // A list of sample modes.  Should match the dropdown in index.html.
 const sampleModes = {
-	load_foods: { id: "load_dataset", setId: 3 }
+  load_foods: { id: "load_dataset", setId: 3 }
 };
 
 // Look for a ?mode= parameter on the URL

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -1,4 +1,15 @@
-import {initAll} from './index';
-import './assetPath';
+import { initAll } from "./index";
+import "./assetPath";
+import queryString from 'query-string';
 
-initAll({mode: {id: "load_dataset", setId: 3}});
+// A list of sample modes.  Should match the dropdown in index.html.
+const sampleModes = {
+	load_foods: { id: "load_dataset", setId: 3 }
+};
+
+// Look for a ?mode= parameter on the URL
+let parameters = queryString.parse(location.search);
+const mode = parameters["mode"] ? sampleModes[parameters["mode"]] : null;
+
+// Initialize the app.
+initAll({mode: mode});

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -1,4 +1,4 @@
 import {initAll} from './index';
 import './assetPath';
 
-initAll();
+initAll({mode: {id: "load_dataset", setId: 3}});

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -1,6 +1,6 @@
 import { initAll } from "./index";
 import "./assetPath";
-import queryString from 'query-string';
+import queryString from "query-string";
 
 // A list of sample modes.  Should match the dropdown in index.html.
 const sampleModes = {
@@ -12,4 +12,4 @@ let parameters = queryString.parse(location.search);
 const mode = parameters["mode"] ? sampleModes[parameters["mode"]] : null;
 
 // Initialize the app.
-initAll({mode: mode});
+initAll({ mode: mode });

--- a/src/redux.js
+++ b/src/redux.js
@@ -22,6 +22,7 @@ import { ColumnTypes } from "./constants.js";
 
 // Action types
 const RESET_STATE = "RESET_STATE";
+const SET_MODE = "SET_MODE";
 const SET_SELECTED_CSV = "SET_SELECTED_CSV";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_SELECTED_TRAINER = "SET_SELECTED_TRAINER";
@@ -41,6 +42,10 @@ const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
 
 // Action creators
+export function setMode(mode) {
+  return { type: SET_MODE, mode };
+}
+
 export function setSelectedCSV(csvfile) {
   return { type: SET_SELECTED_CSV, csvfile };
 }
@@ -147,6 +152,12 @@ const initialState = {
 
 // Reducer
 export default function rootReducer(state = initialState, action) {
+  if (action.type === SET_MODE) {
+    return {
+      ...state,
+      mode: action.mode
+    }
+  }
   if (action.type === SET_SELECTED_CSV) {
     return {
       ...state,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5747,6 +5747,13 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.1.0.tgz#a092273bcef2dddad4a2f0d4e1796701beb35a23"
+  integrity sha1-oJInO87y3drUovDU4XlnAb6zWiM=
+  dependencies:
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6657,6 +6664,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is an initial attempt at simple parameterisation of the app.

`initAll` now takes an optional parameter, and the first one that actually does something looks like this:
```
initAll({ mode: { id: "load_dataset", setId: 3 } });
```
In particular, this loads the "Foods" dataset.  It also hides the dataset selection UI entirely.

For local runs, a dropdown is now shown:

![Screen Shot 2020-11-05 at 4 41 24 PM](https://user-images.githubusercontent.com/2205926/98312171-fff09380-1f85-11eb-9b31-d70c47fbd4f4.png)

If an option is chosen, the page is reloaded with a `?mode=` URL parameter for the appropriate "sample mode".

This makes use of the factoring done in https://github.com/code-dot-org/ml-playground/pull/30.