### PR TITLE
Results improvements 

### DIFF
--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -69,8 +69,8 @@ class Results extends Component {
                     {this.props.selectedFeatures.map((feature, index) => {
                       return <th key={index}>{feature}</th>;
                     })}
-                    <th>Expected Label</th>
-                    <th>Predicted Label</th>
+                    <th>Expected Label: {this.props.labelColumn}</th>
+                    <th>Predicted Label: {this.props.labelColumn}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -28,59 +28,73 @@ class Results extends Component {
             {this.props.percentDataToReserve}% of the training data was reserved
             to test the accuracy of the newly trained model.
           </p>
+          {isNaN(this.props.summaryStat.stat) && (
+            <p>
+              An accuracy score was not calculated because no training data was
+              reserved for testing.
+            </p>
+          )}
           <div>
-            {this.props.summaryStat.type === MLTypes.REGRESSION && (
-              <div>
+            {this.props.summaryStat.type === MLTypes.REGRESSION &&
+              !isNaN(this.props.summaryStat.stat) && (
                 <div>
-                  The average difference between expected and predicted labels
-                  is:
+                  <div>
+                    The average difference between expected and predicted labels
+                    is:
+                  </div>
+                  <div style={styles.subPanel}>
+                    {this.props.summaryStat.stat}
+                  </div>
                 </div>
-                <div style={styles.subPanel}>{this.props.summaryStat.stat}</div>
-              </div>
-            )}
-            {this.props.summaryStat.type === MLTypes.CLASSIFICATION && (
-              <div>
-                <div style={styles.mediumText}>
-                  The calculated accuracy of this model is:
+              )}
+            {this.props.summaryStat.type === MLTypes.CLASSIFICATION &&
+              !isNaN(this.props.summaryStat.stat) && (
+                <div>
+                  <div style={styles.mediumText}>
+                    The calculated accuracy of this model is:
+                  </div>
+                  <div style={styles.subPanel}>
+                    {this.props.summaryStat.stat}%
+                  </div>
                 </div>
-                <div style={styles.subPanel}>
-                  {this.props.summaryStat.stat}%
-                </div>
-              </div>
-            )}
+              )}
             <br />
             <br />
           </div>
-          <div style={styles.subPanel}>
-            <table>
-              <thead>
-                <tr>
-                  {this.props.selectedFeatures.map((feature, index) => {
-                    return <th key={index}>{feature}</th>;
+          {!isNaN(this.props.summaryStat.stat) && (
+            <div style={styles.subPanel}>
+              <table>
+                <thead>
+                  <tr>
+                    {this.props.selectedFeatures.map((feature, index) => {
+                      return <th key={index}>{feature}</th>;
+                    })}
+                    <th>Expected Label</th>
+                    <th>Predicted Label</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {this.props.accuracyCheckExamples.map((examples, index) => {
+                    return (
+                      <tr key={index}>
+                        {examples.map((example, i) => {
+                          return <td key={i}>{example}</td>;
+                        })}
+                        <td>{this.props.accuracyCheckLabels[index]}</td>
+                        <td>
+                          {this.props.accuracyCheckPredictedLabels[index]}
+                        </td>
+                        {this.props.accuracyCheckLabels[index] ===
+                          this.props.accuracyCheckPredictedLabels[index] && (
+                          <td style={styles.ready}>&#x2713;</td>
+                        )}
+                      </tr>
+                    );
                   })}
-                  <th>Expected Label</th>
-                  <th>Predicted Label</th>
-                </tr>
-              </thead>
-              <tbody>
-                {this.props.accuracyCheckExamples.map((examples, index) => {
-                  return (
-                    <tr key={index}>
-                      {examples.map((example, i) => {
-                        return <td key={i}>{example}</td>;
-                      })}
-                      <td>{this.props.accuracyCheckLabels[index]}</td>
-                      <td>{this.props.accuracyCheckPredictedLabels[index]}</td>
-                      {this.props.accuracyCheckLabels[index] ===
-                        this.props.accuracyCheckPredictedLabels[index] && (
-                        <td style={styles.ready}>&#x2713;</td>
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/train.js
+++ b/src/train.js
@@ -180,13 +180,16 @@ const prepareTrainingData = () => {
     .map(row => extractLabel(updatedState, row))
     .filter(label => label !== undefined && label !== "" && !isNaN(label));
   /*
-  Randomly select 10% (default) of examples and corresponding labels from the training set to reserve for a post-training accuracy calculation. The accuracy check examples and labels are excluded from the training set when the model is trained and saved to state separately to test the model's accuracy.
+  Select X% of examples and corresponding labels from the training set to reserve for a post-training accuracy calculation. The accuracy check examples and labels are excluded from the training set when the model is trained and saved to state separately to test the model's accuracy.
   */
   const percent = updatedState.percentDataToReserve / 100;
   const numToReserve = parseInt(trainingExamples.length * percent);
   let accuracyCheckExamples = [];
   let accuracyCheckLabels = [];
-  if (updatedState.reserveLocation === TestDataLocations.BEGINNING) {
+  if (
+    updatedState.reserveLocation === TestDataLocations.BEGINNING &&
+    percent !== 0
+  ) {
     accuracyCheckExamples = trainingExamples.slice(numToReserve);
     accuracyCheckLabels = trainingLabels.slice(numToReserve);
   }


### PR DESCRIPTION
A few improvements to the Results panel: 

1.) There was a bug if you picked to reserve 0% of the training data from the beginning of the dataset testing, because `array.slice(0)` basically copies all elements in the array. Now we are correctly not reserving any testing data if the user selects 0%. 

2.) Furthermore, we now hide the results table if 0% of the training data was reserved, because there is nothing to show in the table. Instead we add an explanatory note. 
<img width="930" alt="Screen Shot 2021-02-15 at 5 30 53 PM" src="https://user-images.githubusercontent.com/12300669/108000108-22e40800-6fb7-11eb-8229-e70c010c42e7.png">

3.) Lastly, we're now stating in the results table which column is selected as the label. 
<img width="472" alt="Screen Shot 2021-02-15 at 6 00 03 PM" src="https://user-images.githubusercontent.com/12300669/108000827-d4376d80-6fb8-11eb-9f25-f0d261a53fa3.png">


