### PR TITLE
CrossTab changes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -143,8 +143,12 @@ class App extends Component {
               <DataDisplay />
             </ContainerLeft>
             <ContainerRight>
-              <ColumnInspector />
-              <CrossTab />
+              {currentPanel === "dataDisplayLabel" && (
+                <ColumnInspector />
+              )}
+              {currentPanel === "dataDisplayFeatures" && (
+                <CrossTab />
+              )}
             </ContainerRight>
           </BodyContainer>
         )}

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -23,7 +23,7 @@ class CrossTab extends Component {
   render() {
     const { currentColumn, crossTabData } = this.props;
 
-    return !currentColumn && crossTabData && (
+    return currentColumn !== undefined && crossTabData !== undefined && (
       <div id="cross-tab" style={{...styles.panel, ...styles.rightPanel}}>
         <div style={styles.largeText}>Correlation Information</div>
         <div style={styles.scrollableContents}>
@@ -89,5 +89,5 @@ class CrossTab extends Component {
 
 export default connect(state => ({
   currentColumn: state.currentColumn,
-  crossTabData: getCrossTabData(state)
+  crossTabData: state.currentColumn && getCrossTabData(state)
 }))(CrossTab);

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -10,7 +10,6 @@ import { styles } from "../constants.js";
 
 class CrossTab extends Component {
   static propTypes = {
-    currentColumn: PropTypes.string,
     crossTabData: PropTypes.object
   };
 
@@ -21,73 +20,74 @@ class CrossTab extends Component {
     };
   };
   render() {
-    const { currentColumn, crossTabData } = this.props;
+    const { crossTabData } = this.props;
 
-    return currentColumn !== undefined && crossTabData !== undefined && (
-      <div id="cross-tab" style={{...styles.panel, ...styles.rightPanel}}>
-        <div style={styles.largeText}>Correlation Information</div>
-        <div style={styles.scrollableContents}>
-          <div style={styles.scrollingContents}>
-            <table>
-              <thead>
-                <tr>
-                  <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
-                  <th colSpan={crossTabData.uniqueLabelValues.length}>
-                    {crossTabData.labelName}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  {crossTabData.featureNames.map((featureName, index) => {
-                    return <td key={index}>{featureName}</td>;
+    return (
+      crossTabData && (
+        <div id="cross-tab" style={{ ...styles.panel, ...styles.rightPanel }}>
+          <div style={styles.largeText}>Correlation Information</div>
+          <div style={styles.scrollableContents}>
+            <div style={styles.scrollingContents}>
+              <table>
+                <thead>
+                  <tr>
+                    <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
+                    <th colSpan={crossTabData.uniqueLabelValues.length}>
+                      {crossTabData.labelName}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    {crossTabData.featureNames.map((featureName, index) => {
+                      return <td key={index}>{featureName}</td>;
+                    })}
+
+                    {crossTabData.uniqueLabelValues.map(
+                      (uniqueLabelValue, index) => {
+                        return (
+                          <td key={index} style={styles.dataDisplayCell}>
+                            {uniqueLabelValue}
+                          </td>
+                        );
+                      }
+                    )}
+                  </tr>
+                  {crossTabData.results.map((result, resultIndex) => {
+                    return (
+                      <tr key={resultIndex}>
+                        {result.featureValues.map(
+                          (featureValue, featureIndex) => {
+                            return <td key={featureIndex}>{featureValue}</td>;
+                          }
+                        )}
+                        {crossTabData.uniqueLabelValues.map(
+                          (uniqueLabelValue, labelIndex) => {
+                            return (
+                              <td
+                                key={labelIndex}
+                                style={this.getCellStyle(
+                                  result.labelPercents[uniqueLabelValue]
+                                )}
+                              >
+                                {result.labelPercents[uniqueLabelValue] || 0}%
+                              </td>
+                            );
+                          }
+                        )}
+                      </tr>
+                    );
                   })}
-
-                  {crossTabData.uniqueLabelValues.map(
-                    (uniqueLabelValue, index) => {
-                      return (
-                        <td key={index} style={styles.dataDisplayCell}>
-                          {uniqueLabelValue}
-                        </td>
-                      );
-                    }
-                  )}
-                </tr>
-                {crossTabData.results.map((result, resultIndex) => {
-                  return (
-                    <tr key={resultIndex}>
-                      {result.featureValues.map(
-                        (featureValue, featureIndex) => {
-                          return <td key={featureIndex}>{featureValue}</td>;
-                        }
-                      )}
-                      {crossTabData.uniqueLabelValues.map(
-                        (uniqueLabelValue, labelIndex) => {
-                          return (
-                            <td
-                              key={labelIndex}
-                              style={this.getCellStyle(
-                                result.labelPercents[uniqueLabelValue]
-                              )}
-                            >
-                              {result.labelPercents[uniqueLabelValue] || 0}%
-                            </td>
-                          );
-                        }
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
-      </div>
+      )
     );
   }
 }
 
 export default connect(state => ({
-  currentColumn: state.currentColumn,
-  crossTabData: state.currentColumn && getCrossTabData(state)
+  crossTabData: getCrossTabData(state)
 }))(CrossTab);

--- a/src/redux.js
+++ b/src/redux.js
@@ -1074,7 +1074,14 @@ export function getPanelButtons(state) {
  */
 
 export function getCrossTabData(state) {
-  if (!state.labelColumn || state.selectedFeatures.length <= 0) {
+  if (!state.labelColumn || !state.currentColumn) {
+    return null;
+  }
+
+  if (
+    state.columnsByDataType[state.labelColumn] !== ColumnTypes.CATEGORICAL ||
+    state.columnsByDataType[state.currentColumn] !== ColumnTypes.CATEGORICAL
+  ) {
     return null;
   }
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -469,14 +469,14 @@ export default function rootReducer(state = initialState, action) {
           ...state,
           selectedFeatures: state.selectedFeatures.filter(
             item => item !== action.currentColumn
-          )
-          //currentColumn: undefined
+          ),
+          currentColumn: undefined
         };
       } else {
         return {
           ...state,
-          selectedFeatures: [...state.selectedFeatures, action.currentColumn]
-          //currentColumn: action.currentColumn
+          selectedFeatures: [...state.selectedFeatures, action.currentColumn],
+          currentColumn: action.currentColumn
         };
       }
     }
@@ -1087,9 +1087,7 @@ export function getCrossTabData(state) {
 
   for (let row of state.data) {
     var featureValues = [];
-    for (let selectedFeature of state.selectedFeatures) {
-      featureValues.push(row[selectedFeature]);
-    }
+    featureValues.push(row[state.currentColumn]);
 
     var existingEntry = results.find(result => {
       return areArraysEqual(result.featureValues, featureValues);
@@ -1134,7 +1132,7 @@ export function getCrossTabData(state) {
   return {
     results,
     uniqueLabelValues,
-    featureNames: state.selectedFeatures,
+    featureNames: [state.currentColumn],
     labelName: state.labelColumn
   };
 }


### PR DESCRIPTION
It was recently decided that the CrossTab would only show results for the current label and one feature, rather than all the selected features.  Until we have a UI that more easily supports a new modality of choosing this column pairing, a quick way to enable this is to show the CrossTab for the current label and the last-selected feature.

The CrossTab also now only shows when both the current label and the last-selected feature are both categorical.
