### PR TITLE
Message shown instead of bar graph

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -130,22 +130,30 @@ class ColumnInspector extends Component {
                   <div>
                     <br />
                     <div>{currentColumnData.description}</div>
+                    <br />
                   </div>
                 )}
               </label>
 
-              {currentColumnData.dataType === ColumnTypes.CATEGORICAL &&
-                barData.labels.length <= maxLabelsInHistogram && (
-                  <div>
-                    <br />
+              {currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
+                <div>
+                  {barData.labels.length <= maxLabelsInHistogram && (
                     <Bar
                       data={barData}
                       width={100}
                       height={150}
                       options={chartOptions}
                     />
-                  </div>
-                )}
+                  )}
+                  {barData.labels.length > maxLabelsInHistogram && (
+                    <div>
+                      {barData.labels.length} values were found in this column.
+                      A graph is only shown when there are{" "}
+                      {maxLabelsInHistogram} or fewer.
+                    </div>
+                  )}
+                </div>
+              )}
 
               {currentColumnData.dataType === ColumnTypes.CONTINUOUS && (
                 <div>


### PR DESCRIPTION
A message is shown instead of the bar graph for a categorical column when it's not shown because it has too many values.

![Screen Shot 2021-03-07 at 1 06 50 AM](https://user-images.githubusercontent.com/2205926/110209587-3231d500-7e42-11eb-93ee-8427dc83f72e.png)
