### PR TITLE
Extract ResultsTable as a sub-component

### DIFF
--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -8,6 +8,7 @@ import {
   getSummaryStat
 } from "../redux";
 import { styles, MLTypes } from "../constants";
+import ResultsTable from "./ResultsTable";
 
 class Results extends Component {
   static propTypes = {
@@ -61,40 +62,7 @@ class Results extends Component {
             <br />
             <br />
           </div>
-          {!isNaN(this.props.summaryStat.stat) && (
-            <div style={styles.subPanel}>
-              <table>
-                <thead>
-                  <tr>
-                    {this.props.selectedFeatures.map((feature, index) => {
-                      return <th key={index}>{feature}</th>;
-                    })}
-                    <th>Expected Label: {this.props.labelColumn}</th>
-                    <th>Predicted Label: {this.props.labelColumn}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {this.props.accuracyCheckExamples.map((examples, index) => {
-                    return (
-                      <tr key={index}>
-                        {examples.map((example, i) => {
-                          return <td key={i}>{example}</td>;
-                        })}
-                        <td>{this.props.accuracyCheckLabels[index]}</td>
-                        <td>
-                          {this.props.accuracyCheckPredictedLabels[index]}
-                        </td>
-                        {this.props.accuracyCheckLabels[index] ===
-                          this.props.accuracyCheckPredictedLabels[index] && (
-                          <td style={styles.ready}>&#x2713;</td>
-                        )}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
+          {!isNaN(this.props.summaryStat.stat) && <ResultsTable />}
         </div>
       </div>
     );

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -1,0 +1,107 @@
+/* React component to handle displaying test data and A.I. Bot's guesses. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import {
+  getConvertedAccuracyCheckExamples,
+  getConvertedLabels,
+  getSummaryStat
+} from "../redux";
+import { styles, colors, MLTypes } from "../constants";
+
+class ResultsTable extends Component {
+  static propTypes = {
+    selectedFeatures: PropTypes.array,
+    labelColumn: PropTypes.string,
+    accuracyCheckExamples: PropTypes.array,
+    accuracyCheckLabels: PropTypes.array,
+    accuracyCheckPredictedLabels: PropTypes.array
+  };
+
+  render() {
+    return (
+      <div>
+        <div style={styles.floatLeft}>
+          <span style={styles.largeText}>Features</span>
+          <table>
+            <thead>
+              <tr style={{ backgroundColor: colors.feature }}>
+                {this.props.selectedFeatures.map((feature, index) => {
+                  return <th key={index}>{feature}</th>;
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {this.props.accuracyCheckExamples.map((examples, index) => {
+                return (
+                  <tr key={index}>
+                    {examples.map((example, i) => {
+                      return <td key={i}>{example}</td>;
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div style={styles.floatLeft}>
+          <span style={styles.largeText}>{"A.I. Bot's Guess"}</span>
+          <table>
+            <thead>
+              <tr style={{ backgroundColor: colors.label }}>
+                <th>{this.props.labelColumn}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.props.accuracyCheckExamples.map((examples, index) => {
+                return (
+                  <tr key={index}>
+                    <td>{this.props.accuracyCheckPredictedLabels[index]}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div style={styles.floatLeft}>
+          <span style={styles.largeText}>{"Actual"}</span>
+          <table>
+            <thead>
+              <tr style={{ backgroundColor: colors.label }}>
+                <th>{this.props.labelColumn}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.props.accuracyCheckExamples.map((examples, index) => {
+                return (
+                  <tr key={index}>
+                    <td>{this.props.accuracyCheckLabels[index]}</td>
+                    {this.props.accuracyCheckLabels[index] ===
+                      this.props.accuracyCheckPredictedLabels[index] && (
+                      <td style={styles.ready}>&#x2713;</td>
+                    )}
+                    {this.props.accuracyCheckLabels[index] !==
+                      this.props.accuracyCheckPredictedLabels[index] && (
+                      <td style={styles.error}>&#10006;</td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default connect(state => ({
+  selectedFeatures: state.selectedFeatures,
+  labelColumn: state.labelColumn,
+  accuracyCheckExamples: getConvertedAccuracyCheckExamples(state),
+  accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
+  accuracyCheckPredictedLabels: getConvertedLabels(
+    state,
+    state.accuracyCheckPredictedLabels
+  )
+}))(ResultsTable);

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -4,10 +4,9 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import {
   getConvertedAccuracyCheckExamples,
-  getConvertedLabels,
-  getSummaryStat
+  getConvertedLabels
 } from "../redux";
-import { styles, colors, MLTypes } from "../constants";
+import { styles, colors } from "../constants";
 
 class ResultsTable extends Component {
   static propTypes = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,11 @@ export const TestDataLocations = {
   RANDOM: "random"
 };
 
+export const colors = {
+  feature: "rgb(70, 186, 168)",
+  label: "rgb(186, 168, 70)"
+};
+
 export const styles = {
   app: {
     userSelect: "none"
@@ -183,12 +188,10 @@ export const styles = {
     backgroundColor: "rgb(70, 186, 168)"
   },
   dataDisplayCellUnselected: {},
-
   tabContainer: {
     overflow: "hidden",
     marginTop: 10
   },
-
   crossTabCell0: {
     backgroundColor: "rgba(255,100,100, 0)"
   },
@@ -314,5 +317,10 @@ export const styles = {
 
   selectFeaturesText: {
     color: "rgb(70, 186, 168)"
+  },
+
+  floatLeft: {
+    float: "left",
+    margin: 20
   }
 };


### PR DESCRIPTION
Initial improvements to the Results table. 

UI improvement: 
- Features are grouped and colored to match other references to features throughout the flow. 
- Predicted column and Actual column flip in order since A.I. Bot makes its guess, _then_ we check if it's correct or not 
- Clearer column labeling and slightly better spacing 
- Added an X when A.I. Bot's guess is wrong 

Code improvements: 
- Extracted the ResultsTable into it's own component 
- Started a colors constant to track feature and label colors

Before: 
<img width="814" alt="Screen Shot 2021-02-22 at 3 12 53 PM" src="https://user-images.githubusercontent.com/12300669/108766230-e36f6b80-7522-11eb-9a96-821fb1cc9579.png">

After: 
<img width="697" alt="Screen Shot 2021-02-22 at 3 20 15 PM" src="https://user-images.githubusercontent.com/12300669/108766212-db173080-7522-11eb-9194-c3d1b48af3ff.png">