### PR TITLE
Summary statistic for regression trainers

### DIFF
--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -2,8 +2,8 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getAccuracy, getConvertedLabels } from "../redux";
-import { styles } from "../constants";
+import { getConvertedLabels, getSummaryStat } from "../redux";
+import { styles, MLTypes } from "../constants";
 
 class Results extends Component {
   static propTypes = {
@@ -11,7 +11,7 @@ class Results extends Component {
     selectedFeatures: PropTypes.array,
     labelColumn: PropTypes.string,
     percentDataToReserve: PropTypes.number,
-    accuracy: PropTypes.string,
+    summaryStat: PropTypes.object,
     accuracyCheckExamples: PropTypes.array,
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array
@@ -29,8 +29,23 @@ class Results extends Component {
                 reserved to test the accuracy of the newly trained model.
               </p>
               <div>
-                <h3>The calculated accuracy of this model is:</h3>
-                {this.props.accuracy}%
+                {this.props.summaryStat.type === MLTypes.REGRESSION && (
+                  <div>
+                    <h3>
+                      The average difference between expected and predicted
+                      labels is:
+                    </h3>{" "}
+                    {this.props.summaryStat.stat}
+                  </div>
+                )}
+                {this.props.summaryStat.type === MLTypes.CLASSIFICATION && (
+                  <div>
+                    <h3>The calculated accuracy of this model is:</h3>{" "}
+                    {this.props.summaryStat.stat}%
+                  </div>
+                )}
+                <br />
+                <br />
               </div>
               <div>
                 <table>
@@ -75,7 +90,7 @@ export default connect(state => ({
   showPredict: state.showPredict,
   selectedFeatures: state.selectedFeatures,
   labelColumn: state.labelColumn,
-  accuracy: getAccuracy(state),
+  summaryStat: getSummaryStat(state),
   accuracyCheckExamples: state.accuracyCheckExamples,
   accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
   accuracyCheckPredictedLabels: getConvertedLabels(

--- a/src/redux.js
+++ b/src/redux.js
@@ -1,7 +1,8 @@
 import {
   availableTrainers,
   getRegressionTrainers,
-  getClassificationTrainers
+  getClassificationTrainers,
+  getMLType
 } from "./train.js";
 
 import {
@@ -18,7 +19,7 @@ import {
   compatibleLabelAndTrainer
 } from "./validate.js";
 
-import { ColumnTypes } from "./constants.js";
+import { ColumnTypes, MLTypes } from "./constants.js";
 
 // Action types
 const RESET_STATE = "RESET_STATE";
@@ -162,7 +163,7 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       mode: action.mode
-    }
+    };
   }
   if (action.type === SET_SELECTED_CSV) {
     return {
@@ -408,6 +409,23 @@ export function getCompatibleTrainers(state) {
   return compatibleTrainers;
 }
 
+function getSum(total, num) {
+  return total + num;
+}
+
+function getAverageDiff(state) {
+  let diffs = [];
+  const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
+  for (let i = 0; i < numPredictedLabels; i++) {
+    diffs.push(
+      Math.abs(
+        state.accuracyCheckLabels[i] - state.accuracyCheckPredictedLabels[i]
+      )
+    );
+  }
+  return (diffs.reduce(getSum, 0) / numPredictedLabels).toFixed(2);
+}
+
 export function getAccuracy(state) {
   let numCorrect = 0;
   const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
@@ -420,6 +438,20 @@ export function getAccuracy(state) {
     }
   }
   return ((numCorrect / numPredictedLabels) * 100).toFixed(2);
+}
+
+export function getSummaryStat(state) {
+  let summaryStat = {};
+  const mlType = getMLType(state.selectedTrainer);
+  if (mlType === MLTypes.REGRESSION) {
+    summaryStat.type = MLTypes.REGRESSION;
+    summaryStat.stat = getAverageDiff(state);
+  }
+  if (mlType === MLTypes.CLASSIFICATION) {
+    summaryStat.type = MLTypes.CLASSIFICATION;
+    summaryStat.stat = getAccuracy(state);
+  }
+  return summaryStat;
 }
 
 export function validationMessages(state) {

--- a/src/train.js
+++ b/src/train.js
@@ -65,6 +65,12 @@ export const getRegressionTrainers = () => {
   return filterTrainersByType(MLTypes.REGRESSION);
 };
 
+export const getMLType = trainerName => {
+  if (availableTrainers[trainerName]) {
+    return availableTrainers[trainerName].mlType;
+  }
+};
+
 /* Builds a hash that maps a feature's categorical options to numbers because
   the ML algorithms only accept numerical inputs.
   @param {string} - feature name


### PR DESCRIPTION
When using a classification trainer, accuracy is based on the percentage of correctly predicted labels. For regression trainers, where the prediction is a continuous value, it doesn't make sense to gauge accuracy based on percent correctly predicted labels because there is very, very small likelihood that the prediction will exactly match the expected label. For example, the expected label might be 2.5 and the predicted label might be 2.7 which are obviously very close, but not the same. Instead, I calculated the average difference between predicted and expected labels for regression algorithms.  A low average difference indicates that the model is predicting successfully, but must be considered in the context of the range of values in the label column. 

<img width="626" alt="Screen Shot 2020-11-06 at 12 47 10 PM" src="https://user-images.githubusercontent.com/12300669/98398634-4948ed80-202f-11eb-928d-9c4e94829a25.png">
