### PR TITLE
Add a close X to the column metapanel

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -10,10 +10,13 @@ import {
   removeSelectedFeature,
   getCurrentColumnIsSelectedFeature,
   getCurrentColumnIsSelectedLabel,
-  getRangesByColumn
+  getRangesByColumn,
+  setCurrentColumn
 } from "../redux";
 import { ColumnTypes, styles } from "../constants.js";
 import Histogram from "react-chart-histogram";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 class ColumnInspector extends Component {
   static propTypes = {
@@ -24,7 +27,8 @@ class ColumnInspector extends Component {
     removeSelectedFeature: PropTypes.func.isRequired,
     currentColumnIsSelectedFeature: PropTypes.bool,
     currentColumnIsSelectedLabel: PropTypes.bool,
-    rangesByColumn: PropTypes.object
+    rangesByColumn: PropTypes.object,
+    setCurrentColumn: PropTypes.func
   };
 
   handleChangeDataType = (event, feature) => {
@@ -43,9 +47,14 @@ class ColumnInspector extends Component {
   removeLabel = () => {
     this.props.setLabelColumn(null);
   }
+
   removeFeature = () => {
     this.props.removeSelectedFeature(this.props.currentColumnData.id);
   };
+
+  onClose = () => {
+    this.props.setCurrentColumn(undefined);
+  }
 
   render() {
     const {
@@ -71,6 +80,9 @@ class ColumnInspector extends Component {
       <div id="column-inspector">
         {currentColumnData && (
           <div style={styles.validationMessagesLight}>
+            <div onClick={this.onClose} style={styles.popupClose}>
+              <FontAwesomeIcon icon={faTimes} />
+            </div>
 
             {currentColumnData.dataType === ColumnTypes.OTHER && (
               <div>
@@ -234,6 +246,9 @@ export default connect(
     },
     removeSelectedFeature(labelColumn) {
       dispatch(removeSelectedFeature(labelColumn));
+    },
+    setCurrentColumn(column) {
+      dispatch(setCurrentColumn(column));
     }
   })
 )(ColumnInspector);

--- a/src/UIComponents/SelectFeatures.jsx
+++ b/src/UIComponents/SelectFeatures.jsx
@@ -10,6 +10,8 @@ import {
   getSelectableLabels
 } from "../redux";
 import { styles } from "../constants";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 class SelectFeatures extends Component {
   static propTypes = {
@@ -54,8 +56,8 @@ class SelectFeatures extends Component {
         style={popupStyle}
       >
         <div style={{ width: "initial", ...styles.panel }}>
-          <div onClick={onClose} style={styles.selectFeaturesPopupClose}>
-            X
+          <div onClick={onClose} style={styles.popupClose}>
+            <FontAwesomeIcon icon={faTimes} />
           </div>
           {mode === "label" && showSelectLabels && (
             <form style={styles.panelContentLeft}>

--- a/src/constants.js
+++ b/src/constants.js
@@ -92,7 +92,7 @@ export const styles = {
     float: "left",
     marginLeft: 10,
     width: "calc(30% - 20px)",
-    padding: 10,
+    padding: 20,
     backgroundColor: "rgb(230,230,230)",
     border: "solid 1px black",
     borderRadius: 5,
@@ -100,7 +100,8 @@ export const styles = {
     fontSize: 18,
     boxSizing: "border-box",
     overflow: "scroll",
-    marginTop: 59
+    marginTop: 59,
+    position: "relative"
   },
 
   dataDisplayTable: {
@@ -270,14 +271,16 @@ export const styles = {
     color: "rgb(186, 168, 70)",
     border: "dotted 1px grey",
     paddingLeft: 4,
-    paddingRight: 4
+    paddingRight: 4,
+    cursor: "pointer"
   },
 
   statementFeature: {
     color: "rgb(70, 186, 168)",
     border: "dotted 1px grey",
     paddingLeft: 4,
-    paddingRight: 4
+    paddingRight: 4,
+    cursor: "pointer"
   },
 
   selectLabelPopup: {
@@ -290,9 +293,10 @@ export const styles = {
     marginLeft: 440
   },
 
-  selectFeaturesPopupClose: {
+  popupClose: {
     position: "absolute",
-    right: 20
+    right: 20,
+    cursor: "pointer"
   },
 
   selectLabelText: {


### PR DESCRIPTION
It deselects the current column and allows the user to see the CrossTab again.  Not sure if this is the right UI scheme but it's at least a bit easier.

#### With column selected:

![Screen Shot 2021-01-30 at 5 21 45 PM](https://user-images.githubusercontent.com/2205926/106349140-6b45bb00-6280-11eb-97d3-00d4b6022d25.png)

#### After pressing X:

![Screen Shot 2021-01-30 at 5 21 50 PM](https://user-images.githubusercontent.com/2205926/106349142-6e40ab80-6280-11eb-9fb7-6a774845a809.png)


