### PR TITLE
Use showChooseReserve boolean to conditionally show PercentReserveSlider

### DIFF
--- a/src/UIComponents/TrainingSettings.jsx
+++ b/src/UIComponents/TrainingSettings.jsx
@@ -5,12 +5,14 @@ import PercentReserveSlider from "./PercentReserveSlider";
 import ColumnTypeSelector from "./ColumnTypeSelector";
 import { connect } from "react-redux";
 import { styles } from "../constants";
+import { getShowChooseReserve } from "../redux";
 
 class TrainingSettings extends Component {
   static propTypes = {
     selectedFeatures: PropTypes.array,
     labelColumn: PropTypes.string,
-    hideSpecifyColumns: PropTypes.bool
+    hideSpecifyColumns: PropTypes.bool,
+    showChooseReserve: PropTypes.bool
   };
 
   render() {
@@ -22,7 +24,7 @@ class TrainingSettings extends Component {
             A.I. Bot will predict {this.props.labelColumn} based on{" "}
             {this.props.selectedFeatures.join(", ")}.
           </div>
-          <PercentReserveSlider />
+          {this.showChooseReserve && <PercentReserveSlider />}
           {!this.props.hideSpecifyColumns && <ColumnTypeSelector />}
         </div>
       </div>
@@ -33,5 +35,6 @@ class TrainingSettings extends Component {
 export default connect(state => ({
   labelColumn: state.labelColumn,
   selectedFeatures: state.selectedFeatures,
-  hideSpecifyColumns: state.mode && state.mode.hideSpecifyColumns
+  hideSpecifyColumns: state.mode && state.mode.hideSpecifyColumns,
+  showChooseReserve: getShowChooseReserve(state)
 }))(TrainingSettings);


### PR DESCRIPTION
By default we want to hide the % training data to reserve slider and conditionally show it based on a levelbuilder setting `hideChooseReserve`. 

<img width="443" alt="slider" src="https://user-images.githubusercontent.com/12300669/110663640-a0ed9600-8194-11eb-9078-28b651aa6848.png">

When I refactored the `TrainingSettings` component in #83 I overlooked this detail. Restoring that functionality in this PR. 

Without the slider, the training set-up panel looks like this: 
 
![Screen Shot 2021-03-10 at 11 28 27 AM](https://user-images.githubusercontent.com/12300669/110663450-71d72480-8194-11eb-9e18-e6f0cfc31023.png)
