### PR TITLE
Increase maxLabelsInHistogram

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -94,7 +94,7 @@ class ColumnInspector extends Component {
       barData.datasets[0].label = currentColumnData.id;
     }
 
-    const maxLabelsInHistogram = 4;
+    const maxLabelsInHistogram = 5;
 
     return (
       currentColumnData && (


### PR DESCRIPTION
Tiny [request](https://codedotorg.slack.com/archives/C016VGH1BT6/p1615485039057100) to increase the max number of options for showing histogram data, particularly because racial information is typically broken down into 5 categories, which is useful for the curriculum. 