### PR TITLE
User can select where in the dataset the test data comes from 

### DIFF
--- a/src/UIComponents/SelectTrainer.jsx
+++ b/src/UIComponents/SelectTrainer.jsx
@@ -5,17 +5,20 @@ import { connect } from "react-redux";
 import {
   getShowChooseReserve,
   setPercentDataToReserve,
+  setReserveLocation,
   setSelectedTrainer,
   getCompatibleTrainers,
   setKValue
 } from "../redux";
-import { styles, TRAINING_DATA_PERCENTS } from "../constants";
+import { styles, TEST_DATA_PERCENTS, TestDataLocations } from "../constants";
 
 class SelectTrainer extends Component {
   static propTypes = {
     showChooseReserve: PropTypes.bool,
     percentDataToReserve: PropTypes.number,
     setPercentDataToReserve: PropTypes.func,
+    reserveLocation: PropTypes.string,
+    setReserveLocation: PropTypes.func,
     selectedTrainer: PropTypes.string,
     setSelectedTrainer: PropTypes.func,
     compatibleTrainers: PropTypes.object,
@@ -27,11 +30,14 @@ class SelectTrainer extends Component {
     this.props.setPercentDataToReserve(parseInt(event.target.value));
   };
 
+  handleChangeReserveLocation = event => {
+    this.props.setReserveLocation(event.target.value);
+  };
+
   handleChangeSelectTrainer = event => {
     this.props.setSelectedTrainer(event.target.value);
   };
 
-  /* add event handler -> handleChangeInput Function */
   handleChangeKValue = event => {
     this.props.setKValue(parseInt(event.target.value));
   };
@@ -39,10 +45,12 @@ class SelectTrainer extends Component {
   render() {
     const {
       showChooseReserve,
+      reserveLocation,
       percentDataToReserve,
       compatibleTrainers,
       selectedTrainer
     } = this.props;
+
     return (
       <div id="select-trainer" style={styles.panel}>
         {showChooseReserve && (
@@ -50,7 +58,6 @@ class SelectTrainer extends Component {
             <div style={styles.largeText}>
               Are you ready to train the model?
             </div>
-
             <div>
               How much of the data would you like to reserve for testing?
             </div>
@@ -61,7 +68,7 @@ class SelectTrainer extends Component {
                   value={percentDataToReserve}
                   onChange={this.handleChangePercentReserve}
                 >
-                  {TRAINING_DATA_PERCENTS.map((percent, index) => {
+                  {TEST_DATA_PERCENTS.map((percent, index) => {
                     return (
                       <option key={index} value={percent}>
                         {percent}
@@ -70,10 +77,31 @@ class SelectTrainer extends Component {
                   })}
                 </select>
               </label>
+              <br />
+              <br />
+              {percentDataToReserve > 0 && (
+                <label>
+                  Where in the dataset would you like to pull the test data
+                  from?{" "}
+                  <select
+                    value={reserveLocation}
+                    onChange={this.handleChangeReserveLocation}
+                  >
+                    {Object.keys(TestDataLocations).map((location, index) => {
+                      return (
+                        <option key={index} value={TestDataLocations[location]}>
+                          {TestDataLocations[location]}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              )}
             </form>
           </div>
         )}
-
+        <br />
+        <br />
         <div style={styles.largeText}>Pick an Algorithm</div>
         <form>
           <label>
@@ -123,7 +151,7 @@ export default connect(
   state => ({
     showChooseReserve: getShowChooseReserve(state),
     percentDataToReserve: state.percentDataToReserve,
-
+    reserveLocation: state.reserveLocation,
     selectedTrainer: state.selectedTrainer,
     compatibleTrainers: getCompatibleTrainers(state),
     kValue: state.kValue
@@ -131,6 +159,9 @@ export default connect(
   dispatch => ({
     setPercentDataToReserve(percentDataToReserve) {
       dispatch(setPercentDataToReserve(percentDataToReserve));
+    },
+    setReserveLocation(reserveLocation) {
+      dispatch(setReserveLocation(reserveLocation));
     },
     setSelectedTrainer(selectedTrainer) {
       dispatch(setSelectedTrainer(selectedTrainer));

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,13 @@ export const MLTypes = {
   REGRESSION: "regression"
 };
 
-export const TRAINING_DATA_PERCENTS = [0, 5, 10, 15, 20];
+export const TEST_DATA_PERCENTS = [0, 5, 10, 15, 20];
+
+export const TestDataLocations = {
+  BEGINNING: "beginnning",
+  END: "end",
+  RANDOM: "random"
+};
 
 export const styles = {
   app: {
@@ -120,11 +126,11 @@ export const styles = {
   },
   dataDisplayHeaderLabelSelected: {
     backgroundColor: "rgba(186, 168, 70)",
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayHeaderFeatureSelected: {
     backgroundColor: "rgb(70, 186, 168)",
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayHeaderSelected: {
     color: "yellow",
@@ -149,24 +155,23 @@ export const styles = {
   },
   dataDisplayCellLabelSelected: {
     backgroundColor: "rgba(186, 168, 70, 0.4)",
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayCellFeatureSelected: {
     backgroundColor: "rgb(70, 186, 168)",
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayCellSelected: {
     color: "yellow",
     backgroundColor: "grey"
   },
   dataDisplayCellLabelUnselected: {
-    backgroundColor: "rgba(186, 168, 70, 0.4)",
+    backgroundColor: "rgba(186, 168, 70, 0.4)"
   },
   dataDisplayCellFeatureUnselected: {
-    backgroundColor: "rgb(70, 186, 168)",
+    backgroundColor: "rgb(70, 186, 168)"
   },
-  dataDisplayCellUnselected: {
-  },
+  dataDisplayCellUnselected: {},
 
   tabContainer: {
     overflow: "hidden",
@@ -277,5 +282,4 @@ export const styles = {
   selectFeaturesText: {
     color: "rgb(70, 186, 168)"
   }
-
 };

--- a/src/redux.js
+++ b/src/redux.js
@@ -20,7 +20,7 @@ import {
   namedModel
 } from "./validate.js";
 
-import { ColumnTypes, MLTypes } from "./constants.js";
+import { ColumnTypes, MLTypes, TestDataLocations } from "./constants.js";
 
 // Action types
 const RESET_STATE = "RESET_STATE";
@@ -38,6 +38,7 @@ const REMOVE_SELECTED_FEATURE = "REMOVE_SELECTED_FEATURE";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
 const SET_PERCENT_DATA_TO_RESERVE = "SET_PERCENT_DATA_TO_RESERVE";
+const SET_RESERVE_LOCATION = "SET_RESERVE_LOCATION";
 const SET_ACCURACY_CHECK_EXAMPLES = "SET_ACCURACY_CHECK_EXAMPLES";
 const SET_ACCURACY_CHECK_LABELS = "SET_ACCURACY_CHECK_LABELS";
 const SET_ACCURACY_CHECK_PREDICTED_LABELS =
@@ -126,6 +127,10 @@ export function setPercentDataToReserve(percentDataToReserve) {
   return { type: SET_PERCENT_DATA_TO_RESERVE, percentDataToReserve };
 }
 
+export function setReserveLocation(reserveLocation) {
+  return { type: SET_RESERVE_LOCATION, reserveLocation };
+}
+
 export function setAccuracyCheckExamples(accuracyCheckExamples) {
   return { type: SET_ACCURACY_CHECK_EXAMPLES, accuracyCheckExamples };
 }
@@ -192,6 +197,7 @@ const initialState = {
   trainingExamples: [],
   trainingLabels: [],
   percentDataToReserve: 10,
+  reserveLocation: TestDataLocations.BEGINNING,
   accuracyCheckExamples: [],
   accuracyCheckLabels: [],
   accuracyCheckPredictedLabels: [],
@@ -319,6 +325,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       percentDataToReserve: action.percentDataToReserve
+    };
+  }
+  if (action.type === SET_RESERVE_LOCATION) {
+    return {
+      ...state,
+      reserveLocation: action.reserveLocation
     };
   }
   if (action.type === SET_ACCURACY_CHECK_EXAMPLES) {


### PR DESCRIPTION
Early in the curriculum unit, we'd like to ensure that students are creating the same models given the same datasets.  The only way to do this is to eliminate the randomness with which we've been selecting the test data from the data set. This change adds a dropdown for a user to select "beginning", "middle" or "random" for where the test data comes from. 

<img width="891" alt="Screen Shot 2021-01-22 at 3 48 01 PM" src="https://user-images.githubusercontent.com/12300669/105545361-f7c50c00-5cc9-11eb-94f2-3ee7f4477487.png">

If the user has selected to reserve 0% of the dataset, they will not see this additional dropdown. 

<img width="825" alt="Screen Shot 2021-01-22 at 3 48 09 PM" src="https://user-images.githubusercontent.com/12300669/105545405-07dceb80-5cca-11eb-8414-788ba259d897.png">
