### PR TITLE
Convert numbers back to human readable strings in Results table 

### DIFF
--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -2,7 +2,11 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getConvertedLabels, getSummaryStat } from "../redux";
+import {
+  getConvertedAccuracyCheckExamples,
+  getConvertedLabels,
+  getSummaryStat
+} from "../redux";
 import { styles, MLTypes } from "../constants";
 
 class Results extends Component {
@@ -87,7 +91,7 @@ export default connect(state => ({
   selectedFeatures: state.selectedFeatures,
   labelColumn: state.labelColumn,
   summaryStat: getSummaryStat(state),
-  accuracyCheckExamples: state.accuracyCheckExamples,
+  accuracyCheckExamples: getConvertedAccuracyCheckExamples(state),
   accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
   accuracyCheckPredictedLabels: getConvertedLabels(
     state,

--- a/src/redux.js
+++ b/src/redux.js
@@ -582,8 +582,13 @@ export function getConvertedAccuracyCheckExamples(state) {
 }
 
 export function getConvertedLabel(state, rawLabel) {
-  if (state.labelColumn) {
-    getConvertedValue(state, rawLabel, state.labelColumn);
+  if (state.labelColumn && !isEmpty(state.featureNumberKey)) {
+    const convertedLabel = getCategoricalColumns(state).includes(
+      state.labelColumn
+    )
+      ? getKeyByValue(state.featureNumberKey[state.labelColumn], rawLabel)
+      : rawLabel;
+    return convertedLabel;
   }
 }
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -570,8 +570,7 @@ export function getConvertedAccuracyCheckExamples(state) {
   var example;
   for (example of state.accuracyCheckExamples) {
     let convertedAccuracyCheckExample = [];
-    var i;
-    for (i = 0; i < state.selectedFeatures.length; i++) {
+    for (var i = 0; i < state.selectedFeatures.length; i++) {
       convertedAccuracyCheckExample.push(
         getConvertedValue(state, example[i], state.selectedFeatures[i])
       );

--- a/src/redux.js
+++ b/src/redux.js
@@ -556,14 +556,34 @@ function isEmpty(object) {
   return Object.keys(object).length === 0;
 }
 
+export function getConvertedValue(state, rawValue, column) {
+  if (!isEmpty(state.featureNumberKey)) {
+    const convertedValue = getCategoricalColumns(state).includes(column)
+      ? getKeyByValue(state.featureNumberKey[column], rawValue)
+      : rawValue;
+    return convertedValue;
+  }
+}
+
+export function getConvertedAccuracyCheckExamples(state) {
+  const convertedAccuracyCheckExamples = [];
+  var example;
+  for (example of state.accuracyCheckExamples) {
+    let convertedAccuracyCheckExample = [];
+    var i;
+    for (i = 0; i < state.selectedFeatures.length; i++) {
+      convertedAccuracyCheckExample.push(
+        getConvertedValue(state, example[i], state.selectedFeatures[i])
+      );
+    }
+    convertedAccuracyCheckExamples.push(convertedAccuracyCheckExample);
+  }
+  return convertedAccuracyCheckExamples;
+}
+
 export function getConvertedLabel(state, rawLabel) {
-  if (state.labelColumn && !isEmpty(state.featureNumberKey)) {
-    const convertedLabel = getCategoricalColumns(state).includes(
-      state.labelColumn
-    )
-      ? getKeyByValue(state.featureNumberKey[state.labelColumn], rawLabel)
-      : rawLabel;
-    return convertedLabel;
+  if (state.labelColumn) {
+    getConvertedValue(state, rawLabel, state.labelColumn);
   }
 }
 


### PR DESCRIPTION
For categorical data, we convert each category to a number "behind the scenes" before it can be used by the machine learning algorithms.  We're converting the predictions back to human readable strings for the expected and predicted labels in the Results table, but we weren't converting the feature column data in the results table. Now we are. 

Before: 
<img width="779" alt="Screen Shot 2021-01-26 at 9 23 07 PM" src="https://user-images.githubusercontent.com/12300669/105933937-3f76cb00-601d-11eb-8808-74bba0028f4b.png">

After: 
<img width="735" alt="Screen Shot 2021-01-26 at 9 21 09 PM" src="https://user-images.githubusercontent.com/12300669/105933957-4ac9f680-601d-11eb-9a73-70218d660936.png">

