### PR TITLE
Dataset metadata support

### DIFF
--- a/public/datasets/erin_candy_preferences.json
+++ b/public/datasets/erin_candy_preferences.json
@@ -1,0 +1,59 @@
+{
+  "fields": [
+  	{
+  		"id": "name",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "chocolate",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "fruity",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "caramel",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "nuts",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "nougat",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "crispy",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "hard",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "bar",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "pluribus",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "delicious?",
+  		"type": "categorical",
+  		"name": "Name"
+  	}
+  ]
+}

--- a/public/datasets/erin_candy_preferences.json
+++ b/public/datasets/erin_candy_preferences.json
@@ -2,58 +2,47 @@
   "fields": [
   	{
   		"id": "name",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "chocolate",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "fruity",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "caramel",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "nuts",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "nougat",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "crispy",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "hard",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "bar",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "pluribus",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "delicious?",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	}
   ]
 }

--- a/public/datasets/flight_delays.json
+++ b/public/datasets/flight_delays.json
@@ -1,0 +1,54 @@
+{
+  "fields": [
+  	{
+  		"id": "Month",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "DayofMonth",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "DayOfWeek",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "DepTime",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "TimeOfDay",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "UniqueCarrier",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Origin",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Dest",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Distance",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "dep_delayed_15min",
+  		"type": "categorical",
+  		"name": "Name"
+  	}
+  ]
+}

--- a/public/datasets/flight_delays.json
+++ b/public/datasets/flight_delays.json
@@ -2,53 +2,43 @@
   "fields": [
   	{
   		"id": "Month",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "DayofMonth",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "DayOfWeek",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "DepTime",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "TimeOfDay",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "UniqueCarrier",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Origin",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Dest",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Distance",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "dep_delayed_15min",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	}
   ]
 }

--- a/public/datasets/foods.json
+++ b/public/datasets/foods.json
@@ -1,0 +1,84 @@
+{
+  "fields": [
+  	{
+  		"id": "cook",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "eating_out",
+  		"type": "continuous",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "fav_cuisine_coded",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "fav_food",
+  		"type": "continuous",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "comfort_food_reasons_coded",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "healthy_feeling",
+  		"type": "continuous",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "life_rewarding",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "fruit_day",
+  		"type": "continuous",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "veggies_day",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "sports",
+  		"type": "continuous",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "type_sports?",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+    {
+      "id": "indian_food",
+      "type": "continuous",
+      "name": "Name"
+    },
+    {
+      "id": "italian_food",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "Greek_food",
+      "type": "continuous",
+      "name": "Name"
+    },
+    {
+      "id": "Greek_food",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "persian_food",
+      "type": "continuous",
+      "name": "Name"
+    }
+  ]
+}

--- a/public/datasets/foods.json
+++ b/public/datasets/foods.json
@@ -2,62 +2,51 @@
   "fields": [
   	{
   		"id": "cook",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "eating_out",
-  		"type": "continuous",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "fav_cuisine_coded",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "fav_food",
-  		"type": "continuous",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "comfort_food_reasons_coded",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "healthy_feeling",
-  		"type": "continuous",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "life_rewarding",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "fruit_day",
-  		"type": "continuous",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "veggies_day",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "sports",
-  		"type": "continuous",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "type_sports?",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
     {
       "id": "indian_food",
-      "type": "continuous",
+      "type": "categorical",
       "name": "Name"
     },
     {
@@ -67,7 +56,7 @@
     },
     {
       "id": "Greek_food",
-      "type": "continuous",
+      "type": "categorical",
       "name": "Name"
     },
     {
@@ -77,7 +66,7 @@
     },
     {
       "id": "persian_food",
-      "type": "continuous",
+      "type": "categorical",
       "name": "Name"
     }
   ]

--- a/public/datasets/titanic.json
+++ b/public/datasets/titanic.json
@@ -22,7 +22,7 @@
   	},
   	{
   		"id": "Age",
-  		"type": "categorical",
+  		"type": "continuous",
   		"name": "Name"
   	},
   	{
@@ -37,7 +37,7 @@
   	},
   	{
   		"id": "Fare",
-  		"type": "categorical",
+  		"type": "continuous",
   		"name": "Name"
   	}
   ]

--- a/public/datasets/titanic.json
+++ b/public/datasets/titanic.json
@@ -1,0 +1,44 @@
+{
+  "fields": [
+  	{
+  		"id": "Survived",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Pclass",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Name",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Sex",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Age",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Siblings/Spouses Aboard",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Parents/Children Aboard",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Fare",
+  		"type": "categorical",
+  		"name": "Name"
+  	}
+  ]
+}

--- a/public/datasets/videogame_sales.json
+++ b/public/datasets/videogame_sales.json
@@ -1,0 +1,84 @@
+{
+  "fields": [
+  	{
+  		"id": "Name",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Platform",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Year_of_Release",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Genre",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Publisher",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "NA_Sales",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "EU_Sales",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "JP_Sales",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Other_Sales",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Global_Sales",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+  	{
+  		"id": "Critic_Score",
+  		"type": "categorical",
+  		"name": "Name"
+  	},
+    {
+      "id": "Critic_Count",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "User_Score",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "User_Count",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "Developer",
+      "type": "categorical",
+      "name": "Name"
+    },
+    {
+      "id": "Rating",
+      "type": "categorical",
+      "name": "Name"
+    }
+  ]
+}

--- a/public/datasets/videogame_sales.json
+++ b/public/datasets/videogame_sales.json
@@ -2,72 +2,61 @@
   "fields": [
   	{
   		"id": "Name",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Platform",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Year_of_Release",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Genre",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "Publisher",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "categorical"
   	},
   	{
   		"id": "NA_Sales",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "EU_Sales",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "JP_Sales",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "Other_Sales",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "Global_Sales",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
   	{
   		"id": "Critic_Score",
-  		"type": "categorical",
-  		"name": "Name"
+  		"type": "continuous"
   	},
     {
       "id": "Critic_Count",
-      "type": "categorical",
+      "type": "continuous",
       "name": "Name"
     },
     {
       "id": "User_Score",
-      "type": "categorical",
+      "type": "continuous",
       "name": "Name"
     },
     {
       "id": "User_Count",
-      "type": "categorical",
+      "type": "continuous",
       "name": "Name"
     },
     {

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -19,7 +19,8 @@ class ColumnInspector extends Component {
     getUniqueOptionsByColumn: PropTypes.func,
     uniqueOptionsByColumn: PropTypes.object,
     getRangesByColumn: PropTypes.func,
-    rangesByColumn: PropTypes.object
+    rangesByColumn: PropTypes.object,
+    metadata: PropTypes.object
   };
 
   handleChangeDataType = (event, feature) => {
@@ -27,12 +28,23 @@ class ColumnInspector extends Component {
     this.props.setColumnsByDataType(feature, event.target.value);
   };
 
+  getMetadataColumnType(column) {
+    return (
+      this.props.metadata.fields &&
+      this.props.metadata.fields.find(field => {
+        return field.id === column;
+      }).type
+    );
+  }
+
   render() {
     return (
       <div id="column-inspector">
         {this.props.selectedColumns.length > 0 && (
           <div style={styles.panel}>
-            <div style={styles.largeText}>Describe the data in each of your selected columns</div>
+            <div style={styles.largeText}>
+              Describe the data in each of your selected columns
+            </div>
             <p>
               Categorical columns contain a fixed number of possible values that
               indicate a group. For example, the column "Size" might contain
@@ -55,21 +67,23 @@ class ColumnInspector extends Component {
                   <div key={index}>
                     {this.props.columnsByDataType[column] && (
                       <label>
-                        {column}:{' '}
-                        <select
-                          onChange={event =>
-                            this.handleChangeDataType(event, column)
-                          }
-                          value={this.props.columnsByDataType[column]}
-                        >
-                          {Object.values(ColumnTypes).map((option, index) => {
-                            return (
-                              <option key={index} value={option}>
-                                {option}
-                              </option>
-                            );
-                          })}
-                        </select>
+                        {column}: {this.getMetadataColumnType(column)}
+                        {!this.getMetadataColumnType(column) && (
+                          <select
+                            onChange={event =>
+                              this.handleChangeDataType(event, column)
+                            }
+                            value={this.props.columnsByDataType[column]}
+                          >
+                            {Object.values(ColumnTypes).map((option, index) => {
+                              return (
+                                <option key={index} value={option}>
+                                  {option}
+                                </option>
+                              );
+                            })}
+                          </select>
+                        )}
                       </label>
                     )}
                     {this.props.columnsByDataType[column] ===
@@ -127,7 +141,8 @@ export default connect(
     selectedColumns: getSelectedColumns(state),
     columnsByDataType: state.columnsByDataType,
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
-    rangesByColumn: getRangesByColumn(state)
+    rangesByColumn: getRangesByColumn(state),
+    metadata: state.metadata
   }),
   dispatch => ({
     setColumnsByDataType(column, dataType) {

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -39,7 +39,7 @@ class SelectDataset extends Component {
   };
 
   importCSV = () => {
-    parseCSV(this.props.csvfile, this.state.download);
+    parseCSV(this.props.csvfile, this.state.download, true);
   };
 
   render() {

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -3,19 +3,22 @@ import { store } from "./index.js";
 import { setImportedData, setColumnsByDataType } from "./redux";
 import { ColumnTypes } from "./constants.js";
 
-export const parseCSV = (csvfile, download) => {
+export const parseCSV = (csvfile, download, setColumnsToOther) => {
   Papa.parse(csvfile, {
-    complete: updateData,
+    complete: result => { updateData(result, setColumnsToOther) },
     header: true,
     download: download,
     skipEmptyLines: true
   });
 };
 
-const updateData = result => {
+const updateData = (result, setColumnsToOther) => {
   var data = result.data;
+
   store.dispatch(setImportedData(data));
-  setDefaultColumnDataType(data);
+  if (setColumnsToOther) {
+    setDefaultColumnDataType(data);
+  }
 };
 
 const setDefaultColumnDataType = data => {

--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -1,28 +1,33 @@
 export const allDatasets = [
   {
-    id: 1,
+    id: "candy",
     name: "Erin's Candy Preferences - all binary",
-    path: "datasets/erin_candy_preferences.csv"
+    path: "datasets/erin_candy_preferences.csv",
+    metadataPath: "datasets/erin_candy_preferences.json"
   },
   {
-    id: 2,
+    id: "titanic",
     name: "Titanic - multiple datatypes",
-    path: "datasets/titanic.csv"
+    path: "datasets/titanic.csv",
+    metadataPath: "datasets/titanic.json"
   },
 
   {
-    id: 3,
+    id: "foods",
     name: "Foods",
-    path: "datasets/foods.csv"
+    path: "datasets/foods.csv",
+    metadataPath: "datasets/foods.json"
   },
   {
-    id: 4,
+    id: "flights",
     name: "Flight delays",
-    path: "datasets/flight_delays.csv"
+    path: "datasets/flight_delays.csv",
+    metadataPath: "datasets/flight_delays.json"
   },
   {
-    id: 5,
+    id: "videogames",
     name: "Videogame sales",
-    path: "datasets/videogame_sales.csv"
+    path: "datasets/videogame_sales.csv",
+    metadataPath: "datasets/videogame_sales.json"
   }
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ const processMode = mode => {
         for (const field of result.fields) {
            store.dispatch(setColumnsByDataType(field.id, field.type));
         }
-        console.log("dispatched json");
       });
     }
   }

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -4,7 +4,7 @@ import queryString from "query-string";
 
 // A list of sample modes.  Should match the dropdown in index.html.
 const sampleModes = {
-  load_foods: { id: "load_dataset", setId: 3 }
+  load_foods: { id: "load_dataset", setId: "foods" }
 };
 
 // Look for a ?mode= parameter on the URL

--- a/src/jsonReaderWrapper.js
+++ b/src/jsonReaderWrapper.js
@@ -1,0 +1,20 @@
+import { store } from "./index.js";
+import { setImportedMetadata } from "./redux";
+
+export const parseJSON = (jsonfile, successCallback) => {
+  var rawFile = new XMLHttpRequest();
+  rawFile.overrideMimeType("application/json");
+  rawFile.open("GET", jsonfile, true);
+  rawFile.onreadystatechange = function() {
+      if (rawFile.readyState === 4 && rawFile.status === "200") {
+          updateData(rawFile.responseText, successCallback);
+      }
+  }
+  rawFile.send(null);
+};
+
+const updateData = (result, successCallback) => {
+  var metadata = JSON.parse(result);
+  store.dispatch(setImportedMetadata(metadata));
+  successCallback(metadata);
+};

--- a/src/jsonReaderWrapper.js
+++ b/src/jsonReaderWrapper.js
@@ -6,9 +6,9 @@ export const parseJSON = (jsonfile, successCallback) => {
   rawFile.overrideMimeType("application/json");
   rawFile.open("GET", jsonfile, true);
   rawFile.onreadystatechange = function() {
-      if (rawFile.readyState === 4 && rawFile.status === "200") {
-          updateData(rawFile.responseText, successCallback);
-      }
+    if (rawFile.readyState === 4 && rawFile.status === 200) {
+      updateData(rawFile.responseText, successCallback);
+    }
   }
   rawFile.send(null);
 };

--- a/src/redux.js
+++ b/src/redux.js
@@ -25,7 +25,9 @@ import { ColumnTypes, MLTypes } from "./constants.js";
 const RESET_STATE = "RESET_STATE";
 const SET_MODE = "SET_MODE";
 const SET_SELECTED_CSV = "SET_SELECTED_CSV";
+const SET_SELECTED_JSON = "SET_SELECTED_JSON";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
+const SET_IMPORTED_METADATA = "SET_IMPORTED_METADATA";
 const SET_SELECTED_TRAINER = "SET_SELECTED_TRAINER";
 const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
 const SET_SELECTED_FEATURES = "SET_SELECTED_FEATURES";
@@ -52,8 +54,16 @@ export function setSelectedCSV(csvfile) {
   return { type: SET_SELECTED_CSV, csvfile };
 }
 
+export function setSelectedJSON(jsonfile) {
+  return { type: SET_SELECTED_JSON, jsonfile };
+}
+
 export function setImportedData(data) {
   return { type: SET_IMPORTED_DATA, data };
+}
+
+export function setImportedMetadata(metadata) {
+  return { type: SET_IMPORTED_METADATA, metadata };
 }
 
 export function setSelectedTrainer(selectedTrainer) {
@@ -139,7 +149,9 @@ export function setModelSize(modelSize) {
 
 const initialState = {
   csvfile: undefined,
+  jsonfile: undefined,
   data: [],
+  metadata: {},
   selectedTrainer: undefined,
   columnsByDataType: {},
   selectedFeatures: [],
@@ -171,10 +183,22 @@ export default function rootReducer(state = initialState, action) {
       csvfile: action.csvfile
     };
   }
+  if (action.type === SET_SELECTED_JSON) {
+    return {
+      ...state,
+      jsonfile: action.jsonfile
+    };
+  }
   if (action.type === SET_IMPORTED_DATA) {
     return {
       ...state,
       data: action.data
+    };
+  }
+  if (action.type === SET_IMPORTED_METADATA) {
+    return {
+      ...state,
+      metadata: action.metadata
     };
   }
   if (action.type === SET_SELECTED_TRAINER) {
@@ -508,7 +532,7 @@ export function validationMessages(state) {
   validationMessages.push({
     readyToTrain: compatibleLabelAndTrainer(state),
     errorString:
-      "The label datatype must be compatiable with the training algorithm.",
+      "The label datatype must be compatible with the training algorithm.",
     successString: "The label datatype and training algorithm are compatible."
   });
   return validationMessages;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ const firstConfigOnly = {
     new CleanWebpackPlugin(),
     new CopyPlugin([
       {
-        from: 'public/datasets/*.csv',
+        from: 'public/datasets/*.*',
         to: 'assets/datasets/',
         flatten: true
       }


### PR DESCRIPTION
Loading a dataset via parameter now loads its metadata too.  The metadata is defined in a JSON file that sits alongside the data's CSV file.  The metadata controls the feature types, with the UI only showing them, but not allowing them to be selected.

Note also that parameterisation has changed slightly to use a more friendly id for the dataset, e.g.
```
initAll({ mode: { id: "load_dataset", setId: "foods" } });
```
