### PR TITLE
Enable buttons conditionally

### DIFF
--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -7,10 +7,7 @@ import {
   setSelectedCSV,
   setSelectedJSON,
   resetState,
-  setColumnsByDataType,
-  setLabelColumn,
-  getSpecifiedDatasets,
-  setSelectedTrainer
+  getSpecifiedDatasets
 } from "../redux";
 import { parseCSV } from "../csvReaderWrapper";
 import { parseJSON } from "../jsonReaderWrapper";
@@ -22,9 +19,6 @@ class SelectDataset extends Component {
     setSelectedName: PropTypes.func.isRequired,
     setSelectedCSV: PropTypes.func.isRequired,
     setSelectedJSON: PropTypes.func.isRequired,
-    setColumnsByDataType: PropTypes.func.isRequired,
-    setLabelColumn: PropTypes.func.isRequired,
-    setSelectedTrainer: PropTypes.func.isRequired,
     csvfile: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     jsonfile: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     resetState: PropTypes.func.isRequired,
@@ -168,15 +162,6 @@ export default connect(
     },
     setSelectedJSON(jsonfilePath) {
       dispatch(setSelectedJSON(jsonfilePath));
-    },
-    setColumnsByDataType(column, dataType) {
-      dispatch(setColumnsByDataType(column, dataType));
-    },
-    setLabelColumn(labelColumn) {
-      dispatch(setLabelColumn(labelColumn));
-    },
-    setSelectedTrainer(selectedTrainer) {
-      dispatch(setSelectedTrainer(selectedTrainer));
     }
   })
 )(SelectDataset);

--- a/src/constants.js
+++ b/src/constants.js
@@ -64,7 +64,7 @@ export const styles = {
 
   panelContainerRight: {
     marginLeft: 10,
-    width: "calc(30% - 20px)"
+    width: "calc(30% - 10px)"
   },
 
   panelContainerFullWidth: {

--- a/src/redux.js
+++ b/src/redux.js
@@ -934,6 +934,12 @@ function isPanelEnabled(state, panelId) {
     }
   }
 
+  if (panelId === "specifyColumns") {
+    if (state.data.length === 0) {
+      return false;
+    }
+  }
+
   if (panelId === "dataDisplayLabel") {
     if (state.data.length === 0) {
       return false;
@@ -960,6 +966,9 @@ function isPanelEnabled(state, panelId) {
 
   if (panelId === "selectTrainer") {
     if (mode && mode.hideSelectTrainer && mode.hideChooseReserve) {
+      return false;
+    }
+    if (!uniqLabelFeaturesSelected(state)) {
       return false;
     }
   }


### PR DESCRIPTION
Only enable continue from SelectDataset when a dataset has been selected.

And only enable continue into SelectTrainer when a label and feature have been selected.