### PR TITLE
Better table scrolling

### DIFF
--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -58,7 +58,7 @@ class DataDisplay extends Component {
       }
     }
 
-    return {...style, ...styles.dataDisplayHeader};
+    return { ...style, ...styles.dataDisplayHeader };
   };
 
   getColumnCellStyle = key => {
@@ -82,7 +82,7 @@ class DataDisplay extends Component {
       }
     }
 
-    return {...style, ...styles.dataDisplayCell};
+    return { ...style, ...styles.dataDisplayCell };
   };
 
   render() {
@@ -92,18 +92,14 @@ class DataDisplay extends Component {
       <div id="data-display" style={styles.panel}>
         <div style={styles.statement}>
           Predict{" "}
-          <span
-            style={styles.statementLabel}
-          >
+          <span style={styles.statementLabel}>
             {this.props.labelColumn || "..."}
           </span>
           {currentPanel === "dataDisplayFeatures" && (
             <span>
               {" "}
               based on{" "}
-              <span
-                style={styles.statementFeature}
-              >
+              <span style={styles.statementFeature}>
                 {this.props.selectedFeatures.length > 0
                   ? this.props.selectedFeatures.join(", ")
                   : ".."}
@@ -112,55 +108,49 @@ class DataDisplay extends Component {
             </span>
           )}
         </div>
-        <div style={styles.scrollableContents}>
-          <div style={styles.scrollingContents}>
-            {this.state.showRawData && (
-              <div >
-                <div style={styles.finePrint}>
-                  <table style={styles.dataDisplayTable}>
-                    <thead>
-                      <tr>
+        {this.state.showRawData && (
+          <div style={styles.tableParent}>
+            <table style={styles.dataDisplayTable}>
+              <thead>
+                <tr>
+                  {data.length > 0 &&
+                    Object.keys(data[0]).map(key => {
+                      return (
+                        <th
+                          key={key}
+                          style={this.getColumnHeaderStyle(key)}
+                          onClick={() => setCurrentColumn(key)}
+                        >
+                          {key}
+                        </th>
+                      );
+                    })}
+                </tr>
+              </thead>
+              <tbody>
+                {data.length > 0 &&
+                  data.map((row, index) => {
+                    return (
+                      <tr key={index}>
                         {data.length > 0 &&
-                          Object.keys(data[0]).map(key => {
+                          Object.keys(row).map(key => {
                             return (
-                              <th
+                              <td
                                 key={key}
-                                style={this.getColumnHeaderStyle(key)}
+                                style={this.getColumnCellStyle(key)}
                                 onClick={() => setCurrentColumn(key)}
                               >
-                                {key}
-                              </th>
+                                {row[key]}
+                              </td>
                             );
                           })}
                       </tr>
-                    </thead>
-                    <tbody>
-                      {data.length > 0 &&
-                        data.map((row, index) => {
-                          return (
-                            <tr key={index}>
-                              {data.length > 0 &&
-                                Object.keys(row).map(key => {
-                                  return (
-                                    <td
-                                      key={key}
-                                      style={this.getColumnCellStyle(key)}
-                                      onClick={() => setCurrentColumn(key)}
-                                    >
-                                      {row[key]}
-                                    </td>
-                                  );
-                                })}
-                            </tr>
-                          );
-                        })}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            )}
+                    );
+                  })}
+              </tbody>
+            </table>
           </div>
-        </div>
+        )}
         {!this.state.showRawData && (
           <button type="button" onClick={this.toggleRawData}>
             show data

--- a/src/constants.js
+++ b/src/constants.js
@@ -194,11 +194,10 @@ export const styles = {
     width: "100%"
   },
 
-  finePrint: {
+  tableParent: {
     overflow: "scroll",
     overflowWrap: "break-word",
     fontSize: 10,
-    padding: 10,
     boxSizing: "border-box",
     borderRadius: 5,
     backgroundColor: "white"
@@ -206,7 +205,9 @@ export const styles = {
 
   dataDisplayHeader: {
     paddingLeft: 20,
-    textAlign: "right"
+    textAlign: "right",
+    position: "sticky",
+    top: 0
   },
   dataDisplayHeaderLabelSelected: {
     backgroundColor: labelColor,


### PR DESCRIPTION
The DataDisplay table had its vertical and horizontal scrolling handled by different layers of the DOM, resulting in two sets of scrollbars (when the operating system/browser was set to show them).  This fixes things so that the scrolling is all handled by the same layer.

The table also now gets sticky headers which makes for better data perusal.

### before

![Screen Shot 2021-03-04 at 8 17 22 PM](https://user-images.githubusercontent.com/2205926/109941421-01a63b80-7c88-11eb-84c0-6161022fd244.png)

### after

![Screen Shot 2021-03-04 at 8 32 40 PM](https://user-images.githubusercontent.com/2205926/109942985-8f365b00-7c89-11eb-9ff0-6b17eb6bfe9b.png)

