### PR TITLE
Convert predicted label before setting for single test prediction

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -86,7 +86,7 @@ class Predict extends Component {
             <button type="button" onClick={this.onClickPredict}>
               Predict!
             </button>
-            <p/>
+            <p />
             {this.props.predictedLabel && (
               <div>
                 <div> The Machine Learning model predicts... </div>

--- a/src/trainers/SVMTrainer.js
+++ b/src/trainers/SVMTrainer.js
@@ -91,7 +91,9 @@ export default class SVMTrainer {
 
   predict(testValues) {
     let prediction = {};
-    prediction.predictedLabel = this.svm.predict(testValues);
+    const predictedLabel = this.svm.predict(testValues);
+    const convertedPredictedLabel = this.convertPredictedLabel(predictedLabel);
+    prediction.predictedLabel = convertedPredictedLabel;
     store.dispatch(setPrediction(prediction));
   }
 


### PR DESCRIPTION
The SVM algorithm we're using expects the label column to contain -1 or 1. To support strings in categorical columns we do a multi-step conversion: raw value -> number -> -1 or 1. When we get the prediction back from the SVM algorithm we need to do that same conversion in reverse. 

We were doing this for the batch prediction, but _not_ for the single test prediction. It _looked_ like it was working when I was playing with it for https://github.com/code-dot-org/ml-playground/pull/17 because the algorithm predicted 1, which coincidentally mapped to a number in the `featureNumberKey` without needing to be converted. 

This update fixes the issue by taking the value returned from the prediction, converting appropriately and then using that number to convert back to a string if necessary for display. 