### PR TITLE
save metadata about trained models

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -600,11 +600,14 @@ export function getEmptyCellDetails(state) {
 
 export function getTrainedModelDataToSave(state) {
   const dataToSave = {};
-  dataToSave.selectedTrainer = state.selectedTrainer;
-  dataToSave.trainedModel = state.trainedModel;
   dataToSave.name = state.trainedModelDetails.name;
   dataToSave.description = state.trainedModelDetails.description;
+  dataToSave.selectedTrainer = state.selectedTrainer;
+  dataToSave.selectedFeatures = state.selectedFeatures;
+  dataToSave.featureNumberKey = state.featureNumberKey;
+  dataToSave.labelColumn = state.labelColumn;
   dataToSave.summaryStat = getSummaryStat(state);
+  dataToSave.trainedModel = state.trainedModel;
 
   return dataToSave;
 }


### PR DESCRIPTION
Compatible with [Code Studio PR #38513](https://github.com/code-dot-org/code-dot-org/pull/38153)

Prepare metadata to be saved alongside a trained model in s3. 