### PR TITLE
Display warning when uploaded dataset has >20k rows

### DIFF
--- a/src/UIComponents/DataCard.jsx
+++ b/src/UIComponents/DataCard.jsx
@@ -17,7 +17,7 @@ class DataCard extends Component {
 
     const card = metadata && metadata.card;
 
-    const dataLengthLimit = 20000
+    const dataLengthLimit = 20000;
     if (dataLength > dataLengthLimit) {
       window.alert('Warning: Datasets with more than 20,000 rows will slow down the user experience.');
     }

--- a/src/UIComponents/DataCard.jsx
+++ b/src/UIComponents/DataCard.jsx
@@ -17,6 +17,11 @@ class DataCard extends Component {
 
     const card = metadata && metadata.card;
 
+    const dataLengthLimit = 20000
+    if (dataLength > dataLengthLimit) {
+      window.alert('Warning: Datasets with more than 20,000 rows will slow down the user experience.');
+    }
+
     return dataLength !== 0 && (
       <div id="data-card" style={{...styles.panel, ...styles.rightPanel}}>
         <div style={styles.largeText}>Data Information</div>


### PR DESCRIPTION
I added an alert in the DataCard component. It warns users when their dataset contains more than 20,000 rows. 

Edited to add screenshot: 
![dataset-warning](https://user-images.githubusercontent.com/40412372/110152362-7c5d7c80-7d96-11eb-9963-105768e9377e.png)
