### PR TITLE
Don't add labelColumn to the feature number key if it's continuous

### DIFF
--- a/src/train.js
+++ b/src/train.js
@@ -109,9 +109,7 @@ const buildOptionNumberKey = (state, feature) => {
 
 const buildOptionNumberKeysByFeature = state => {
   let optionsMappedToNumbersByFeature = {};
-  const categoricalColumnsToConvert = getSelectedCategoricalColumns(
-    state
-  ).concat(state.labelColumn);
+  const categoricalColumnsToConvert = getSelectedCategoricalColumns(state);
   categoricalColumnsToConvert.forEach(
     feature =>
       (optionsMappedToNumbersByFeature[feature] = buildOptionNumberKey(


### PR DESCRIPTION
A member of the curriculum team found a bug in which the prediction coming back from the model used in [this project](https://levelbuilder-studio.code.org/projects/applab/xnYiDq9dgJEwxkonxR9XhA) was `undefined` _sometimes_.  This model uses a continuous feature to predict a continuous label. When I looked at the trained model data in s3, I realized that we were erroneously adding the continuous label column data to the `featureNumberKey` - basically pointlessly converting a number into another number.
![Screen Shot 2021-03-04 at 2 49 50 PM](https://user-images.githubusercontent.com/12300669/110021939-5fbf3700-7cf9-11eb-9fbe-02d19f08cf50.png)

When the prediction came back, we use that same `featureNumberKey` to do a reverse look-up. Occasionally, the predicted number would coincidentally be a value in the look-up object, making it appear as though we could get a prediction back. In cases where the predicted number was not in the `featureNumberKey`, we'd get `undefined` as described above.  The solution is to stop creating useless `featureNumberKey` entries for continuous labels by not adding the label column to the categorical columns array when building the key. `getCategoricalColumns` already handles adding the label column if it is categorical. 