### PR TITLE
Remove dead empty cells and toggle raw data code from DataDisplay

### DIFF
--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -86,49 +86,47 @@ class DataDisplay extends Component {
             </span>
           )}
         </div>
-        {this.state.showRawData && (
-          <div style={styles.tableParent}>
-            <table style={styles.dataDisplayTable}>
-              <thead>
-                <tr>
-                  {data.length > 0 &&
-                    Object.keys(data[0]).map(key => {
-                      return (
-                        <th
-                          key={key}
-                          style={this.getColumnHeaderStyle(key)}
-                          onClick={() => setCurrentColumn(key)}
-                        >
-                          {key}
-                        </th>
-                      );
-                    })}
-                </tr>
-              </thead>
-              <tbody>
+        <div style={styles.tableParent}>
+          <table style={styles.dataDisplayTable}>
+            <thead>
+              <tr>
                 {data.length > 0 &&
-                  data.map((row, index) => {
+                  Object.keys(data[0]).map(key => {
                     return (
-                      <tr key={index}>
-                        {data.length > 0 &&
-                          Object.keys(row).map(key => {
-                            return (
-                              <td
-                                key={key}
-                                style={this.getColumnCellStyle(key)}
-                                onClick={() => setCurrentColumn(key)}
-                              >
-                                {row[key]}
-                              </td>
-                            );
-                          })}
-                      </tr>
+                      <th
+                        key={key}
+                        style={this.getColumnHeaderStyle(key)}
+                        onClick={() => setCurrentColumn(key)}
+                      >
+                        {key}
+                      </th>
                     );
                   })}
-              </tbody>
-            </table>
-          </div>
-        )}
+              </tr>
+            </thead>
+            <tbody>
+              {data.length > 0 &&
+                data.map((row, index) => {
+                  return (
+                    <tr key={index}>
+                      {data.length > 0 &&
+                        Object.keys(row).map(key => {
+                          return (
+                            <td
+                              key={key}
+                              style={this.getColumnCellStyle(key)}
+                              onClick={() => setCurrentColumn(key)}
+                            >
+                              {row[key]}
+                            </td>
+                          );
+                        })}
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </table>
+        </div>
         <div style={styles.mediumText}>
           There are {this.props.data.length} rows of data.
         </div>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getEmptyCellDetails, setCurrentColumn } from "../redux";
+import { setCurrentColumn } from "../redux";
 import { styles } from "../constants";
 
 class DataDisplay extends Component {
@@ -10,31 +10,9 @@ class DataDisplay extends Component {
     data: PropTypes.array,
     labelColumn: PropTypes.string,
     selectedFeatures: PropTypes.array,
-    emptyCellDetails: PropTypes.array,
     setCurrentColumn: PropTypes.func,
     currentColumn: PropTypes.string,
     currentPanel: PropTypes.string
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showRawData: true,
-      showEmptyCellDetails: false
-    };
-  }
-
-  toggleRawData = () => {
-    this.setState({
-      showRawData: !this.state.showRawData
-    });
-  };
-
-  toggleEmptyCellDetails = () => {
-    this.setState({
-      showEmptyCellDetails: !this.state.showEmptyCellDetails
-    });
   };
 
   getColumnHeaderStyle = key => {
@@ -151,11 +129,6 @@ class DataDisplay extends Component {
             </table>
           </div>
         )}
-        {!this.state.showRawData && (
-          <button type="button" onClick={this.toggleRawData}>
-            show data
-          </button>
-        )}
         <div style={styles.mediumText}>
           There are {this.props.data.length} rows of data.
         </div>
@@ -169,7 +142,6 @@ export default connect(
     data: state.data,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
-    emptyCellDetails: getEmptyCellDetails(state),
     currentColumn: state.currentColumn,
     currentPanel: state.currentPanel
   }),


### PR DESCRIPTION
As I started to look at performance issues for large datasets, I came across some dead code. In the Data Display view we no longer have a toggle to hide/show raw data, nor do we expose information about the empty cells in a dataset. Going through each of the cells in a large dataset is time consuming, so let's stop doing that work especially since we aren't displaying it to users. This PR removes the aforementioned dead code from the `DataDisplay` component. However, I left in the redux function to do those calculations in case we want to use it in the `DataCard` component; I logged a [work item](https://trello.com/c/BMaXlW8b/122-show-empty-cell-details-or-delete-that-code) to delete that function and related tendrils should we decide to do so post-pilot. 