### PR TITLE
Revise accuracy calculation for regression

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -715,23 +715,6 @@ export function getCompatibleTrainers(state) {
   return compatibleTrainers;
 }
 
-function getSum(total, num) {
-  return total + num;
-}
-
-function getAverageDiff(state) {
-  let diffs = [];
-  const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
-  for (let i = 0; i < numPredictedLabels; i++) {
-    diffs.push(
-      Math.abs(
-        state.accuracyCheckLabels[i] - state.accuracyCheckPredictedLabels[i]
-      )
-    );
-  }
-  return (diffs.reduce(getSum, 0) / numPredictedLabels).toFixed(2);
-}
-
 export function getAccuracyClassification(state) {
   let numCorrect = 0;
   const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
@@ -747,8 +730,20 @@ export function getAccuracyClassification(state) {
 }
 
 export function getAccuracyRegression(state) {
-  let range = getRange(state, state.labelColumn);
-  return getAverageDiff(state) / (range.max - range.min);
+  let numCorrect = 0;
+  const maxMin = getRange(state, state.labelColumn);
+  const range = Math.abs(maxMin.max - maxMin.min);
+  const errorTolerance = range * 0.03;
+  const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
+  for (let i = 0; i < numPredictedLabels; i++) {
+    const diff = Math.abs(
+      state.accuracyCheckLabels[i] - state.accuracyCheckPredictedLabels[i]
+    );
+    if (diff <= errorTolerance) {
+      numCorrect++;
+    }
+  }
+  return ((numCorrect / numPredictedLabels) * 100).toFixed(2);
 }
 
 export function getSummaryStat(state) {

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,4 +1,8 @@
-import { getOptionFrequenciesByColumn } from "../../src/redux.js";
+import {
+  getOptionFrequenciesByColumn,
+  getRange,
+  getAccuracyRegression
+} from "../../src/redux.js";
 
 const initialState = {
   data: [
@@ -54,6 +58,38 @@ const initialState = {
   }
 };
 
+const resultsState = {
+  data: [
+    {
+      sun: "high",
+      height: 3.8
+    },
+    {
+      sun: "high",
+      height: 3.9
+    },
+    {
+      sun: "medium",
+      height: 2.6
+    },
+    {
+      sun: "medium",
+      height: 2.5
+    },
+    {
+      sun: "low",
+      height: 0.9
+    },
+    {
+      sun: "low",
+      height: 1.6
+    }
+  ],
+  labelColumn: "height",
+  accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
+  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9]
+};
+
 describe("redux functions", () => {
   test("getOptionFrequenciesByColumn", async () => {
     const frequencies = getOptionFrequenciesByColumn(initialState);
@@ -63,5 +99,14 @@ describe("redux functions", () => {
     expect(frequencies["nuts"]["no"]).toBe(3);
     expect(frequencies["delicious"]["yes"]).toBe(5);
     expect(frequencies["delicious"]["no"]).toBe(1);
+  });
+
+  test("getAccuracyRegression", async () => {
+    const maxMin = getRange(resultsState, resultsState.labelColumn);
+    const range = Math.abs(maxMin.max - maxMin.min);
+    expect(range).toBe(3);
+    const score = getAccuracyRegression(resultsState);
+    // error tolerance of +/- 0.09, 4/6 correct
+    expect(score).toBe("66.67");
   });
 });


### PR DESCRIPTION
Previously we were calculating the accuracy score for regression results as a measure of the average difference between expected and predicted labels. While this is a reasonable and valid way to calculate the accuracy of a regression model, it proved difficult to reason about in the context of the curriculum. In this old paradigm lower accuracy scores meant less distance from expected and therefore more accurate - lower numbers were good. In comparison, the accuracy scores for classification models are simple % correct calculation, wherein high percentage indicts high accurate - bigger numbers are good. To alleviate this discrepancy, I modified the way we calculate accuracy for regression models per conversations with the Curriculum team. 

Now, we find 3% of the total range for a continuous label column and use that number to calculate a window into which the predicted label can fall to be considered correct. For example, in the test data: 

```
label column range = 3.9-0.9 => 3 
3% of 3  => 0.9
each predicted label that falls within expected +/- 0.9 counts as "correct" 
4/6 are correct => 66.67% accuracy
```  
