### PR TITLE
Prepare to save trained models and details

### DIFF
--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -20,9 +20,10 @@ class SaveModel extends Component {
   };
 
   onClickSave = () => {
-    console.log("dataToSave", this.props.dataToSave);
     this.props.saveTrainedModel(this.props.dataToSave);
-    alert("Don't get too excited, this doesn't do anything yet :)");
+    alert(
+      "Ok, you can get a little excited now; this saves the trained model to an s3 bucket!"
+    );
   };
 
   render() {

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -2,16 +2,27 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { setTrainedModelDetails, getTrainedModelDataToSave } from "../redux";
 
 class SaveModel extends Component {
   static propTypes = {
     saveTrainedModel: PropTypes.func,
-    trainedModel: PropTypes.object
+    trainedModel: PropTypes.object,
+    setTrainedModelDetails: PropTypes.func,
+    trainedModelDetails: PropTypes.object,
+    dataToSave: PropTypes.object
+  };
+
+  handleChange = (event, field) => {
+    const trainedModelDetails = this.props.trainedModelDetails;
+    trainedModelDetails[field] = event.target.value;
+    this.props.setTrainedModelDetails(trainedModelDetails);
   };
 
   onClickSave = () => {
+    console.log("dataToSave", this.props.dataToSave);
+    this.props.saveTrainedModel(this.props.dataToSave);
     alert("Don't get too excited, this doesn't do anything yet :)");
-    this.props.saveTrainedModel();
   };
 
   render() {
@@ -19,6 +30,19 @@ class SaveModel extends Component {
       <div>
         <br />
         <br />
+        <label>
+          Model name:
+          <input
+            type="text"
+            onChange={event => this.handleChange(event, "name")}
+          />
+        </label>
+        <label>
+          Model description:
+          <textarea
+            onChange={event => this.handleChange(event, "description")}
+          />
+        </label>
         <button type="button" onClick={this.onClickSave}>
           Save Trained Model
         </button>
@@ -27,6 +51,15 @@ class SaveModel extends Component {
   }
 }
 
-export default connect(state => ({
-  trainedModel: state.trainedModel
-}))(SaveModel);
+export default connect(
+  state => ({
+    trainedModel: state.trainedModel,
+    trainedModelDetails: state.trainedModelDetails,
+    dataToSave: getTrainedModelDataToSave(state)
+  }),
+  dispatch => ({
+    setTrainedModelDetails(trainedModelDetails) {
+      dispatch(setTrainedModelDetails(trainedModelDetails));
+    }
+  })
+)(SaveModel);

--- a/src/redux.js
+++ b/src/redux.js
@@ -45,6 +45,7 @@ const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
 const SET_MODEL_SIZE = "SET_MODEL_SIZE";
 const SET_TRAINED_MODEL = "SET_TRAINED_MODEL";
+const SET_TRAINED_MODEL_DETAILS = "SET_TRAINED_MODEL_DETAILS";
 
 // Action creators
 export function setMode(mode) {
@@ -152,6 +153,10 @@ export function setTrainedModel(trainedModel) {
   return { type: SET_TRAINED_MODEL, trainedModel };
 }
 
+export function setTrainedModelDetails(trainedModelDetails) {
+  return { type: SET_TRAINED_MODEL_DETAILS, trainedModelDetails };
+}
+
 const initialState = {
   csvfile: undefined,
   jsonfile: undefined,
@@ -172,7 +177,8 @@ const initialState = {
   testData: {},
   prediction: {},
   modelSize: undefined,
-  trainedModel: undefined
+  trainedModel: undefined,
+  trainedModelDetails: {}
 };
 
 // Reducer
@@ -309,6 +315,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       trainedModel: action.trainedModel
+    };
+  }
+  if (action.type === SET_TRAINED_MODEL_DETAILS) {
+    return {
+      ...state,
+      trainedModelDetails: action.trainedModelDetails
     };
   }
   return state;
@@ -584,4 +596,15 @@ export function getEmptyCellDetails(state) {
     return `Column: ${cellDetails.column} Row: ${cellDetails.row}`;
   });
   return emptyCellLocations;
+}
+
+export function getTrainedModelDataToSave(state) {
+  const dataToSave = {};
+  dataToSave.selectedTrainer = state.selectedTrainer;
+  dataToSave.trainedModel = state.trainedModel;
+  dataToSave.name = state.trainedModelDetails.name;
+  dataToSave.description = state.trainedModelDetails.description;
+  dataToSave.summaryStat = getSummaryStat(state);
+
+  return dataToSave;
 }


### PR DESCRIPTION
Adds a model name and description field
<img width="460" alt="Screen Shot 2020-11-17 at 10 32 27 AM" src="https://user-images.githubusercontent.com/12300669/99411471-a1021700-28c1-11eb-85f7-ff68a47069be.png">

Then uses the inputed information in addition with other model details already in state to prepare a bundle of data to pass to the `saveTrainedModel` function. 

Compatible with [Code Studio PR #37811](https://github.com/code-dot-org/code-dot-org/pull/37811)
