### PR TITLE
Display model size in preparation for storing trained models

### DIFF
--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -20,7 +20,8 @@ class TrainModel extends Component {
     setShowPredict: PropTypes.func.isRequired,
     selectedTrainer: PropTypes.string,
     percentDataToReserve: PropTypes.number,
-    setPercentDataToReserve: PropTypes.func
+    setPercentDataToReserve: PropTypes.func,
+    modelSize: PropTypes.number
   };
 
   handleChange = event => {
@@ -80,6 +81,9 @@ class TrainModel extends Component {
             <button type="button" onClick={this.onClickTrainModel}>
               Train model
             </button>
+            {this.props.modelSize && (
+              <p>The trained model is {this.props.modelSize} KB big.</p>
+            )}
           </div>
         )}
       </div>
@@ -94,7 +98,8 @@ export default connect(
     selectedTrainer: state.selectedTrainer,
     readyToTrain: readyToTrain(state),
     validationMessages: validationMessages(state),
-    percentDataToReserve: state.percentDataToReserve
+    percentDataToReserve: state.percentDataToReserve,
+    modelSize: state.modelSize
   }),
   dispatch => ({
     setShowPredict(showPredict) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -39,6 +39,7 @@ const SET_TRAINING_LABELS = "SET_TRAINING_LABELS";
 const SET_SHOW_PREDICT = "SET_SHOW_PREDICT";
 const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
+const SET_MODEL_SIZE = "SET_MODEL_SIZE";
 
 // Action creators
 export function setSelectedCSV(csvfile) {
@@ -126,6 +127,10 @@ export function resetState() {
   return { type: RESET_STATE };
 }
 
+export function setModelSize(modelSize) {
+  return { type: SET_MODEL_SIZE, modelSize };
+}
+
 const initialState = {
   csvfile: undefined,
   data: [],
@@ -142,7 +147,8 @@ const initialState = {
   accuracyCheckPredictedLabels: [],
   showPredict: false,
   testData: {},
-  prediction: {}
+  prediction: {},
+  modelSize: undefined
 };
 
 // Reducer
@@ -249,6 +255,12 @@ export default function rootReducer(state = initialState, action) {
   if (action.type === RESET_STATE) {
     return {
       ...initialState
+    };
+  }
+  if (action.type === SET_MODEL_SIZE) {
+    return {
+      ...state,
+      modelSize: action.modelSize
     };
   }
   return state;

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -2,9 +2,13 @@
 https://github.com/mljs/knn */
 
 import { store } from "../index.js";
-import { setPrediction, setAccuracyCheckPredictedLabels } from "../redux";
+import {
+  setModelSize,
+  setPrediction,
+  setAccuracyCheckPredictedLabels
+} from "../redux";
 
-const KNN = require('ml-knn');
+const KNN = require("ml-knn");
 
 export default class KNNTrainer {
   startTraining() {
@@ -12,6 +16,10 @@ export default class KNNTrainer {
     this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
       k: 5
     });
+    var model = this.knn.toJSON();
+    const size = Buffer.byteLength(JSON.stringify(model));
+    const kiloBytes = size / 1024;
+    store.dispatch(setModelSize(kiloBytes));
     if (state.accuracyCheckExamples.length > 0) {
       this.batchPredict(state.accuracyCheckExamples);
     } else {

--- a/src/trainers/SVMTrainer.js
+++ b/src/trainers/SVMTrainer.js
@@ -3,7 +3,11 @@ https://github.com/mljs/svm */
 
 /* eslint-env node */
 import { store } from "../index.js";
-import { setPrediction, setAccuracyCheckPredictedLabels } from "../redux";
+import {
+  setPrediction,
+  setAccuracyCheckPredictedLabels,
+  setModelSize
+} from "../redux";
 
 const SVM = require("ml-svm");
 
@@ -69,6 +73,10 @@ export default class SVMTrainer {
 
   train(trainingExamples, trainingLabels) {
     this.svm.train(trainingExamples, trainingLabels);
+    var model = this.svm.toJSON();
+    const size = Buffer.byteLength(JSON.stringify(model));
+    const kiloBytes = size / 1024;
+    store.dispatch(setModelSize(kiloBytes));
   }
 
   batchPredict(accuracyCheckExamples) {


### PR DESCRIPTION
In anticipation of storing models so they can be used in App Lab, I've started calculating and displaying the size of trained models.  I don't ultimately expect this will be visible to users (unless, maybe we determine some kind of max size that they exceed down the road?), but do think it will be handy for us and perhaps the data contractor to see in the meantime. 
<img width="476" alt="Screen Shot 2020-11-05 at 3 00 06 PM" src="https://user-images.githubusercontent.com/12300669/98291884-d2055200-1f79-11eb-94b7-fd28bb6338ea.png">

I also started a [tracking doc](https://docs.google.com/spreadsheets/d/1w92vsFZorDA4cn3tR0gAKSpY1WwUJRwdwMS5Z1rsfIY/edit#gid=0) with a few model sizes from runs of AI Lab with different settings we can use as reference and add to if we find anything interesting. Basically, at least with KNN, as the complexity (number of features selected and number of options in each feature or label column) increases so does the size of the trained model. 
