### PR TITLE
Swap in a new SVM trainer and make sure results show correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "react-papaparse": "^3.8.0",
     "react-redux": "^5.0.0",
     "redux": "^4.0.5",
-    "svm": "^0.1.1",
     "webpack": "4.19.1",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.6",
@@ -60,5 +59,8 @@
   "files": [
     "dist/**/!(mainDev.js)",
     "i18n/ailab.json"
-  ]
+  ],
+  "dependencies": {
+    "ml-svm": "^2.1.2"
+  }
 }

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -67,15 +67,15 @@ class Predict extends Component {
                         onChange={event => this.handleChange(event, feature)}
                       >
                         <option>{""}</option>
-                        {this.props.uniqueOptionsByColumn[feature].map(
-                          (option, index) => {
+                        {this.props.uniqueOptionsByColumn[feature]
+                          .sort()
+                          .map((option, index) => {
                             return (
                               <option key={index} value={option}>
                                 {option}
                               </option>
                             );
-                          }
-                        )}
+                          })}
                       </select>
                     </label>
                   </span>

--- a/src/trainers/SVMTrainer.js
+++ b/src/trainers/SVMTrainer.js
@@ -1,10 +1,11 @@
 /* Training and prediction using a binary SVM machine learning model from
-(https://github.com/karpathy/svmjs) */
+https://github.com/mljs/svm */
 
 /* eslint-env node */
-const svmjs = require("svm");
 import { store } from "../index.js";
 import { setPrediction, setAccuracyCheckPredictedLabels } from "../redux";
+
+const SVM = require("ml-svm");
 
 export default class SVMTrainer {
   constructor() {
@@ -12,7 +13,17 @@ export default class SVMTrainer {
   }
 
   initTrainingState() {
-    this.svm = new svmjs.SVM();
+    var options = {
+      C: 0.01,
+      tol: 10e-4,
+      maxPasses: 10,
+      maxInterations: 10000,
+      kernel: "rbf",
+      kernelOptions: {
+        sigma: 0.5
+      }
+    };
+    this.svm = new SVM(options);
     this.converter = {};
   }
 
@@ -24,15 +35,17 @@ export default class SVMTrainer {
   */
   convertLabel = (labelOption, key) => {
     const converter = {};
-    converter[key[Object.keys(key)[0]]] = -1;
-    converter[key[Object.keys(key)[1]]] = 1;
+    converter[key[Object.keys(key)[0]]] = 1;
+    converter[key[Object.keys(key)[1]]] = -1;
     this.converter = converter;
     return converter[labelOption];
   };
 
   convertPredictedLabel = predictedLabel => {
-    return Object.keys(this.converter).find(
-      key => this.converter[key] === predictedLabel
+    return parseInt(
+      Object.keys(this.converter).find(
+        key => this.converter[key] === predictedLabel
+      )
     );
   };
 

--- a/src/trainers/SVMTrainer.js
+++ b/src/trainers/SVMTrainer.js
@@ -81,8 +81,7 @@ export default class SVMTrainer {
 
   predict(testValues) {
     let prediction = {};
-    prediction.predictedLabel = this.svm.predict([testValues])[0];
-    prediction.confidence = Math.abs(this.svm.marginOne(testValues));
+    prediction.predictedLabel = this.svm.predict(testValues);
     store.dispatch(setPrediction(prediction));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,11 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/estree@*":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -308,7 +313,7 @@ acorn@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.1:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3682,6 +3687,13 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-any-array@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-0.1.0.tgz#e5a27965e3371610c10c66bca3be37ee177bdf8e"
+  integrity sha512-6Kkl1RnvfdkmXM6ZlP+kELGBMA74Nq5pSOm9gIKDaPRe9KQlIJzonrOgq0Jzn/iElB6F2/olpLgWYeVySzrSRg==
+  dependencies:
+    rollup "^1.31.1"
+
 is-arguments@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
@@ -4913,10 +4925,66 @@ mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "^1.2.5"
 
+ml-array-max@^1.1.1, ml-array-max@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ml-array-max/-/ml-array-max-1.2.0.tgz#141595131fe10208dd89897ce98ab7fd382a3951"
+  integrity sha512-3UH7XCdjINxbtBWj1EuHMeI242Q3uLuC4rTpSybBWUpGjnG/BefAFxmTolUCuXDM59mJ/G/re80CQbaVIuMjQA==
+  dependencies:
+    is-any-array "^0.1.0"
+
+ml-array-min@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ml-array-min/-/ml-array-min-1.2.0.tgz#6880ea319250a99ec73bc2799ac005c10a0f0489"
+  integrity sha512-Wgf2+lCndLy1SbeOZSUqlkxD9T1CXPT7CIlNGAZRRQI35wsqvfuNtLNH4qKFx8kNjlq3VGXKOSBHeiXR31vaTA==
+  dependencies:
+    is-any-array "^0.1.0"
+
+ml-array-rescale@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/ml-array-rescale/-/ml-array-rescale-1.3.2.tgz#ebdeaaa84d15f714dbb00e94a6a9336ddcf10413"
+  integrity sha512-kiXwdVCGrer7rLnjR6Q9ZgP6e9rbnmQvYVUMLXyqNg4+zOs+jek8yBupqPZPDr+NvlSE5OuMnfAbP1oA63kHBA==
+  dependencies:
+    is-any-array "^0.1.0"
+    ml-array-max "^1.2.0"
+    ml-array-min "^1.2.0"
+
+ml-distance-euclidean@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ml-distance-euclidean/-/ml-distance-euclidean-1.0.0.tgz#08447c2233641a2b2a9b4c29e5f792d28f1d5b95"
+  integrity sha1-CER8IjNkGisqm0wp5feS0o8dW5U=
+
 ml-distance-euclidean@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz#3a668d236649d1b8fec96380b9435c6f42c9a817"
   integrity sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==
+
+ml-kernel-gaussian@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ml-kernel-gaussian/-/ml-kernel-gaussian-2.0.2.tgz#2d1a1130d3205e551e7d1dbe642b8f150076e6c0"
+  integrity sha512-5MBrH2g9MBO53I6mcyXvMhyOLsmO2w21+26A1ZV/vYoxqpsov2PWkT8bhdFCEe0kgDupmAb6u81iOID/rhnarA==
+  dependencies:
+    ml-distance-euclidean "^2.0.0"
+
+ml-kernel-polynomial@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ml-kernel-polynomial/-/ml-kernel-polynomial-2.0.1.tgz#ae99e26892f5763185e2334bad862adc5733c599"
+  integrity sha512-aGDNRPHDiKeJmBxB0L9wTxKNLfp5JytbdRIo5K+FTcmFjkWDe3YZPo6R6wBB5mxaJ5eqTRawzeV4RoIWHbakyQ==
+
+ml-kernel-sigmoid@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ml-kernel-sigmoid/-/ml-kernel-sigmoid-1.0.1.tgz#3eb4419a97d68d299dd6faffa8dca0fb91dd3300"
+  integrity sha512-mSbYOSbNQ7GsUAGrHuUHNsLgM3bZGpXkotw/FBdKZD9YMXfVOgQb1LvvvVeSlOR/ZdmX23qqaV0RnKSYWBF8og==
+
+ml-kernel@^2.2.0:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/ml-kernel/-/ml-kernel-2.3.4.tgz#7f6cdd5a3a9b1b6ee3c34bfd15c181664a0661dd"
+  integrity sha512-XH841rI/FANQD1JbhJuSy2XpXmstDjTRoYqJTQRq3V+sZmphvOKIJx1bWTr2vCxduDcWV/M77AYPZRivqt5QTA==
+  dependencies:
+    ml-distance-euclidean "^1.0.0"
+    ml-kernel-gaussian "^2.0.1"
+    ml-kernel-polynomial "^2.0.0"
+    ml-kernel-sigmoid "^1.0.0"
+    ml-matrix "^5.0.0"
 
 ml-knn@^3.0.0:
   version "3.0.0"
@@ -4924,6 +4992,27 @@ ml-knn@^3.0.0:
   integrity sha512-w7Jig4vW09OYMurlIRRJj8yL2O/835QJpxup+yW7QVYXSjixmanPtPQL+weiTYbaB/wWX8JilB+Wllk4mxvP5w==
   dependencies:
     ml-distance-euclidean "^2.0.0"
+
+ml-matrix@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ml-matrix/-/ml-matrix-5.3.0.tgz#2154902a3380f6a0874ab9a2539a09e873e8db92"
+  integrity sha512-DuvdXYwfGRpM+7MVdvi/zSjiazn+8QPrACT3Xi0pQpYx5SXZ1WuFYwUDXTSmV9+hrCxRhrC4hrzesNcfjpvOsw==
+  dependencies:
+    ml-array-max "^1.1.1"
+    ml-array-rescale "^1.2.1"
+
+ml-stat@^1.2.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/ml-stat/-/ml-stat-1.3.3.tgz#8a5493b0f67382fbf705c260e070436655a7dcfa"
+  integrity sha1-ilSTsPZzgvv3BcJg4HBDZlWn3Po=
+
+ml-svm@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ml-svm/-/ml-svm-2.1.2.tgz#baecbd2e35a83ee675e8d81b9217ce5dfdffd529"
+  integrity sha1-uuy9LjWoPuZ16NgbkhfOXf3/1Sk=
+  dependencies:
+    ml-kernel "^2.2.0"
+    ml-stat "^1.2.0"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6172,6 +6261,15 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rollup@^1.31.1:
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
+  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
+  dependencies:
+    "@types/estree" "*"
+    "@types/node" "*"
+    acorn "^7.1.0"
+
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -6790,11 +6888,6 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
-
-svm@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/svm/-/svm-0.1.1.tgz#3ac1ef565bf641d8edfe4f1606a8a9457a4ab0e4"
-  integrity sha1-OsHvVlv2Qdjt/k8WBqipRXpKsOQ=
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Previously, we were using github.com/karpathy/svmjs to handle SVM training, but it started throwing this error: 
<img width="1079" alt="Screen Shot 2020-11-04 at 10 23 59 PM" src="https://user-images.githubusercontent.com/12300669/98194030-7771e480-1eec-11eb-90bb-f7c7af44df14.png">

After lengthy investigating, I couldn't identify the root cause and decided to use the SVM trainer from the same library we're using for KNN.

![binary-svm-results](https://user-images.githubusercontent.com/12300669/98193943-4a253680-1eec-11eb-928b-e37295e11b48.gif)
