### PR TITLE
Candy dataset: use yes and no rather than -1 and 1 for clarity

### DIFF
--- a/public/datasets/erin_candy_preferences.csv
+++ b/public/datasets/erin_candy_preferences.csv
@@ -1,86 +1,86 @@
 name,chocolate,fruity,caramel,nuts,nougat,crispy,hard,bar,pluribus,delicious?
-100 Grand,1,0,1,0,0,1,0,1,0,1
-3 Musketeers,1,0,0,0,1,0,0,1,0,1
-One dime,0,0,0,0,0,0,0,0,0,-1
-One quarter,0,0,0,0,0,0,0,0,0,-1
-Air Heads,0,1,0,0,0,0,0,0,0,1
-Almond Joy,1,0,0,1,0,0,0,1,0,-1
-Baby Ruth,1,0,1,1,1,0,0,1,0,1
-Boston Baked Beans,0,0,0,1,0,0,0,0,1,-1
-Candy Corn,0,0,0,0,0,0,0,0,1,-1
-Caramel Apple Pops,0,1,1,0,0,0,0,0,0,1
-Charleston Chew,1,0,0,0,1,0,0,1,0,-1
-Chewey Lemonhead Fruit Mix,0,1,0,0,0,0,0,0,1,-1
-Chiclets,0,1,0,0,0,0,0,0,1,-1
-Dots,0,1,0,0,0,0,0,0,1,-1
-Dum Dums,0,1,0,0,0,0,1,0,0,-1
-Fruit Chews,0,1,0,0,0,0,0,0,1,-1
-Fun Dip,0,1,0,0,0,0,1,0,0,1
-Gobstopper,0,1,0,0,0,0,1,0,1,1
-Haribo Gold Bears,0,1,0,0,0,0,0,0,1,1
-Haribo Happy Cola,0,0,0,0,0,0,0,0,1,-1
-Haribo Sour Bears,0,1,0,0,0,0,0,0,1,1
-Haribo Twin Snakes,0,1,0,0,0,0,0,0,1,-1
-Hershey's Kisses,1,0,0,0,0,0,0,0,1,-1
-Hershey's Krackel,1,0,0,0,0,1,0,1,0,-1
-Hershey's Milk Chocolate,1,0,0,0,0,0,0,1,0,-1
-Hershey's Special Dark,1,0,0,0,0,0,0,1,0,1
-Jawbusters,0,1,0,0,0,0,1,0,1,-1
-Junior Mints,1,0,0,0,0,0,0,0,1,1
-Kit Kat,1,0,0,0,0,1,0,1,0,1
-Laffy Taffy,0,1,0,0,0,0,0,0,0,-1
-Lemonhead,0,1,0,0,0,0,1,0,0,-1
-Lifesavers big ring gummies,0,1,0,0,0,0,0,0,0,-1
-Peanut butter M&Ms,1,0,0,1,0,0,0,0,1,1
-M&Ms,1,0,0,0,0,0,0,0,1,1
-Mike & Ike,0,1,0,0,0,0,0,0,1,1
-Milk Duds,1,0,1,0,0,0,0,0,1,-1
-Milky Way,1,0,1,0,1,0,0,1,0,-1
-Milky Way Midnight,1,0,1,0,1,0,0,1,0,-1
-Milky Way Simply Caramel,1,0,1,0,0,0,0,1,0,-1
-Mounds,1,0,0,0,0,0,0,1,0,-1
-Mr Good Bar,1,0,0,1,0,0,0,1,0,-1
-Nerds,0,1,0,0,0,0,1,0,1,-1
-Nestle Butterfinger,1,0,0,1,0,0,0,1,0,1
-Nestle Crunch,1,0,0,0,0,1,0,1,0,-1
-Nik L Nip,0,1,0,0,0,0,0,0,1,-1
-Now & Later,0,1,0,0,0,0,0,0,1,-1
-Payday,0,0,0,1,1,0,0,1,0,1
-Peanut M&Ms,1,0,0,1,0,0,0,0,1,1
-Pixie Sticks,0,0,0,0,0,0,0,0,1,-1
-Pop Rocks,0,1,0,0,0,0,1,0,1,-1
-Red vines,0,1,0,0,0,0,0,0,1,-1
-Reese's Miniatures,1,0,0,1,0,0,0,0,0,1
-Reese's Peanut Butter cup,1,0,0,1,0,0,0,0,0,1
-Reese's pieces,1,0,0,1,0,0,0,0,1,1
-Reese's stuffed with pieces,1,0,0,1,0,0,0,0,0,1
-Ring pop,0,1,0,0,0,0,1,0,0,-1
-Rolo,1,0,1,0,0,0,0,0,1,1
-Root Beer Barrels,0,0,0,0,0,0,1,0,1,-1
-Runts,0,1,0,0,0,0,1,0,1,1
-Sixlets,1,0,0,0,0,0,0,0,1,1
-Skittles original,0,1,0,0,0,0,0,0,1,1
-Skittles wildberry,0,1,0,0,0,0,0,0,1,-1
-Nestle Smarties,1,0,0,0,0,0,0,0,1,-1
-Smarties candy,0,1,0,0,0,0,1,0,1,1
-Snickers,1,0,1,1,1,0,0,1,0,1
-Snickers Crisper,1,0,1,1,0,1,0,1,0,-1
-Sour Patch Kids,0,1,0,0,0,0,0,0,1,1
-Sour Patch Tricksters,0,1,0,0,0,0,0,0,1,-1
-Starburst,0,1,0,0,0,0,0,0,1,1
-Strawberry bon bons,0,1,0,0,0,0,1,0,1,-1
-Sugar Babies,0,0,1,0,0,0,0,0,1,-1
-Sugar Daddy,0,0,1,0,0,0,0,0,0,-1
-Super Bubble,0,1,0,0,0,0,0,0,0,-1
-Swedish Fish,0,1,0,0,0,0,0,0,1,1
-Tootsie Pop,1,1,0,0,0,0,1,0,0,-1
-Tootsie Roll Juniors,1,0,0,0,0,0,0,0,0,-1
-Tootsie Roll Midgies,1,0,0,0,0,0,0,0,1,-1
-Tootsie Roll Snack Bars,1,0,0,0,0,0,0,1,0,-1
-Trolli Sour Bites,0,1,0,0,0,0,0,0,1,-1
-Twix,1,0,1,0,0,1,0,1,0,1
-Twizzlers,0,1,0,0,0,0,0,0,0,-1
-Warheads,0,1,0,0,0,0,1,0,0,1
-Welch's Fruit Snacks,0,1,0,0,0,0,0,0,1,-1
-Werther's Original Caramel,0,0,1,0,0,0,1,0,0,-1
-Whoppers,1,0,0,0,0,1,0,0,1,1
+100 Grand,1,0,1,0,0,1,0,1,0,yes
+3 Musketeers,1,0,0,0,1,0,0,1,0,yes
+One dime,0,0,0,0,0,0,0,0,0,no
+One quarter,0,0,0,0,0,0,0,0,0,no
+Air Heads,0,1,0,0,0,0,0,0,0,yes
+Almond Joy,1,0,0,1,0,0,0,1,0,yes
+Baby Ruth,1,0,1,1,1,0,0,1,0,yes
+Boston Baked Beans,0,0,0,1,0,0,0,0,1,no
+Candy Corn,0,0,0,0,0,0,0,0,1,no
+Caramel Apple Pops,0,1,1,0,0,0,0,0,0,yes
+Charleston Chew,1,0,0,0,1,0,0,1,0,no
+Chewey Lemonhead Fruit Mix,0,1,0,0,0,0,0,0,1,no
+Chiclets,0,1,0,0,0,0,0,0,1,no
+Dots,0,1,0,0,0,0,0,0,1,no
+Dum Dums,0,1,0,0,0,0,1,0,0,no
+Fruit Chews,0,1,0,0,0,0,0,0,1,no
+Fun Dip,0,1,0,0,0,0,1,0,0,yes
+Gobstopper,0,1,0,0,0,0,1,0,1,yes
+Haribo Gold Bears,0,1,0,0,0,0,0,0,1,no
+Haribo Happy Cola,0,0,0,0,0,0,0,0,1,no
+Haribo Sour Bears,0,1,0,0,0,0,0,0,1,no
+Haribo Twin Snakes,0,1,0,0,0,0,0,0,1,no
+Hershey's Kisses,1,0,0,0,0,0,0,0,1,no
+Hershey's Krackel,1,0,0,0,0,1,0,1,0,no
+Hershey's Milk Chocolate,1,0,0,0,0,0,0,1,0,no
+Hershey's Special Dark,1,0,0,0,0,0,0,1,0,yes
+Jawbusters,0,1,0,0,0,0,1,0,1,no
+Junior Mints,1,0,0,0,0,0,0,0,1,yes
+Kit Kat,1,0,0,0,0,1,0,1,0,yes
+Laffy Taffy,0,1,0,0,0,0,0,0,0,no
+Lemonhead,0,1,0,0,0,0,1,0,0,no
+Lifesavers big ring gummies,0,1,0,0,0,0,0,0,0,no
+Peanut butter M&Ms,1,0,0,1,0,0,0,0,1,yes
+M&Ms,1,0,0,0,0,0,0,0,1,yes
+Mike & Ike,0,1,0,0,0,0,0,0,1,yes
+Milk Duds,1,0,1,0,0,0,0,0,1,no
+Milky Way,1,0,1,0,1,0,0,1,0,no
+Milky Way Midnight,1,0,1,0,1,0,0,1,0,no
+Milky Way Simply Caramel,1,0,1,0,0,0,0,1,0,no
+Mounds,1,0,0,0,0,0,0,1,0,no
+Mr Good Bar,1,0,0,1,0,0,0,1,0,no
+Nerds,0,1,0,0,0,0,1,0,1,no
+Nestle Butterfinger,1,0,0,1,0,0,0,1,0,yes
+Nestle Crunch,1,0,0,0,0,1,0,1,0,no
+Nik L Nip,0,1,0,0,0,0,0,0,1,no
+Now & Later,0,1,0,0,0,0,0,0,1,no
+Payday,0,0,0,1,1,0,0,1,0,yes
+Peanut M&Ms,1,0,0,1,0,0,0,0,1,yes
+Pixie Sticks,0,0,0,0,0,0,0,0,1,no
+Pop Rocks,0,1,0,0,0,0,1,0,1,no
+Red vines,0,1,0,0,0,0,0,0,1,no
+Reese's Miniatures,1,0,0,1,0,0,0,0,0,yes
+Reese's Peanut Butter cup,1,0,0,1,0,0,0,0,0,yes
+Reese's pieces,1,0,0,1,0,0,0,0,1,yes
+Reese's stuffed with pieces,1,0,0,1,0,0,0,0,0,yes
+Ring pop,0,1,0,0,0,0,1,0,0,no
+Rolo,1,0,1,0,0,0,0,0,1,yes
+Root Beer Barrels,0,0,0,0,0,0,1,0,1,no
+Runts,0,1,0,0,0,0,1,0,1,yes
+Sixlets,1,0,0,0,0,0,0,0,1,yes
+Skittles original,0,1,0,0,0,0,0,0,1,yes
+Skittles wildberry,0,1,0,0,0,0,0,0,1,no
+Nestle Smarties,1,0,0,0,0,0,0,0,1,no
+Smarties candy,0,1,0,0,0,0,1,0,1,yes
+Snickers,1,0,1,1,1,0,0,1,0,yes
+Snickers Crisper,1,0,1,1,0,1,0,1,0,no
+Sour Patch Kids,0,1,0,0,0,0,0,0,1,yes
+Sour Patch Tricksters,0,1,0,0,0,0,0,0,1,no
+Starburst,0,1,0,0,0,0,0,0,1,yes
+Strawberry bon bons,0,1,0,0,0,0,1,0,1,no
+Sugar Babies,0,0,1,0,0,0,0,0,1,yes
+Sugar Daddy,0,0,1,0,0,0,0,0,0,yes
+Super Bubble,0,1,0,0,0,0,0,0,0,no
+Swedish Fish,0,1,0,0,0,0,0,0,1,yes
+Tootsie Pop,1,1,0,0,0,0,1,0,0,no
+Tootsie Roll Juniors,1,0,0,0,0,0,0,0,0,no
+Tootsie Roll Midgies,1,0,0,0,0,0,0,0,1,no
+Tootsie Roll Snack Bars,1,0,0,0,0,0,0,1,0,no
+Trolli Sour Bites,0,1,0,0,0,0,0,0,1,no
+Twix,1,0,1,0,0,1,0,1,0,yes
+Twizzlers,0,1,0,0,0,0,0,0,0,no
+Warheads,0,1,0,0,0,0,1,0,0,yes
+Welch's Fruit Snacks,0,1,0,0,0,0,0,0,1,no
+Werther's Original Caramel,0,0,1,0,0,0,1,0,0,no
+Whoppers,1,0,0,0,0,1,0,0,1,yes


### PR DESCRIPTION
The SVM algorithm expects 1 and -1 in the label column. When I initially added the candy dataset, I used -1 and 1 for the delicious column to play nicely with this algorithm, but now that we convert strings behind the scenes "yes" and "no" are more user friendly as we test things.  

<img width="716" alt="Screen Shot 2020-12-15 at 6 57 39 PM" src="https://user-images.githubusercontent.com/12300669/102287487-8f378200-3f08-11eb-9a4e-70c96e9c9f2f.png">
