### PR TITLE
Export to App Lab button and function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,11 +58,12 @@ class PanelTabs extends Component {
 class Panels extends Component {
   static propTypes = {
     currentPanel: PropTypes.string,
-    saveTrainedModel: PropTypes.func
+    saveTrainedModel: PropTypes.func,
+    exportToAppLab: PropTypes.func
   };
 
   render() {
-    const { currentPanel, saveTrainedModel } = this.props;
+    const { currentPanel, saveTrainedModel, exportToAppLab } = this.props;
 
     return (
       <div style={styles.panelContainer}>
@@ -75,7 +76,10 @@ class Panels extends Component {
         {currentPanel === "results" && <Results />}
         {currentPanel === "predict" && <Predict />}
         {currentPanel === "saveModel" && (
-          <SaveModel saveTrainedModel={saveTrainedModel} />
+          <SaveModel
+            saveTrainedModel={saveTrainedModel}
+            exportToAppLab={exportToAppLab}
+          />
         )}
       </div>
     );
@@ -126,7 +130,8 @@ class App extends Component {
     currentPanel: PropTypes.string,
     setCurrentPanel: PropTypes.func,
     validationMessages: PropTypes.object,
-    saveTrainedModel: PropTypes.func
+    saveTrainedModel: PropTypes.func,
+    exportToAppLab: PropTypes.func
   };
 
   render() {
@@ -135,7 +140,8 @@ class App extends Component {
       currentPanel,
       setCurrentPanel,
       validationMessages,
-      saveTrainedModel
+      saveTrainedModel,
+      exportToAppLab
     } = this.props;
 
     return (
@@ -149,6 +155,7 @@ class App extends Component {
           <Panels
             currentPanel={currentPanel}
             saveTrainedModel={saveTrainedModel}
+            exportToAppLab={exportToAppLab}
           />
           <ValidationMessages
             currentPanel={currentPanel}

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -7,6 +7,7 @@ import { setTrainedModelDetails, getTrainedModelDataToSave } from "../redux";
 class SaveModel extends Component {
   static propTypes = {
     saveTrainedModel: PropTypes.func,
+    exportToAppLab: PropTypes.func,
     trainedModel: PropTypes.object,
     setTrainedModelDetails: PropTypes.func,
     trainedModelDetails: PropTypes.object,
@@ -23,6 +24,10 @@ class SaveModel extends Component {
     if (this.props.trainedModelDetails.name !== undefined) {
       this.props.saveTrainedModel(this.props.dataToSave);
     }
+  };
+
+  onClickExport = () => {
+    this.props.exportToAppLab(this.props.dataToSave);
   };
 
   render() {
@@ -45,6 +50,9 @@ class SaveModel extends Component {
         </label>
         <button type="button" onClick={this.onClickSave}>
           Save Trained Model
+        </button>
+        <button type="button" onClick={this.onClickExport}>
+          Export to App Lab
         </button>
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,17 @@ export const initAll = function(options) {
   // Handle an optional mode.
   const mode = options && options.mode;
   const saveTrainedModel = options && options.saveTrainedModel;
+  const exportToAppLab = options && options.exportToAppLab;
   store.dispatch(setMode(mode));
   processMode(mode);
 
   ReactDOM.render(
     <Provider store={store}>
-      <App mode={mode} saveTrainedModel={saveTrainedModel} />
+      <App
+        mode={mode}
+        saveTrainedModel={saveTrainedModel}
+        exportToAppLab={exportToAppLab}
+      />
     </Provider>,
     document.getElementById("root")
   );


### PR DESCRIPTION
Adds a new button "Export to App Lab" to the "save" panel that when clicked will save the trained model and pass the model id as a query param to a newly opened App Lab project. 

Compatible with Code Studio PR [#38468](https://github.com/code-dot-org/code-dot-org/pull/38468)

<img width="683" alt="Screen Shot 2021-01-08 at 11 34 30 AM" src="https://user-images.githubusercontent.com/12300669/104041447-0b8b5100-51a7-11eb-93ac-e89aa072fdc5.png">
