### PR TITLE
Raise the Previous/Next buttons

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -227,7 +227,7 @@ export const styles = {
   previousButton: {
     position: "fixed",
     left: 20,
-    bottom: 20,
+    bottom: 60,
     fontSize: 30,
     cursor: "pointer"
   },
@@ -235,7 +235,7 @@ export const styles = {
   nextButton: {
     position: "fixed",
     right: 20,
-    bottom: 20,
+    bottom: 60,
     fontSize: 30,
     cursor: "pointer"
   },


### PR DESCRIPTION
Just temporarily, so that level authors don't have the the Previous button hidden behind the Extra Links box.