### PR TITLE
Handle cases where we have metadata but not column descriptions

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -915,7 +915,7 @@ export function getTrainedModelDataToSave(state) {
   if (
     state.metadata &&
     state.metadata.fields &&
-    state.metedata.fields[0].description
+    state.metadata.fields[0].description
   ) {
     dataToSave.columns = [];
     for (const columnDescription of getSelectedColumnDescriptions(state)) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -910,8 +910,9 @@ export function getTrainedModelDataToSave(state) {
 
   dataToSave.name = state.trainedModelDetails.name;
 
-  // If we have column descriptions in metadata, use that, otherwise
-  // use what the user has manually entered.
+  // If the first column has a description, assume descriptions are in the
+  // metadata for that dataset and use them; otherwise, use manually entered
+  // column desscriptions.
   if (
     state.metadata &&
     state.metadata.fields &&

--- a/src/redux.js
+++ b/src/redux.js
@@ -912,7 +912,11 @@ export function getTrainedModelDataToSave(state) {
 
   // If we have column descriptions in metadata, use that, otherwise
   // use what the user has manually entered.
-  if (state.metadata && state.metadata.fields) {
+  if (
+    state.metadata &&
+    state.metadata.fields &&
+    state.metedata.fields[0].description
+  ) {
     dataToSave.columns = [];
     for (const columnDescription of getSelectedColumnDescriptions(state)) {
       dataToSave.columns.push({


### PR DESCRIPTION
We noticed that there were scenarios where column descriptions were not being displayed in the model  card details for models trained with certain datasets (initially discovered with the titanic dataset) when viewing them in the Model Manger Dialog in App Lab. 

![Screen Shot 2021-03-05 at 4 31 06 PM](https://user-images.githubusercontent.com/12300669/110175706-37eed280-7dd0-11eb-8289-5ea315729855.png)



 This is because we were not saving column descriptions correctly in some cases. Specifically, if there was metadata for a dataset, but that metadata did not include column descriptions we were not saving the user entered descriptions when we should have been.  Now, we check if there is metadata _and_ if that metadata contains column descriptions before saving the metadata for column descriptions rather than the user inputed descriptions. 