### PR TITLE
Display regression results correctly 

### DIFF
--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -17,7 +17,7 @@ class ResultsTable extends Component {
     accuracyCheckExamples: PropTypes.array,
     accuracyCheckLabels: PropTypes.array,
     accuracyCheckPredictedLabels: PropTypes.array,
-    acccuracyGrades: PropTypes.array,
+    accuracyGrades: PropTypes.array,
     isRegression: PropTypes.bool
   };
 
@@ -67,11 +67,11 @@ class ResultsTable extends Component {
                   })}
                   <td>{this.props.accuracyCheckPredictedLabels[index]}</td>
                   <td>{this.props.accuracyCheckLabels[index]}</td>
-                  {this.props.acccuracyGrades[index] ===
+                  {this.props.accuracyGrades[index] ===
                     ResultsGrades.CORRECT && (
                     <td style={styles.ready}>&#x2713;</td>
                   )}
-                  {this.props.acccuracyGrades[index] ===
+                  {this.props.accuracyGrades[index] ===
                     ResultsGrades.INCORRECT && (
                     <td style={styles.error}>&#10006;</td>
                   )}
@@ -94,6 +94,6 @@ export default connect(state => ({
     state,
     state.accuracyCheckPredictedLabels
   ),
-  acccuracyGrades: getAccuracyGrades(state),
+  accuracyGrades: getAccuracyGrades(state),
   isRegression: isRegression(state)
 }))(ResultsTable);

--- a/src/redux.js
+++ b/src/redux.js
@@ -694,12 +694,11 @@ function isEmpty(object) {
 }
 
 export function getConvertedValue(state, rawValue, column) {
-  if (!isEmpty(state.featureNumberKey)) {
-    const convertedValue = getCategoricalColumns(state).includes(column)
-      ? getKeyByValue(state.featureNumberKey[column], rawValue)
-      : rawValue;
-    return convertedValue;
-  }
+  const convertedValue = getCategoricalColumns(state).includes(column) &&
+    !isEmpty(state.featureNumberKey)
+    ? getKeyByValue(state.featureNumberKey[column], rawValue)
+    : rawValue;
+  return convertedValue;
 }
 
 export function getConvertedAccuracyCheckExamples(state) {
@@ -718,13 +717,8 @@ export function getConvertedAccuracyCheckExamples(state) {
 }
 
 export function getConvertedLabel(state, rawLabel) {
-  if (state.labelColumn && !isEmpty(state.featureNumberKey)) {
-    const convertedLabel = getCategoricalColumns(state).includes(
-      state.labelColumn
-    )
-      ? getKeyByValue(state.featureNumberKey[state.labelColumn], rawLabel)
-      : rawLabel;
-    return convertedLabel;
+  if (state.labelColumn) {
+    return getConvertedValue(state, rawLabel, state.labelColumn);
   }
 }
 
@@ -752,7 +746,7 @@ export function getCompatibleTrainers(state) {
 }
 
 export function isRegression(state) {
-  const mlType = getMLType(state.selectedTrainer);
+  const mlType = getMLType(getSelectedTrainer(state));
   return mlType === MLTypes.REGRESSION;
 }
 


### PR DESCRIPTION
There are few changes included in this PR: 

1.) Correcting a typo "acccuracy" -> "accuracy". I had, at least, consistently misspelled accuracy so there isn't any functional change here 

2.) Using the `getSelectedTrainer` helper in the `isRegression` function rather than directly relying on `state.selectedTrainer`, which might be undefined if not set by a levelbuilder param since we are now hiding the select trainer dropdown. 

3.) Updating `getCovertedValue`  to only check for the featureNumberKey if the label column is categorical. This is the root cause of why continuous results were not showing up in the Results table as expected. In #90 we stopped incorrectly adding continuous label columns to the featureNumberKey, which means that for a model that uses continuous features to predict a continuous label, such as temperature and lions, there is no featureNumberKey. Thus, we never met the criteria of the conditional and didn't return converted values correctly.  Now, we do. 

BEFORE: 
![Screen Shot 2021-03-10 at 2 14 06 PM](https://user-images.githubusercontent.com/12300669/110684246-ea48e000-81aa-11eb-9cfa-1cc6a888635d.png)

AFTER: 
<img width="814" alt="Screen Shot 2021-03-10 at 1 58 06 PM" src="https://user-images.githubusercontent.com/12300669/110684179-d604e300-81aa-11eb-9bcf-42603399559e.png">

4.) Lastly, including a slight clean-up to reduce redundancy - `getCovertedLabel` now calls `getConvertedValue` rather than duplicating the conversion code. 