### PR TITLE
Option frequency for categorical columns

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import {
   getSelectedColumns,
   setColumnsByDataType,
-  getUniqueOptionsByColumn,
+  getOptionFrequenciesByColumn,
   getRangesByColumn
 } from "../redux";
 import { ColumnTypes, styles } from "../constants.js";
@@ -78,15 +78,40 @@ class ColumnInspector extends Component {
                       ColumnTypes.CATEGORICAL && (
                       <div>
                         <p>
-                          {this.props.uniqueOptionsByColumn[column].length}{" "}
+                          {
+                            Object.keys(
+                              this.props.uniqueOptionsByColumn[column]
+                            ).length
+                          }{" "}
                           unique values for {column}:{" "}
                         </p>
                         <div style={styles.subPanel}>
-                          {this.props.uniqueOptionsByColumn[column].map(
-                            (option, index) => {
-                              return <div key={index}>{option}</div>;
-                            }
-                          )}
+                          <table>
+                            <thead>
+                              <tr>
+                                <th>Option</th>
+                                <th>Frequency</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {Object.keys(
+                                this.props.uniqueOptionsByColumn[column]
+                              ).map((option, index) => {
+                                return (
+                                  <tr key={index}>
+                                    <td>{option}</td>
+                                    <td>
+                                      {
+                                        this.props.uniqueOptionsByColumn[
+                                          column
+                                        ][option]
+                                      }
+                                    </td>
+                                  </tr>
+                                );
+                              })}
+                            </tbody>
+                          </table>
                         </div>
                       </div>
                     )}
@@ -128,7 +153,7 @@ export default connect(
   state => ({
     selectedColumns: getSelectedColumns(state),
     columnsByDataType: state.columnsByDataType,
-    uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
+    uniqueOptionsByColumn: getOptionFrequenciesByColumn(state),
     rangesByColumn: getRangesByColumn(state)
   }),
   dispatch => ({

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -96,20 +96,22 @@ class ColumnInspector extends Component {
                             <tbody>
                               {Object.keys(
                                 this.props.uniqueOptionsByColumn[column]
-                              ).map((option, index) => {
-                                return (
-                                  <tr key={index}>
-                                    <td>{option}</td>
-                                    <td>
-                                      {
-                                        this.props.uniqueOptionsByColumn[
-                                          column
-                                        ][option]
-                                      }
-                                    </td>
-                                  </tr>
-                                );
-                              })}
+                              )
+                                .sort()
+                                .map((option, index) => {
+                                  return (
+                                    <tr key={index}>
+                                      <td>{option}</td>
+                                      <td>
+                                        {
+                                          this.props.uniqueOptionsByColumn[
+                                            column
+                                          ][option]
+                                        }
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
                             </tbody>
                           </table>
                         </div>

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -32,7 +32,9 @@ class ColumnInspector extends Component {
       <div id="column-inspector">
         {this.props.selectedColumns.length > 0 && (
           <div style={styles.panel}>
-            <div style={styles.largeText}>Describe the data in each of your selected columns</div>
+            <div style={styles.largeText}>
+              Describe the data in each of your selected columns
+            </div>
             <p>
               Categorical columns contain a fixed number of possible values that
               indicate a group. For example, the column "Size" might contain
@@ -55,7 +57,7 @@ class ColumnInspector extends Component {
                   <div key={index}>
                     {this.props.columnsByDataType[column] && (
                       <label>
-                        {column}:{' '}
+                        {column}:{" "}
                         <select
                           onChange={event =>
                             this.handleChangeDataType(event, column)

--- a/src/redux.js
+++ b/src/redux.js
@@ -356,6 +356,27 @@ export function getUniqueOptions(state, column) {
   );
 }
 
+export function getOptionFrequencies(state, column) {
+  let optionFrequencies = {};
+  for (let row of state.data) {
+    if (optionFrequencies[row[column]]) {
+      optionFrequencies[row[column]]++;
+    } else {
+      optionFrequencies[row[column]] = 1;
+    }
+  }
+  return optionFrequencies;
+}
+
+export function getOptionFrequenciesByColumn(state) {
+  let uniqueOptionsByColumn = {};
+  getSelectedCategoricalColumns(state).map(
+    column =>
+      (uniqueOptionsByColumn[column] = getOptionFrequencies(state, column))
+  );
+  return uniqueOptionsByColumn;
+}
+
 export function getUniqueOptionsByColumn(state) {
   let uniqueOptionsByColumn = {};
   getSelectedCategoricalColumns(state).map(

--- a/src/redux.js
+++ b/src/redux.js
@@ -369,12 +369,12 @@ export function getOptionFrequencies(state, column) {
 }
 
 export function getOptionFrequenciesByColumn(state) {
-  let uniqueOptionsByColumn = {};
+  let optionFrequenciesByColumn = {};
   getSelectedCategoricalColumns(state).map(
     column =>
-      (uniqueOptionsByColumn[column] = getOptionFrequencies(state, column))
+      (optionFrequenciesByColumn[column] = getOptionFrequencies(state, column))
   );
-  return uniqueOptionsByColumn;
+  return optionFrequenciesByColumn;
 }
 
 export function getUniqueOptionsByColumn(state) {

--- a/test/unit/first.test.js
+++ b/test/unit/first.test.js
@@ -1,5 +1,5 @@
-describe('Model quality test', () => {
-  test('first', async () => {
-    expect(true).toBe(true)
-  })
-})
+describe("Model quality test", () => {
+  test("first", async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,0 +1,67 @@
+import { getOptionFrequenciesByColumn } from "../../src/redux.js";
+
+const initialState = {
+  data: [
+    {
+      name: "Plain M&Ms",
+      chocolate: "yes",
+      nuts: "no",
+      fruity: "no",
+      delicious: "yes"
+    },
+    {
+      name: "Peanut M&Ms",
+      chocolate: "yes",
+      nuts: "yes",
+      fruity: "no",
+      delicious: "yes"
+    },
+    {
+      name: "Snickers",
+      chocolate: "yes",
+      nuts: "yes",
+      fruity: "no",
+      delicious: "yes"
+    },
+    {
+      name: "Almond Joy",
+      chocolate: "yes",
+      nuts: "yes",
+      fruity: "no",
+      delicious: "yes"
+    },
+    {
+      name: "Black Licorice",
+      chocolate: "no",
+      nuts: "no",
+      fruity: "no",
+      delicious: "no"
+    },
+    {
+      name: "Skittles",
+      chocolate: "no",
+      nuts: "no",
+      fruity: "yes",
+      delicious: "yes"
+    }
+  ],
+  labelColumn: "delicious",
+  selectedFeatures: ["chocolate", "nuts"],
+  columnsByDataType: {
+    chocolate: "categorical",
+    nuts: "categorical",
+    delicious: "categorical"
+  }
+};
+
+describe("redux functions", () => {
+  test("getOptionFrequenciesByColumn", async () => {
+    const frequencies = getOptionFrequenciesByColumn(initialState);
+    expect(frequencies["chocolate"]["yes"]).toBe(4);
+    expect(frequencies["chocolate"]["no"]).toBe(2);
+    expect(frequencies["nuts"]["yes"]).toBe(3);
+    expect(frequencies["nuts"]["no"]).toBe(3);
+    expect(frequencies["delicious"]["yes"]).toBe(5);
+    expect(frequencies["delicious"]["no"]).toBe(1);
+  });
+});


### PR DESCRIPTION
When inspecting columns to determine which would be good to select for training, students can now see how often each unique option in a categorical column appears in the data set. 

<img width="690" alt="Screen Shot 2020-11-12 at 11 23 31 AM" src="https://user-images.githubusercontent.com/12300669/98968059-35900200-24db-11eb-8baa-a335711c6b60.png">

This PR also includes test for the new `getOptionFrequencies` function. This initial Redux test sets up state and an example that can be used in future tests. 