### PR TITLE
CrossTab UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import SelectDataset from "./UIComponents/SelectDataset";
 import DataDisplay from "./UIComponents/DataDisplay";
 import ColumnInspector from "./UIComponents/ColumnInspector";
+import CrossTab from "./UIComponents/CrossTab";
 import SelectTrainer from "./UIComponents/SelectTrainer";
 import TrainModel from "./UIComponents/TrainModel";
 import Results from "./UIComponents/Results";
@@ -201,6 +202,7 @@ class App extends Component {
             saveTrainedModel={saveTrainedModel}
           />
           {currentPanel === "dataDisplay" && <ColumnInspector />}
+          {currentPanel === "dataDisplay" && <CrossTab />}
           <PanelButtons
             panels={panels}
             panelButtons={panelButtons}

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -139,38 +139,6 @@ class ColumnInspector extends Component {
                   </div>
                 )}
 
-                {/*currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
-                  <div>
-                    <p>
-                      {Object.keys(currentColumnData.uniqueOptions).length}{" "}
-                      unique values for {currentColumnData.id}:{" "}
-                    </p>
-                    <div style={styles.subPanel}>
-                      <table>
-                        <thead>
-                          <tr>
-                            <th>Option</th>
-                            <th>Frequency</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {Object.keys(currentColumnData.uniqueOptions)
-                            .sort()
-                            .map((option, index) => {
-                              return (
-                                <tr key={index}>
-                                  <td>{option}</td>
-                                  <td>
-                                    {currentColumnData.frequencies[option]}
-                                  </td>
-                                </tr>
-                              );
-                            })}
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                )*/}
                 {currentColumnData.dataType === ColumnTypes.CONTINUOUS && (
                   <div>
                     {currentColumnData.range && (

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getCrossTabData } from "../redux";
-import { ColumnTypes, styles } from "../constants.js";
+import { styles } from "../constants.js";
 
 class CrossTab extends Component {
   static propTypes = {

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -1,0 +1,90 @@
+/* React component to render a special kind of crosstab table. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getCrossTabData } from "../redux";
+import { ColumnTypes, styles } from "../constants.js";
+
+class CrossTab extends Component {
+  static propTypes = {
+    crossTabData: PropTypes.object
+  };
+
+  getCellStyle = percent => {
+    return {
+      ...styles["crossTabCell" + Math.round(percent / 20)],
+      ...styles.dataDisplayCell
+    };
+  };
+  render() {
+    const { crossTabData } = this.props;
+
+    return (
+      <div id="cross-tab">
+        <div style={styles.validationMessagesLight}>
+          {crossTabData && (
+            <table>
+              <thead>
+                <tr>
+                  <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
+                  <th colSpan={crossTabData.uniqueLabelValues.length}>
+                    {crossTabData.labelName}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {crossTabData.featureNames.map((featureName, index) => {
+                    return <td key={index}>{featureName}</td>;
+                  })}
+
+                  {crossTabData.uniqueLabelValues.map(
+                    (uniqueLabelValue, index) => {
+                      return (
+                        <td key={index} style={styles.dataDisplayCell}>
+                          {uniqueLabelValue}
+                        </td>
+                      );
+                    }
+                  )}
+                </tr>
+                {crossTabData.results.map((result, resultIndex) => {
+                  return (
+                    <tr key={resultIndex}>
+                      {result.featureValues.map(
+                        (featureValue, featureIndex) => {
+                          return <td key={featureIndex}>{featureValue}</td>;
+                        }
+                      )}
+                      {crossTabData.uniqueLabelValues.map(
+                        (uniqueLabelValue, labelIndex) => {
+                          return (
+                            <td
+                              key={labelIndex}
+                              style={this.getCellStyle(
+                                result.labelPercents[uniqueLabelValue]
+                              )}
+                            >
+                              {/*
+                            {result.labelCounts[uniqueLabelValue]}
+                            */}
+                              {result.labelPercents[uniqueLabelValue] || 0}%
+                            </td>
+                          );
+                        }
+                      )}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default connect(state => ({
+  crossTabData: getCrossTabData(state)
+}))(CrossTab);

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -1,4 +1,7 @@
-/* React component to render a special kind of crosstab table. */
+/* React component to render a special kind of crosstab table, with a row for each
+ * active combination of features values, and corresponding percentage of label
+ * values, with a heatmap style applied. */
+
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
@@ -7,6 +10,7 @@ import { ColumnTypes, styles } from "../constants.js";
 
 class CrossTab extends Component {
   static propTypes = {
+    currentColumn: PropTypes.string,
     crossTabData: PropTypes.object
   };
 
@@ -17,74 +21,77 @@ class CrossTab extends Component {
     };
   };
   render() {
-    const { crossTabData } = this.props;
+    const { currentColumn, crossTabData } = this.props;
 
     return (
       <div id="cross-tab">
-        <div style={styles.validationMessagesLight}>
-          {crossTabData && (
-            <table>
-              <thead>
-                <tr>
-                  <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
-                  <th colSpan={crossTabData.uniqueLabelValues.length}>
-                    {crossTabData.labelName}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  {crossTabData.featureNames.map((featureName, index) => {
-                    return <td key={index}>{featureName}</td>;
-                  })}
+        {!currentColumn && (
+          <div style={styles.validationMessagesLight}>
+            {crossTabData && (
+              <table>
+                <thead>
+                  <tr>
+                    <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
+                    <th colSpan={crossTabData.uniqueLabelValues.length}>
+                      {crossTabData.labelName}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    {crossTabData.featureNames.map((featureName, index) => {
+                      return <td key={index}>{featureName}</td>;
+                    })}
 
-                  {crossTabData.uniqueLabelValues.map(
-                    (uniqueLabelValue, index) => {
-                      return (
-                        <td key={index} style={styles.dataDisplayCell}>
-                          {uniqueLabelValue}
-                        </td>
-                      );
-                    }
-                  )}
-                </tr>
-                {crossTabData.results.map((result, resultIndex) => {
-                  return (
-                    <tr key={resultIndex}>
-                      {result.featureValues.map(
-                        (featureValue, featureIndex) => {
-                          return <td key={featureIndex}>{featureValue}</td>;
-                        }
-                      )}
-                      {crossTabData.uniqueLabelValues.map(
-                        (uniqueLabelValue, labelIndex) => {
-                          return (
-                            <td
-                              key={labelIndex}
-                              style={this.getCellStyle(
-                                result.labelPercents[uniqueLabelValue]
-                              )}
-                            >
-                              {/*
-                            {result.labelCounts[uniqueLabelValue]}
-                            */}
-                              {result.labelPercents[uniqueLabelValue] || 0}%
-                            </td>
-                          );
-                        }
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          )}
-        </div>
+                    {crossTabData.uniqueLabelValues.map(
+                      (uniqueLabelValue, index) => {
+                        return (
+                          <td key={index} style={styles.dataDisplayCell}>
+                            {uniqueLabelValue}
+                          </td>
+                        );
+                      }
+                    )}
+                  </tr>
+                  {crossTabData.results.map((result, resultIndex) => {
+                    return (
+                      <tr key={resultIndex}>
+                        {result.featureValues.map(
+                          (featureValue, featureIndex) => {
+                            return <td key={featureIndex}>{featureValue}</td>;
+                          }
+                        )}
+                        {crossTabData.uniqueLabelValues.map(
+                          (uniqueLabelValue, labelIndex) => {
+                            return (
+                              <td
+                                key={labelIndex}
+                                style={this.getCellStyle(
+                                  result.labelPercents[uniqueLabelValue]
+                                )}
+                              >
+                                {/*
+                              {result.labelCounts[uniqueLabelValue]}
+                              */}
+                                {result.labelPercents[uniqueLabelValue] || 0}%
+                              </td>
+                            );
+                          }
+                        )}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
       </div>
     );
   }
 }
 
 export default connect(state => ({
+  currentColumn: state.currentColumn,
   crossTabData: getCrossTabData(state)
 }))(CrossTab);

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -25,9 +25,9 @@ class CrossTab extends Component {
 
     return (
       <div id="cross-tab">
-        {!currentColumn && (
+        {!currentColumn && crossTabData && (
           <div style={styles.validationMessagesLight}>
-            {crossTabData && (
+            <div style={styles.subPanel}>
               <table>
                 <thead>
                   <tr>
@@ -83,7 +83,7 @@ class CrossTab extends Component {
                   })}
                 </tbody>
               </table>
-            )}
+            </div>
           </div>
         )}
       </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -178,6 +178,25 @@ export const styles = {
     marginTop: 10
   },
 
+  crossTabCell0: {
+    backgroundColor: "rgba(255,100,100, 0)"
+  },
+  crossTabCell1: {
+    backgroundColor: "rgba(255,100,100, 0.2)"
+  },
+  crossTabCell2: {
+    backgroundColor: "rgba(255,100,100, 0.4)"
+  },
+  crossTabCell3: {
+    backgroundColor: "rgba(255,100,100, 0.6)"
+  },
+  crossTabCell4: {
+    backgroundColor: "rgba(255,100,100, 0.8)"
+  },
+  crossTabCell5: {
+    backgroundColor: "rgba(255,100,100, 1)"
+  },
+
   tab: {
     float: "left",
     backgroundColor: "rgba(0,0,0,0.8)",

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,7 +105,8 @@ export const styles = {
 
   dataDisplayTable: {
     whiteSpace: "nowrap",
-    borderSpacing: 0
+    borderSpacing: 0,
+    width: "100%"
   },
 
   finePrint: {

--- a/src/redux.js
+++ b/src/redux.js
@@ -899,12 +899,51 @@ export function getCurrentColumnIsSelectedFeature(state) {
   return state.selectedFeatures.includes(state.currentColumn);
 }
 
+/* Returns an object with information for the CrossTab UI.
+ *
+ * Here is an example result:
+ *
+ *  {
+ *    results: [
+ *      {
+ *        featureValues: ["1", "1"],
+ *        labelCounts: { yes: 2, no: 1 },
+ *        labelPercents: { yes: 67, no: 33 }
+ *      },
+ *      {
+ *        featureValues: ["0", "0"],
+ *        labelCounts: { yes: 25, no: 42 },
+ *        labelPercents: { yes: 37, no: 63 }
+ *      },
+ *      {
+ *        featureValues: ["1", "0"],
+ *        labelCounts: { yes: 6, no: 5 },
+ *        labelPercents: { yes: 55, no: 45 }
+ *      },
+ *      {
+ *        featureValues: ["0", "1"],
+ *        labelCounts: { no: 2, yes: 2 },
+ *        labelPercents: { no: 50, yes: 50 }
+ *      }
+ *    ],
+ *    uniqueLabelValues: ["yes", "no"],
+ *    featureNames: ["caramel", "crispy"],
+ *    labelName: "delicious?"
+ *  }
+ *
+ */
+
 export function getCrossTabData(state) {
   if (!state.labelColumn || state.selectedFeatures.length <= 0) {
     return null;
   }
 
   var results = [];
+
+  // For each row of data, determine whether we have found a new or existing
+  // combination of feature values.  If new, then add a new entry to our results
+  // array.  Then record or increment the count for the corresponding label
+  // value.
 
   for (let row of state.data) {
     var featureValues = [];
@@ -931,6 +970,9 @@ export function getCrossTabData(state) {
     }
   }
 
+  // Now that we have all the counts of label values, we can determine the
+  // corresponding percentage values.
+
   for (let result of results) {
     let totalCount = 0;
     for (let labelCount of Object.values(result.labelCounts)) {
@@ -943,6 +985,9 @@ export function getCrossTabData(state) {
       );
     }
   }
+
+  // Take inventory of all unique label values we have seen, which allows us to
+  // generate the header at the top of the CrossTab UI.
 
   var uniqueLabelValues = [];
   for (let result of results) {
@@ -958,7 +1003,6 @@ export function getCrossTabData(state) {
     }
   }
 
-  console.log(results, uniqueLabelValues);
   return {
     results,
     uniqueLabelValues,
@@ -970,7 +1014,7 @@ export function getCrossTabData(state) {
 function areArraysEqual(array1, array2) {
   return (
     array1.length === array2.length &&
-    array1.every(function(value, index) {
+    array1.every((value, index) => {
       return value === array2[index];
     })
   );

--- a/src/redux.js
+++ b/src/redux.js
@@ -989,19 +989,7 @@ export function getCrossTabData(state) {
   // Take inventory of all unique label values we have seen, which allows us to
   // generate the header at the top of the CrossTab UI.
 
-  var uniqueLabelValues = [];
-  for (let result of results) {
-    var labelValues = Object.keys(result.labelCounts);
-    for (let labelValue of labelValues) {
-      if (
-        !uniqueLabelValues.find(uniqueLabelValue => {
-          return uniqueLabelValue === labelValue;
-        })
-      ) {
-        uniqueLabelValues.push(labelValue);
-      }
-    }
-  }
+  const uniqueLabelValues = getUniqueOptions(state, state.labelColumn);
 
   return {
     results,


### PR DESCRIPTION
This introduces a kind of `CrossTab` UI control, shown when a label and one or more features are selected.  It has a row for each combination of feature values, percentages for the cells, and rudimentary heatmap colouring.

The idea is that students can spot features, and feature combinations, that have particularly strong predictive power over a label.

![Screen Shot 2021-01-29 at 5 38 07 PM](https://user-images.githubusercontent.com/2205926/106240738-a9c47280-61b9-11eb-9612-666b813e85a6.png)
![Screen Shot 2021-01-29 at 5 38 32 PM](https://user-images.githubusercontent.com/2205926/106240743-ac26cc80-61b9-11eb-8e8c-6feacf6b5430.png)
![Screen Shot 2021-01-29 at 5 38 58 PM](https://user-images.githubusercontent.com/2205926/106240748-ad57f980-61b9-11eb-92ab-1093b60ef39d.png)


