### PR TITLE
Regression results icons

### DIFF
--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -6,7 +6,7 @@ import {
   getConvertedAccuracyCheckExamples,
   getConvertedLabels,
   getSummaryStat,
-  setResultsPhase,
+  setResultsPhase
 } from "../redux";
 import { styles, MLTypes } from "../constants";
 import aiBotHead from "@public/images/ai-bot/ai-bot-head.png";
@@ -23,7 +23,7 @@ class Results extends Component {
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array,
     resultsPhase: PropTypes.number,
-    setResultsPhase: PropTypes.func,
+    setResultsPhase: PropTypes.func
   };
 
   componentDidMount() {
@@ -45,12 +45,12 @@ class Results extends Component {
         <div style={styles.largeText}>Results</div>
 
         {this.props.resultsPhase === 0 && (
-          <div style={{...styles.trainBot, margin: '0 auto'}}>
+          <div style={{ ...styles.trainBot, margin: "0 auto" }}>
             <img
               src={aiBotHead}
               style={{
                 ...styles.trainBotHead,
-                ...(false && styles.trainBotOpen),
+                ...(false && styles.trainBotOpen)
               }}
             />
             <img src={aiBotBody} style={styles.trainBotBody} />
@@ -99,7 +99,7 @@ class Results extends Component {
 }
 
 export default connect(
-  (state) => ({
+  state => ({
     selectedFeatures: state.selectedFeatures,
     labelColumn: state.labelColumn,
     summaryStat: getSummaryStat(state),
@@ -110,11 +110,11 @@ export default connect(
       state.accuracyCheckPredictedLabels
     ),
     percentDataToReserve: state.percentDataToReserve,
-    resultsPhase: state.resultsPhase,
+    resultsPhase: state.resultsPhase
   }),
-  (dispatch) => ({
+  dispatch => ({
     setResultsPhase(phase) {
       dispatch(setResultsPhase(phase));
-    },
+    }
   })
 )(Results);

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -8,7 +8,7 @@ import {
   getSummaryStat,
   setResultsPhase
 } from "../redux";
-import { styles, MLTypes } from "../constants";
+import { styles } from "../constants";
 import aiBotHead from "@public/images/ai-bot/ai-bot-head.png";
 import aiBotBody from "@public/images/ai-bot/ai-bot-body.png";
 import ResultsTable from "./ResultsTable";

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -6,7 +6,7 @@ import {
   getConvertedAccuracyCheckExamples,
   getConvertedLabels,
   getSummaryStat,
-  setResultsPhase
+  setResultsPhase,
 } from "../redux";
 import { styles, MLTypes } from "../constants";
 import aiBotHead from "@public/images/ai-bot/ai-bot-head.png";
@@ -23,7 +23,7 @@ class Results extends Component {
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array,
     resultsPhase: PropTypes.number,
-    setResultsPhase: PropTypes.func
+    setResultsPhase: PropTypes.func,
   };
 
   componentDidMount() {
@@ -50,7 +50,7 @@ class Results extends Component {
               src={aiBotHead}
               style={{
                 ...styles.trainBotHead,
-                ...(false && styles.trainBotOpen)
+                ...(false && styles.trainBotOpen),
               }}
             />
             <img src={aiBotBody} style={styles.trainBotBody} />
@@ -81,29 +81,16 @@ class Results extends Component {
             </p>
           )}
           <div>
-            {this.props.summaryStat.type === MLTypes.REGRESSION &&
-              !isNaN(this.props.summaryStat.stat) && (
-                <div>
-                  <div>
-                    The average difference between expected and predicted labels
-                    is:
-                  </div>
-                  <div style={styles.contents}>
-                    {this.props.summaryStat.stat}
-                  </div>
+            {!isNaN(this.props.summaryStat.stat) && (
+              <div>
+                <div style={styles.mediumText}>
+                  The calculated accuracy of this model is:
                 </div>
-              )}
-            {this.props.summaryStat.type === MLTypes.CLASSIFICATION &&
-              !isNaN(this.props.summaryStat.stat) && (
-                <div>
-                  <div style={styles.mediumText}>
-                    The calculated accuracy of this model is:
-                  </div>
-                  <div style={styles.contents}>
-                    {this.props.summaryStat.stat}%
-                  </div>
+                <div style={styles.contents}>
+                  {this.props.summaryStat.stat}%
                 </div>
-              )}
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -112,7 +99,7 @@ class Results extends Component {
 }
 
 export default connect(
-  state => ({
+  (state) => ({
     selectedFeatures: state.selectedFeatures,
     labelColumn: state.labelColumn,
     summaryStat: getSummaryStat(state),
@@ -123,11 +110,11 @@ export default connect(
       state.accuracyCheckPredictedLabels
     ),
     percentDataToReserve: state.percentDataToReserve,
-    resultsPhase: state.resultsPhase
+    resultsPhase: state.resultsPhase,
   }),
-  dispatch => ({
+  (dispatch) => ({
     setResultsPhase(phase) {
       dispatch(setResultsPhase(phase));
-    }
+    },
   })
 )(Results);

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -4,9 +4,11 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import {
   getConvertedAccuracyCheckExamples,
-  getConvertedLabels
+  getConvertedLabels,
+  getAccuracyGrades,
+  isRegression,
 } from "../redux";
-import { styles, colors } from "../constants";
+import { styles, colors, ResultsGrades } from "../constants";
 
 class ResultsTable extends Component {
   static propTypes = {
@@ -14,87 +16,76 @@ class ResultsTable extends Component {
     labelColumn: PropTypes.string,
     accuracyCheckExamples: PropTypes.array,
     accuracyCheckLabels: PropTypes.array,
-    accuracyCheckPredictedLabels: PropTypes.array
+    accuracyCheckPredictedLabels: PropTypes.array,
+    acccuracyGrades: PropTypes.array,
+    isRegression: PropTypes.bool,
   };
 
   render() {
+    const featureCount = this.props.selectedFeatures.length;
+
     return (
-      <div>
-        <div style={styles.floatLeft}>
-          <span style={styles.largeText}>Features</span>
-          <table>
-            <thead>
-              <tr style={{ backgroundColor: colors.feature }}>
-                {this.props.selectedFeatures.map((feature, index) => {
-                  return <th key={index}>{feature}</th>;
-                })}
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.accuracyCheckExamples.map((examples, index) => {
+      <div style={styles.scrollableContents}>
+        <table>
+          <thead>
+            <tr>
+              <th colSpan={featureCount} style={styles.largeText}>
+                Features
+              </th>
+              <th>
+                <span style={styles.largeText}>{"A.I. Bot's Guess"}</span>
+              </th>
+              <th>
+                <span style={styles.largeText}>{"Actual"}</span>
+                {this.props.isRegression && (
+                  <div style={styles.smallText}>{"+/- 3% of range"}</div>
+                )}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              {this.props.selectedFeatures.map((feature, index) => {
                 return (
-                  <tr key={index}>
-                    {examples.map((example, i) => {
-                      return <td key={i}>{example}</td>;
-                    })}
-                  </tr>
+                  <td style={{ backgroundColor: colors.feature }} key={index}>
+                    {feature}
+                  </td>
                 );
               })}
-            </tbody>
-          </table>
-        </div>
-        <div style={styles.floatLeft}>
-          <span style={styles.largeText}>{"A.I. Bot's Guess"}</span>
-          <table>
-            <thead>
-              <tr style={{ backgroundColor: colors.label }}>
-                <th>{this.props.labelColumn}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.accuracyCheckExamples.map((examples, index) => {
-                return (
-                  <tr key={index}>
-                    <td>{this.props.accuracyCheckPredictedLabels[index]}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-        <div style={styles.floatLeft}>
-          <span style={styles.largeText}>{"Actual"}</span>
-          <table>
-            <thead>
-              <tr style={{ backgroundColor: colors.label }}>
-                <th>{this.props.labelColumn}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.accuracyCheckExamples.map((examples, index) => {
-                return (
-                  <tr key={index}>
-                    <td>{this.props.accuracyCheckLabels[index]}</td>
-                    {this.props.accuracyCheckLabels[index] ===
-                      this.props.accuracyCheckPredictedLabels[index] && (
-                      <td style={styles.ready}>&#x2713;</td>
-                    )}
-                    {this.props.accuracyCheckLabels[index] !==
-                      this.props.accuracyCheckPredictedLabels[index] && (
-                      <td style={styles.error}>&#10006;</td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+              <td style={{ backgroundColor: colors.label }}>
+                {this.props.labelColumn}
+              </td>
+              <td style={{ backgroundColor: colors.label }}>
+                {this.props.labelColumn}
+              </td>
+            </tr>
+            {this.props.accuracyCheckExamples.map((examples, index) => {
+              return (
+                <tr key={index}>
+                  {examples.map((example, i) => {
+                    return <td key={i}>{example}</td>;
+                  })}
+                  <td>{this.props.accuracyCheckPredictedLabels[index]}</td>
+                  <td>{this.props.accuracyCheckLabels[index]}</td>
+                  {this.props.acccuracyGrades[index] ===
+                    ResultsGrades.CORRECT && (
+                    <td style={styles.ready}>&#x2713;</td>
+                  )}
+                  {this.props.acccuracyGrades[index] ===
+                    ResultsGrades.INCORRECT && (
+                    <td style={styles.error}>&#10006;</td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
     );
   }
 }
 
-export default connect(state => ({
+export default connect((state) => ({
   selectedFeatures: state.selectedFeatures,
   labelColumn: state.labelColumn,
   accuracyCheckExamples: getConvertedAccuracyCheckExamples(state),
@@ -102,5 +93,7 @@ export default connect(state => ({
   accuracyCheckPredictedLabels: getConvertedLabels(
     state,
     state.accuracyCheckPredictedLabels
-  )
+  ),
+  acccuracyGrades: getAccuracyGrades(state),
+  isRegression: isRegression(state),
 }))(ResultsTable);

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -6,7 +6,7 @@ import {
   getConvertedAccuracyCheckExamples,
   getConvertedLabels,
   getAccuracyGrades,
-  isRegression,
+  isRegression
 } from "../redux";
 import { styles, colors, ResultsGrades } from "../constants";
 
@@ -18,7 +18,7 @@ class ResultsTable extends Component {
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array,
     acccuracyGrades: PropTypes.array,
-    isRegression: PropTypes.bool,
+    isRegression: PropTypes.bool
   };
 
   render() {
@@ -85,7 +85,7 @@ class ResultsTable extends Component {
   }
 }
 
-export default connect((state) => ({
+export default connect(state => ({
   selectedFeatures: state.selectedFeatures,
   labelColumn: state.labelColumn,
   accuracyCheckExamples: getConvertedAccuracyCheckExamples(state),
@@ -95,5 +95,5 @@ export default connect((state) => ({
     state.accuracyCheckPredictedLabels
   ),
   acccuracyGrades: getAccuracyGrades(state),
-  isRegression: isRegression(state),
+  isRegression: isRegression(state)
 }))(ResultsTable);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,12 +1,17 @@
 export const ColumnTypes = {
   CATEGORICAL: "categorical",
   CONTINUOUS: "continuous",
-  OTHER: "other"
+  OTHER: "other",
 };
 
 export const MLTypes = {
   CLASSIFICATION: "classification",
-  REGRESSION: "regression"
+  REGRESSION: "regression",
+};
+
+export const ResultsGrades = {
+  CORRECT: "correct",
+  INCORRECT: "incorrect",
 };
 
 export const TEST_DATA_PERCENTS = [0, 5, 10, 15, 20];
@@ -14,13 +19,13 @@ export const TEST_DATA_PERCENTS = [0, 5, 10, 15, 20];
 export const TestDataLocations = {
   BEGINNING: "beginning",
   END: "end",
-  RANDOM: "random"
+  RANDOM: "random",
 };
 
 export const saveMessages = {
   success: "Your model was saved!",
   failure: "There was an error. Your model did not save.",
-  name: "Please name your model."
+  name: "Please name your model.",
 };
 
 const labelColor = "rgb(254, 96, 3)"; // was 186
@@ -29,25 +34,25 @@ const featureColor = "rgb(75, 155, 213)";
 
 export const colors = {
   feature: "rgb(70, 186, 168)",
-  label: "rgb(186, 168, 70)"
+  label: "rgb(186, 168, 70)",
 };
 
 export const styles = {
   app: {
     userSelect: "none",
-    height: "100%"
+    height: "100%",
   },
 
   bold: {
-    fontFamily: '"Gotham 5r", sans-serif'
+    fontFamily: '"Gotham 5r", sans-serif',
   },
 
   error: {
-    color: "#e51f68"
+    color: "#e51f68",
   },
   ready: {
     color: "#73be73",
-    backgroundColor: "white"
+    backgroundColor: "white",
   },
 
   panelContainer: {
@@ -55,16 +60,16 @@ export const styles = {
     position: "relative",
     float: "left",
     width: "70%",
-    height: "100%"
+    height: "100%",
   },
 
   panelContainerLeft: {
-    width: "70%"
+    width: "70%",
   },
 
   panelContainerRight: {
     marginLeft: 10,
-    width: "calc(30% - 10px)"
+    width: "calc(30% - 10px)",
   },
 
   panelContainerFullWidth: {
@@ -72,28 +77,28 @@ export const styles = {
     position: "relative",
     float: "left",
     width: "100%",
-    height: "100%"
+    height: "100%",
   },
 
   bodyContainer: {
     height: "100%",
     boxSizing: "border-box",
-    paddingBottom: 100
+    paddingBottom: 100,
   },
 
   largeText: {
     fontSize: 24,
-    marginBottom: 10
+    marginBottom: 10,
   },
 
   mediumText: {
     fontSize: 18,
-    marginBottom: 8
+    marginBottom: 8,
   },
 
   smallText: {
     fontSize: 12,
-    marginBottom: 8
+    marginBottom: 8,
   },
 
   panel: {
@@ -104,35 +109,35 @@ export const styles = {
     height: "100%",
     boxSizing: "border-box",
     display: "flex",
-    flexDirection: "column"
+    flexDirection: "column",
   },
 
   scrollableContents: {
-    overflow: "hidden"
+    overflow: "hidden",
   },
 
   scrollableContentsTinted: {
     overflow: "hidden",
     borderRadius: 5,
-    backgroundColor: "rgb(206, 206, 206)"
+    backgroundColor: "rgb(206, 206, 206)",
   },
 
   scrollingContents: {
     padding: 15,
     overflow: "scroll",
     height: "100%",
-    boxSizing: "border-box"
+    boxSizing: "border-box",
   },
 
   contents: {
     borderRadius: 5,
     backgroundColor: "rgb(206, 206, 206)",
-    padding: 15
+    padding: 15,
   },
 
   panelContentLeft: {
     float: "left",
-    width: "80%"
+    width: "80%",
   },
 
   validationMessages: {
@@ -142,7 +147,7 @@ export const styles = {
     width: "calc(30% - 20px)",
     padding: 20,
     backgroundColor: "rgba(0,0,0,0.8)",
-    borderRadius: 5
+    borderRadius: 5,
   },
 
   validationMessagesLight: {
@@ -158,11 +163,11 @@ export const styles = {
     boxSizing: "border-box",
     overflow: "scroll",
     marginTop: 59,
-    position: "relative"
+    position: "relative",
   },
 
   rightPanel: {
-    fontSize: 13
+    fontSize: 13,
   },
 
   selectDatasetItem: {
@@ -172,26 +177,26 @@ export const styles = {
     boxSizing: "border-box",
     border: "solid 4px rgba(0,0,0,0)",
     borderRadius: 10,
-    height: 240
+    height: 240,
   },
 
   selectDatasetItemSelected: {
-    border: "solid 4px white"
+    border: "solid 4px white",
   },
 
   selectDatasetImage: {
-    width: "100%"
+    width: "100%",
   },
 
   specifyColumnsItem: {
     display: "inline-block",
-    width: "20%"
+    width: "20%",
   },
 
   dataDisplayTable: {
     whiteSpace: "nowrap",
     borderSpacing: 0,
-    width: "100%"
+    width: "100%",
   },
 
   finePrint: {
@@ -201,78 +206,78 @@ export const styles = {
     padding: 10,
     boxSizing: "border-box",
     borderRadius: 5,
-    backgroundColor: "white"
+    backgroundColor: "white",
   },
 
   dataDisplayHeader: {
     paddingLeft: 20,
-    textAlign: "right"
+    textAlign: "right",
   },
   dataDisplayHeaderLabelSelected: {
     backgroundColor: labelColor,
-    color: "yellow"
+    color: "yellow",
   },
   dataDisplayHeaderFeatureSelected: {
     backgroundColor: featureColor,
-    color: "yellow"
+    color: "yellow",
   },
   dataDisplayHeaderSelected: {
     color: "yellow",
-    backgroundColor: "black"
+    backgroundColor: "black",
   },
   dataDisplayHeaderLabelUnselected: {
     backgroundColor: labelColor,
-    color: "white"
+    color: "white",
   },
   dataDisplayHeaderFeatureUnselected: {
     backgroundColor: featureColor,
-    color: "white"
+    color: "white",
   },
   dataDisplayHeaderUnselected: {
     backgroundColor: "black",
-    color: "white"
+    color: "white",
   },
 
   dataDisplayCell: {
     paddingLeft: 20,
-    textAlign: "right"
+    textAlign: "right",
   },
   dataDisplayCellLabelSelected: {
     backgroundColor: labelColorSemi,
-    color: "yellow"
+    color: "yellow",
   },
   dataDisplayCellFeatureSelected: {
     backgroundColor: featureColor,
-    color: "yellow"
+    color: "yellow",
   },
   dataDisplayCellSelected: {
     color: "yellow",
-    backgroundColor: "grey"
+    backgroundColor: "grey",
   },
   dataDisplayCellLabelUnselected: {
-    backgroundColor: labelColorSemi
+    backgroundColor: labelColorSemi,
   },
   dataDisplayCellFeatureUnselected: {
-    backgroundColor: featureColor
+    backgroundColor: featureColor,
   },
   dataDisplayCellUnselected: {},
   crossTabCell0: {
-    backgroundColor: "rgba(255,100,100, 0)"
+    backgroundColor: "rgba(255,100,100, 0)",
   },
   crossTabCell1: {
-    backgroundColor: "rgba(255,100,100, 0.2)"
+    backgroundColor: "rgba(255,100,100, 0.2)",
   },
   crossTabCell2: {
-    backgroundColor: "rgba(255,100,100, 0.4)"
+    backgroundColor: "rgba(255,100,100, 0.4)",
   },
   crossTabCell3: {
-    backgroundColor: "rgba(255,100,100, 0.6)"
+    backgroundColor: "rgba(255,100,100, 0.6)",
   },
   crossTabCell4: {
-    backgroundColor: "rgba(255,100,100, 0.8)"
+    backgroundColor: "rgba(255,100,100, 0.8)",
   },
   crossTabCell5: {
-    backgroundColor: "rgba(255,100,100, 1)"
+    backgroundColor: "rgba(255,100,100, 1)",
   },
 
   previousButton: {
@@ -280,7 +285,7 @@ export const styles = {
     left: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer"
+    cursor: "pointer",
   },
 
   nextButton: {
@@ -288,7 +293,7 @@ export const styles = {
     right: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer"
+    cursor: "pointer",
   },
 
   navButton: {
@@ -298,36 +303,36 @@ export const styles = {
     fontSize: 24,
     border: "initial",
     padding: "10px 20px 10px 20px",
-    cursor: "pointer"
+    cursor: "pointer",
   },
 
   statement: {
-    fontSize: 36
+    fontSize: 36,
   },
 
   statementLabel: {
     color: labelColor,
     paddingLeft: 4,
-    paddingRight: 4
+    paddingRight: 4,
   },
 
   statementFeature: {
     color: featureColor,
     paddingLeft: 4,
-    paddingRight: 4
+    paddingRight: 4,
   },
 
   selectLabelText: {
-    color: labelColor
+    color: labelColor,
   },
 
   selectFeaturesText: {
-    color: featureColor
+    color: featureColor,
   },
 
   trainBot: {
     position: "relative",
-    width: "20%"
+    width: "20%",
   },
   trainBotHead: {
     transition: "transform 500ms",
@@ -335,28 +340,28 @@ export const styles = {
     width: "43%",
     top: "0%",
     position: "absolute",
-    direction: "ltr"
+    direction: "ltr",
   },
   trainBotOpen: {
     transform: "rotate(90deg)",
     transformOrigin: "bottom right",
-    direction: "ltr"
+    direction: "ltr",
   },
   trainBotBody: {
     width: "49%",
     marginTop: "30%",
-    direction: "ltr"
+    direction: "ltr",
   },
 
   cardRow: {
     marginTop: 5,
-    marginBottom: 5
+    marginBottom: 5,
   },
 
   regularButton: { width: "20%" },
 
   floatLeft: {
     float: "left",
-    margin: 20
-  }
+    margin: 20,
+  },
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,17 +1,17 @@
 export const ColumnTypes = {
   CATEGORICAL: "categorical",
   CONTINUOUS: "continuous",
-  OTHER: "other",
+  OTHER: "other"
 };
 
 export const MLTypes = {
   CLASSIFICATION: "classification",
-  REGRESSION: "regression",
+  REGRESSION: "regression"
 };
 
 export const ResultsGrades = {
   CORRECT: "correct",
-  INCORRECT: "incorrect",
+  INCORRECT: "incorrect"
 };
 
 export const TEST_DATA_PERCENTS = [0, 5, 10, 15, 20];
@@ -19,13 +19,13 @@ export const TEST_DATA_PERCENTS = [0, 5, 10, 15, 20];
 export const TestDataLocations = {
   BEGINNING: "beginning",
   END: "end",
-  RANDOM: "random",
+  RANDOM: "random"
 };
 
 export const saveMessages = {
   success: "Your model was saved!",
   failure: "There was an error. Your model did not save.",
-  name: "Please name your model.",
+  name: "Please name your model."
 };
 
 const labelColor = "rgb(254, 96, 3)"; // was 186
@@ -34,25 +34,25 @@ const featureColor = "rgb(75, 155, 213)";
 
 export const colors = {
   feature: "rgb(70, 186, 168)",
-  label: "rgb(186, 168, 70)",
+  label: "rgb(186, 168, 70)"
 };
 
 export const styles = {
   app: {
     userSelect: "none",
-    height: "100%",
+    height: "100%"
   },
 
   bold: {
-    fontFamily: '"Gotham 5r", sans-serif',
+    fontFamily: '"Gotham 5r", sans-serif'
   },
 
   error: {
-    color: "#e51f68",
+    color: "#e51f68"
   },
   ready: {
     color: "#73be73",
-    backgroundColor: "white",
+    backgroundColor: "white"
   },
 
   panelContainer: {
@@ -60,16 +60,16 @@ export const styles = {
     position: "relative",
     float: "left",
     width: "70%",
-    height: "100%",
+    height: "100%"
   },
 
   panelContainerLeft: {
-    width: "70%",
+    width: "70%"
   },
 
   panelContainerRight: {
     marginLeft: 10,
-    width: "calc(30% - 10px)",
+    width: "calc(30% - 10px)"
   },
 
   panelContainerFullWidth: {
@@ -77,28 +77,28 @@ export const styles = {
     position: "relative",
     float: "left",
     width: "100%",
-    height: "100%",
+    height: "100%"
   },
 
   bodyContainer: {
     height: "100%",
     boxSizing: "border-box",
-    paddingBottom: 100,
+    paddingBottom: 100
   },
 
   largeText: {
     fontSize: 24,
-    marginBottom: 10,
+    marginBottom: 10
   },
 
   mediumText: {
     fontSize: 18,
-    marginBottom: 8,
+    marginBottom: 8
   },
 
   smallText: {
     fontSize: 12,
-    marginBottom: 8,
+    marginBottom: 8
   },
 
   panel: {
@@ -109,35 +109,35 @@ export const styles = {
     height: "100%",
     boxSizing: "border-box",
     display: "flex",
-    flexDirection: "column",
+    flexDirection: "column"
   },
 
   scrollableContents: {
-    overflow: "hidden",
+    overflow: "hidden"
   },
 
   scrollableContentsTinted: {
     overflow: "hidden",
     borderRadius: 5,
-    backgroundColor: "rgb(206, 206, 206)",
+    backgroundColor: "rgb(206, 206, 206)"
   },
 
   scrollingContents: {
     padding: 15,
     overflow: "scroll",
     height: "100%",
-    boxSizing: "border-box",
+    boxSizing: "border-box"
   },
 
   contents: {
     borderRadius: 5,
     backgroundColor: "rgb(206, 206, 206)",
-    padding: 15,
+    padding: 15
   },
 
   panelContentLeft: {
     float: "left",
-    width: "80%",
+    width: "80%"
   },
 
   validationMessages: {
@@ -147,7 +147,7 @@ export const styles = {
     width: "calc(30% - 20px)",
     padding: 20,
     backgroundColor: "rgba(0,0,0,0.8)",
-    borderRadius: 5,
+    borderRadius: 5
   },
 
   validationMessagesLight: {
@@ -163,11 +163,11 @@ export const styles = {
     boxSizing: "border-box",
     overflow: "scroll",
     marginTop: 59,
-    position: "relative",
+    position: "relative"
   },
 
   rightPanel: {
-    fontSize: 13,
+    fontSize: 13
   },
 
   selectDatasetItem: {
@@ -177,26 +177,26 @@ export const styles = {
     boxSizing: "border-box",
     border: "solid 4px rgba(0,0,0,0)",
     borderRadius: 10,
-    height: 240,
+    height: 240
   },
 
   selectDatasetItemSelected: {
-    border: "solid 4px white",
+    border: "solid 4px white"
   },
 
   selectDatasetImage: {
-    width: "100%",
+    width: "100%"
   },
 
   specifyColumnsItem: {
     display: "inline-block",
-    width: "20%",
+    width: "20%"
   },
 
   dataDisplayTable: {
     whiteSpace: "nowrap",
     borderSpacing: 0,
-    width: "100%",
+    width: "100%"
   },
 
   finePrint: {
@@ -206,78 +206,78 @@ export const styles = {
     padding: 10,
     boxSizing: "border-box",
     borderRadius: 5,
-    backgroundColor: "white",
+    backgroundColor: "white"
   },
 
   dataDisplayHeader: {
     paddingLeft: 20,
-    textAlign: "right",
+    textAlign: "right"
   },
   dataDisplayHeaderLabelSelected: {
     backgroundColor: labelColor,
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayHeaderFeatureSelected: {
     backgroundColor: featureColor,
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayHeaderSelected: {
     color: "yellow",
-    backgroundColor: "black",
+    backgroundColor: "black"
   },
   dataDisplayHeaderLabelUnselected: {
     backgroundColor: labelColor,
-    color: "white",
+    color: "white"
   },
   dataDisplayHeaderFeatureUnselected: {
     backgroundColor: featureColor,
-    color: "white",
+    color: "white"
   },
   dataDisplayHeaderUnselected: {
     backgroundColor: "black",
-    color: "white",
+    color: "white"
   },
 
   dataDisplayCell: {
     paddingLeft: 20,
-    textAlign: "right",
+    textAlign: "right"
   },
   dataDisplayCellLabelSelected: {
     backgroundColor: labelColorSemi,
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayCellFeatureSelected: {
     backgroundColor: featureColor,
-    color: "yellow",
+    color: "yellow"
   },
   dataDisplayCellSelected: {
     color: "yellow",
-    backgroundColor: "grey",
+    backgroundColor: "grey"
   },
   dataDisplayCellLabelUnselected: {
-    backgroundColor: labelColorSemi,
+    backgroundColor: labelColorSemi
   },
   dataDisplayCellFeatureUnselected: {
-    backgroundColor: featureColor,
+    backgroundColor: featureColor
   },
   dataDisplayCellUnselected: {},
   crossTabCell0: {
-    backgroundColor: "rgba(255,100,100, 0)",
+    backgroundColor: "rgba(255,100,100, 0)"
   },
   crossTabCell1: {
-    backgroundColor: "rgba(255,100,100, 0.2)",
+    backgroundColor: "rgba(255,100,100, 0.2)"
   },
   crossTabCell2: {
-    backgroundColor: "rgba(255,100,100, 0.4)",
+    backgroundColor: "rgba(255,100,100, 0.4)"
   },
   crossTabCell3: {
-    backgroundColor: "rgba(255,100,100, 0.6)",
+    backgroundColor: "rgba(255,100,100, 0.6)"
   },
   crossTabCell4: {
-    backgroundColor: "rgba(255,100,100, 0.8)",
+    backgroundColor: "rgba(255,100,100, 0.8)"
   },
   crossTabCell5: {
-    backgroundColor: "rgba(255,100,100, 1)",
+    backgroundColor: "rgba(255,100,100, 1)"
   },
 
   previousButton: {
@@ -285,7 +285,7 @@ export const styles = {
     left: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer",
+    cursor: "pointer"
   },
 
   nextButton: {
@@ -293,7 +293,7 @@ export const styles = {
     right: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer",
+    cursor: "pointer"
   },
 
   navButton: {
@@ -303,36 +303,36 @@ export const styles = {
     fontSize: 24,
     border: "initial",
     padding: "10px 20px 10px 20px",
-    cursor: "pointer",
+    cursor: "pointer"
   },
 
   statement: {
-    fontSize: 36,
+    fontSize: 36
   },
 
   statementLabel: {
     color: labelColor,
     paddingLeft: 4,
-    paddingRight: 4,
+    paddingRight: 4
   },
 
   statementFeature: {
     color: featureColor,
     paddingLeft: 4,
-    paddingRight: 4,
+    paddingRight: 4
   },
 
   selectLabelText: {
-    color: labelColor,
+    color: labelColor
   },
 
   selectFeaturesText: {
-    color: featureColor,
+    color: featureColor
   },
 
   trainBot: {
     position: "relative",
-    width: "20%",
+    width: "20%"
   },
   trainBotHead: {
     transition: "transform 500ms",
@@ -340,28 +340,28 @@ export const styles = {
     width: "43%",
     top: "0%",
     position: "absolute",
-    direction: "ltr",
+    direction: "ltr"
   },
   trainBotOpen: {
     transform: "rotate(90deg)",
     transformOrigin: "bottom right",
-    direction: "ltr",
+    direction: "ltr"
   },
   trainBotBody: {
     width: "49%",
     marginTop: "30%",
-    direction: "ltr",
+    direction: "ltr"
   },
 
   cardRow: {
     marginTop: 5,
-    marginBottom: 5,
+    marginBottom: 5
   },
 
   regularButton: { width: "20%" },
 
   floatLeft: {
     float: "left",
-    margin: 20,
-  },
+    margin: 20
+  }
 };

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,7 +1,7 @@
 import {
   getOptionFrequenciesByColumn,
   getRange,
-  getAccuracyRegression,
+  getAccuracyRegression
 } from "../../src/redux.js";
 
 import { ResultsGrades } from "../../src/constants.js";
@@ -13,83 +13,83 @@ const initialState = {
       chocolate: "yes",
       nuts: "no",
       fruity: "no",
-      delicious: "yes",
+      delicious: "yes"
     },
     {
       name: "Peanut M&Ms",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes",
+      delicious: "yes"
     },
     {
       name: "Snickers",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes",
+      delicious: "yes"
     },
     {
       name: "Almond Joy",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes",
+      delicious: "yes"
     },
     {
       name: "Black Licorice",
       chocolate: "no",
       nuts: "no",
       fruity: "no",
-      delicious: "no",
+      delicious: "no"
     },
     {
       name: "Skittles",
       chocolate: "no",
       nuts: "no",
       fruity: "yes",
-      delicious: "yes",
-    },
+      delicious: "yes"
+    }
   ],
   labelColumn: "delicious",
   selectedFeatures: ["chocolate", "nuts"],
   columnsByDataType: {
     chocolate: "categorical",
     nuts: "categorical",
-    delicious: "categorical",
-  },
+    delicious: "categorical"
+  }
 };
 
 const resultsState = {
   data: [
     {
       sun: "high",
-      height: 3.8,
+      height: 3.8
     },
     {
       sun: "high",
-      height: 3.9,
+      height: 3.9
     },
     {
       sun: "medium",
-      height: 2.6,
+      height: 2.6
     },
     {
       sun: "medium",
-      height: 2.5,
+      height: 2.5
     },
     {
       sun: "low",
-      height: 0.9,
+      height: 0.9
     },
     {
       sun: "low",
-      height: 1.6,
-    },
+      height: 1.6
+    }
   ],
   labelColumn: "height",
   accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
-  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9],
+  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9]
 };
 
 describe("redux functions", () => {
@@ -114,7 +114,7 @@ describe("redux functions", () => {
       ResultsGrades.CORRECT,
       ResultsGrades.CORRECT,
       ResultsGrades.CORRECT,
-      ResultsGrades.INCORRECT,
+      ResultsGrades.INCORRECT
     ]);
     // error tolerance of +/- 0.09, 4/6 correct
     expect(accuracy.percentCorrect).toBe("66.67");

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,8 +1,10 @@
 import {
   getOptionFrequenciesByColumn,
   getRange,
-  getAccuracyRegression
+  getAccuracyRegression,
 } from "../../src/redux.js";
+
+import { ResultsGrades } from "../../src/constants.js";
 
 const initialState = {
   data: [
@@ -11,83 +13,83 @@ const initialState = {
       chocolate: "yes",
       nuts: "no",
       fruity: "no",
-      delicious: "yes"
+      delicious: "yes",
     },
     {
       name: "Peanut M&Ms",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes"
+      delicious: "yes",
     },
     {
       name: "Snickers",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes"
+      delicious: "yes",
     },
     {
       name: "Almond Joy",
       chocolate: "yes",
       nuts: "yes",
       fruity: "no",
-      delicious: "yes"
+      delicious: "yes",
     },
     {
       name: "Black Licorice",
       chocolate: "no",
       nuts: "no",
       fruity: "no",
-      delicious: "no"
+      delicious: "no",
     },
     {
       name: "Skittles",
       chocolate: "no",
       nuts: "no",
       fruity: "yes",
-      delicious: "yes"
-    }
+      delicious: "yes",
+    },
   ],
   labelColumn: "delicious",
   selectedFeatures: ["chocolate", "nuts"],
   columnsByDataType: {
     chocolate: "categorical",
     nuts: "categorical",
-    delicious: "categorical"
-  }
+    delicious: "categorical",
+  },
 };
 
 const resultsState = {
   data: [
     {
       sun: "high",
-      height: 3.8
+      height: 3.8,
     },
     {
       sun: "high",
-      height: 3.9
+      height: 3.9,
     },
     {
       sun: "medium",
-      height: 2.6
+      height: 2.6,
     },
     {
       sun: "medium",
-      height: 2.5
+      height: 2.5,
     },
     {
       sun: "low",
-      height: 0.9
+      height: 0.9,
     },
     {
       sun: "low",
-      height: 1.6
-    }
+      height: 1.6,
+    },
   ],
   labelColumn: "height",
   accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
-  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9]
+  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9],
 };
 
 describe("redux functions", () => {
@@ -105,8 +107,16 @@ describe("redux functions", () => {
     const maxMin = getRange(resultsState, resultsState.labelColumn);
     const range = Math.abs(maxMin.max - maxMin.min);
     expect(range).toBe(3);
-    const score = getAccuracyRegression(resultsState);
+    const accuracy = getAccuracyRegression(resultsState);
+    expect(accuracy.grades).toEqual([
+      ResultsGrades.INCORRECT,
+      ResultsGrades.CORRECT,
+      ResultsGrades.CORRECT,
+      ResultsGrades.CORRECT,
+      ResultsGrades.CORRECT,
+      ResultsGrades.INCORRECT,
+    ]);
     // error tolerance of +/- 0.09, 4/6 correct
-    expect(score).toBe("66.67");
+    expect(accuracy.percentCorrect).toBe("66.67");
   });
 });


### PR DESCRIPTION
This PR includes updates to the Results panel. With the new calculation of accuracy for regression models from #81, we needed to also update the logic for whether to show a check or x icon for correct or incorrect guesses from A.I. Bot. In addition to that logic, this includes some minor styling modifications to the Results table, consolidating the results message to always be based on % correct and an update for the getAccuracyRegression test. 

![Screen Shot 2021-03-04 at 10 06 23 AM](https://user-images.githubusercontent.com/12300669/109985607-f3314180-7cd2-11eb-835b-cfc41349b446.png)

This PR intentionally does not include horizontal scrolling UI work. 
