### PR TITLE
Combined select screen

### DIFF
--- a/public/datasets/foods.json
+++ b/public/datasets/foods.json
@@ -31,11 +31,11 @@
   	},
   	{
   		"id": "fruit_day",
-  		"type": "continuous"
+  		"type": "numerical"
   	},
   	{
   		"id": "veggies_day",
-  		"type": "continuous"
+  		"type": "numerical"
   	},
   	{
   		"id": "sports",

--- a/src/App.js
+++ b/src/App.js
@@ -173,13 +173,6 @@ class App extends Component {
             <ColumnInspector columnRefs={this.columnRefs} />
             <ContainerRight>
               <PhraseBuilder />
-              {false && currentPanel === "dataDisplayLabel" && (
-                <ColumnInspector />
-              )}
-              {false && currentPanel === "dataDisplayFeatures" && <CrossTab />}
-              {false && currentPanel === "dataDisplayFeatures" && (
-                <ScatterPlot />
-              )}
             </ContainerRight>
           </BodyContainer>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,6 @@ import SelectDataset from "./UIComponents/SelectDataset";
 import DataDisplay from "./UIComponents/DataDisplay";
 import ColumnInspector from "./UIComponents/ColumnInspector";
 import PhraseBuilder from "./UIComponents/PhraseBuilder";
-import CrossTab from "./UIComponents/CrossTab";
-import ScatterPlot from "./UIComponents/ScatterPlot";
 import DataCard from "./UIComponents/DataCard";
 import TrainingSettings from "./UIComponents/TrainingSettings";
 import TrainModel from "./UIComponents/TrainModel";
@@ -131,13 +129,13 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.columnRefs = {};
+    this.columnPositions = {};
   }
 
   setColumnRef = (columnId, ref) => {
     if (ref) {
       const rect = ref.getBoundingClientRect();
-      this.columnRefs[columnId] = rect.left + rect.width;
+      this.columnPositions[columnId] = rect.left + rect.width;
     }
   };
 
@@ -170,7 +168,7 @@ class App extends Component {
             <ContainerLeft>
               <DataDisplay setColumnRef={this.setColumnRef} />
             </ContainerLeft>
-            <ColumnInspector columnRefs={this.columnRefs} />
+            <ColumnInspector columnPositions={this.columnPositions} />
             <ContainerRight>
               <PhraseBuilder />
             </ContainerRight>

--- a/src/App.js
+++ b/src/App.js
@@ -131,15 +131,13 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      columnRefs: {}
-    };
+    this.columnRefs = {};
   }
 
   setColumnRef = (columnId, ref) => {
     if (ref) {
       const rect = ref.getBoundingClientRect();
-      this.state.columnRefs[columnId] = rect.left + rect.width;
+      this.columnRefs[columnId] = rect.left + rect.width;
     }
   };
 
@@ -172,7 +170,7 @@ class App extends Component {
             <ContainerLeft>
               <DataDisplay setColumnRef={this.setColumnRef} />
             </ContainerLeft>
-            <ColumnInspector columnRefs={this.state.columnRefs} />
+            <ColumnInspector columnRefs={this.columnRefs} />
             <ContainerRight>
               <PhraseBuilder />
               {false && currentPanel === "dataDisplayLabel" && (

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import SelectDataset from "./UIComponents/SelectDataset";
 import DataDisplay from "./UIComponents/DataDisplay";
 import ColumnInspector from "./UIComponents/ColumnInspector";
+import PhraseBuilder from "./UIComponents/PhraseBuilder";
 import CrossTab from "./UIComponents/CrossTab";
 import ScatterPlot from "./UIComponents/ScatterPlot";
 import DataCard from "./UIComponents/DataCard";
@@ -127,6 +128,23 @@ class App extends Component {
     dataToSave: PropTypes.object
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      columnRefs: {}
+    };
+  }
+
+  setColumnRef = (columnId, ref) => {
+
+    if (ref) {
+      const rect = ref.getBoundingClientRect();
+      this.state.columnRefs[columnId] = rect.left + rect.width;
+      console.log(columnId, ref, ref.getBoundingClientRect());
+    }
+  }
+
   render() {
     const {
       panelButtons,
@@ -151,15 +169,17 @@ class App extends Component {
           </BodyContainer>
         )}
 
-        {["dataDisplayLabel", "dataDisplayFeatures"].includes(currentPanel) && (
+        {["dataDisplay"].includes(currentPanel) && (
           <BodyContainer>
             <ContainerLeft>
-              <DataDisplay />
+              <DataDisplay setColumnRef={this.setColumnRef}/>
             </ContainerLeft>
+            <ColumnInspector columnRefs={this.state.columnRefs}/>
             <ContainerRight>
-              {currentPanel === "dataDisplayLabel" && <ColumnInspector />}
-              {currentPanel === "dataDisplayFeatures" && <CrossTab />}
-              {currentPanel === "dataDisplayFeatures" && <ScatterPlot />}
+              <PhraseBuilder />
+              {false && currentPanel === "dataDisplayLabel" && <ColumnInspector />}
+              {false && currentPanel === "dataDisplayFeatures" && <CrossTab />}
+              {false && currentPanel === "dataDisplayFeatures" && <ScatterPlot />}
             </ContainerRight>
           </BodyContainer>
         )}

--- a/src/App.js
+++ b/src/App.js
@@ -137,13 +137,11 @@ class App extends Component {
   }
 
   setColumnRef = (columnId, ref) => {
-
     if (ref) {
       const rect = ref.getBoundingClientRect();
       this.state.columnRefs[columnId] = rect.left + rect.width;
-      console.log(columnId, ref, ref.getBoundingClientRect());
     }
-  }
+  };
 
   render() {
     const {
@@ -172,14 +170,18 @@ class App extends Component {
         {["dataDisplay"].includes(currentPanel) && (
           <BodyContainer>
             <ContainerLeft>
-              <DataDisplay setColumnRef={this.setColumnRef}/>
+              <DataDisplay setColumnRef={this.setColumnRef} />
             </ContainerLeft>
-            <ColumnInspector columnRefs={this.state.columnRefs}/>
+            <ColumnInspector columnRefs={this.state.columnRefs} />
             <ContainerRight>
               <PhraseBuilder />
-              {false && currentPanel === "dataDisplayLabel" && <ColumnInspector />}
+              {false && currentPanel === "dataDisplayLabel" && (
+                <ColumnInspector />
+              )}
               {false && currentPanel === "dataDisplayFeatures" && <CrossTab />}
-              {false && currentPanel === "dataDisplayFeatures" && <ScatterPlot />}
+              {false && currentPanel === "dataDisplayFeatures" && (
+                <ScatterPlot />
+              )}
             </ContainerRight>
           </BodyContainer>
         )}

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -106,11 +106,8 @@ class ColumnInspector extends Component {
     if (currentColumnData) {
       if (this.props.columnRefs[currentColumnData.id]) {
         leftPosition = this.props.columnRefs[currentColumnData.id];
-        //console.log(this.props.columnRefs[currentColumnData.id].getBoundingClientRect());
       }
     }
-
-    console.log("rendering column inspector!");
 
     return (
       currentColumnData && (
@@ -118,13 +115,13 @@ class ColumnInspector extends Component {
           id="column-inspector"
           style={{
             ...styles.panel,
-            ...styles.rightPanel,
             ...{
               position: "absolute",
               border: "1px solid",
               top: 90,
               left: leftPosition,
-              height: "initial"
+              height: "initial",
+              zIndex: 1
             }
           }}
         >
@@ -166,7 +163,7 @@ class ColumnInspector extends Component {
               </label>
 
               {currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
-                <div style={{float: "left", width: "50%"}}>
+                <div style={styles.halfPanel}>
                   {barData.labels.length <= maxLabelsInHistogram && (
                     <Bar
                       data={barData}
@@ -185,10 +182,8 @@ class ColumnInspector extends Component {
                 </div>
               )}
 
-              <div style={{float: "left", width: "50%"}}>
-                <ScatterPlot/>
-                <CrossTab />
-              </div>
+              <ScatterPlot />
+              <CrossTab />
 
               {currentColumnData.dataType === ColumnTypes.CONTINUOUS && (
                 <div>

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -13,6 +13,10 @@ import {
 } from "../redux";
 import { ColumnTypes, styles } from "../constants.js";
 import { Bar } from "react-chartjs-2";
+import ScatterPlot from "./ScatterPlot";
+import CrossTab from "./CrossTab";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 const barData = {
   labels: [],
@@ -52,7 +56,8 @@ class ColumnInspector extends Component {
     removeSelectedFeature: PropTypes.func.isRequired,
     rangesByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
-    hideSpecifyColumns: PropTypes.bool
+    hideSpecifyColumns: PropTypes.bool,
+    columnRefs: PropTypes.object
   };
 
   handleChangeDataType = (event, feature) => {
@@ -96,12 +101,36 @@ class ColumnInspector extends Component {
 
     const maxLabelsInHistogram = 4;
 
+    let leftPosition = 0;
+
+    if (currentColumnData) {
+      if (this.props.columnRefs[currentColumnData.id]) {
+        leftPosition = this.props.columnRefs[currentColumnData.id];
+        //console.log(this.props.columnRefs[currentColumnData.id].getBoundingClientRect());
+      }
+    }
+
+    console.log("rendering column inspector!");
+
     return (
       currentColumnData && (
         <div
           id="column-inspector"
-          style={{ ...styles.panel, ...styles.rightPanel }}
+          style={{
+            ...styles.panel,
+            ...styles.rightPanel,
+            ...{
+              position: "absolute",
+              border: "1px solid",
+              top: 90,
+              left: leftPosition,
+              height: "initial"
+            }
+          }}
         >
+          <div onClick={this.onClose} style={styles.popupClose}>
+            <FontAwesomeIcon icon={faTimes} />
+          </div>
           <div style={styles.largeText}>Column Information</div>
           <form>
             <div>
@@ -137,7 +166,7 @@ class ColumnInspector extends Component {
               </label>
 
               {currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
-                <div>
+                <div style={{float: "left", width: "50%"}}>
                   {barData.labels.length <= maxLabelsInHistogram && (
                     <Bar
                       data={barData}
@@ -155,6 +184,11 @@ class ColumnInspector extends Component {
                   )}
                 </div>
               )}
+
+              <div style={{float: "left", width: "50%"}}>
+                <ScatterPlot/>
+                <CrossTab />
+              </div>
 
               {currentColumnData.dataType === ColumnTypes.CONTINUOUS && (
                 <div>

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -57,7 +57,7 @@ class ColumnInspector extends Component {
     rangesByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
     hideSpecifyColumns: PropTypes.bool,
-    columnRefs: PropTypes.object
+    columnPositions: PropTypes.object
   };
 
   handleChangeDataType = (event, feature) => {
@@ -104,8 +104,8 @@ class ColumnInspector extends Component {
     let leftPosition = 0;
 
     if (currentColumnData) {
-      if (this.props.columnRefs[currentColumnData.id]) {
-        leftPosition = this.props.columnRefs[currentColumnData.id];
+      if (this.props.columnPositions[currentColumnData.id]) {
+        leftPosition = this.props.columnPositions[currentColumnData.id];
       }
     }
 
@@ -115,14 +115,8 @@ class ColumnInspector extends Component {
           id="column-inspector"
           style={{
             ...styles.panel,
-            ...{
-              position: "absolute",
-              border: "1px solid",
-              top: 90,
-              left: leftPosition,
-              height: "initial",
-              zIndex: 1
-            }
+            ...styles.popupPanel,
+            left: leftPosition
           }}
         >
           <div onClick={this.onClose} style={styles.popupClose}>

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -24,8 +24,8 @@ class CrossTab extends Component {
 
     return (
       crossTabData && (
-        <div id="cross-tab" style={{ ...styles.panel, ...styles.rightPanel }}>
-          <div style={styles.largeText}>Correlation Information</div>
+        <div id="cross-tab">
+          {/*<div style={styles.largeText}>Correlation Information</div>*/}
           <div style={styles.scrollableContents}>
             <div style={styles.scrollingContents}>
               <table>

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -25,7 +25,6 @@ class CrossTab extends Component {
     return (
       crossTabData && (
         <div id="cross-tab" style={styles.halfPanel}>
-          {/*<div style={styles.largeText}>Correlation Information</div>*/}
           <div style={styles.scrollableContents}>
             <div style={styles.scrollingContents}>
               <table>

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -24,7 +24,7 @@ class CrossTab extends Component {
 
     return (
       crossTabData && (
-        <div id="cross-tab">
+        <div id="cross-tab" style={styles.halfPanel}>
           {/*<div style={styles.largeText}>Correlation Information</div>*/}
           <div style={styles.scrollableContents}>
             <div style={styles.scrollingContents}>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -14,7 +14,6 @@ class DataDisplay extends Component {
     setHighlightColumn: PropTypes.func,
     currentColumn: PropTypes.string,
     highlightColumn: PropTypes.string,
-    currentPanel: PropTypes.string,
     setColumnRef: PropTypes.func
   };
 
@@ -38,9 +37,9 @@ class DataDisplay extends Component {
         style = styles.dataDisplayHeaderHighlighted;
       }
     } else {
-      if (false && key === this.props.labelColumn) {
+      if (key === this.props.labelColumn) {
         style = styles.dataDisplayHeaderLabelUnselected;
-      } else if (false && this.props.selectedFeatures.includes(key)) {
+      } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayHeaderFeatureUnselected;
       } else {
         style = styles.dataDisplayHeaderUnselected;
@@ -86,7 +85,6 @@ class DataDisplay extends Component {
     const {
       data,
       setCurrentColumn,
-      currentPanel,
       setColumnRef,
       setHighlightColumn
     } = this.props;
@@ -172,8 +170,7 @@ export default connect(
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
     currentColumn: state.currentColumn,
-    highlightColumn: state.highlightColumn,
-    currentPanel: state.currentPanel
+    highlightColumn: state.highlightColumn
   }),
   dispatch => ({
     setCurrentColumn(column) {

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -13,7 +13,8 @@ class DataDisplay extends Component {
     emptyCellDetails: PropTypes.array,
     setCurrentColumn: PropTypes.func,
     currentColumn: PropTypes.string,
-    currentPanel: PropTypes.string
+    currentPanel: PropTypes.string,
+    setColumnRef: PropTypes.func
   };
 
   constructor(props) {
@@ -41,19 +42,19 @@ class DataDisplay extends Component {
     let style;
 
     if (key === this.props.currentColumn) {
-      if (key === this.props.labelColumn) {
+      /*if (key === this.props.labelColumn) {
         style = styles.dataDisplayHeaderLabelSelected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayHeaderFeatureSelected;
-      } else {
+      } else */ {
         style = styles.dataDisplayHeaderSelected;
       }
     } else {
-      if (key === this.props.labelColumn) {
+      /* if (false && key === this.props.labelColumn) {
         style = styles.dataDisplayHeaderLabelUnselected;
-      } else if (this.props.selectedFeatures.includes(key)) {
+      } else if (false && this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayHeaderFeatureUnselected;
-      } else {
+      } else */ {
         style = styles.dataDisplayHeaderUnselected;
       }
     }
@@ -65,19 +66,19 @@ class DataDisplay extends Component {
     let style;
 
     if (key === this.props.currentColumn) {
-      if (key === this.props.labelColumn) {
+      /* if (key === this.props.labelColumn) {
         style = styles.dataDisplayCellLabelSelected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayCellFeatureSelected;
-      } else {
+      } else */ {
         style = styles.dataDisplayCellSelected;
       }
     } else {
-      if (key === this.props.labelColumn) {
+      /* if (key === this.props.labelColumn) {
         style = styles.dataDisplayCellLabelUnselected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayCellFeatureUnselected;
-      } else {
+      } else */ {
         style = styles.dataDisplayCellUnselected;
       }
     }
@@ -86,7 +87,7 @@ class DataDisplay extends Component {
   };
 
   render() {
-    const { data, setCurrentColumn, currentPanel } = this.props;
+    const { data, setCurrentColumn, currentPanel, setColumnRef } = this.props;
 
     return (
       <div id="data-display" style={styles.panel}>
@@ -95,7 +96,7 @@ class DataDisplay extends Component {
           <span style={styles.statementLabel}>
             {this.props.labelColumn || "..."}
           </span>
-          {currentPanel === "dataDisplayFeatures" && (
+          {true && (
             <span>
               {" "}
               based on{" "}
@@ -109,7 +110,7 @@ class DataDisplay extends Component {
           )}
         </div>
         {this.state.showRawData && (
-          <div style={styles.tableParent}>
+          <div style={styles.tableParent} onScroll={() => setCurrentColumn(undefined)}>
             <table style={styles.dataDisplayTable}>
               <thead>
                 <tr>
@@ -120,6 +121,7 @@ class DataDisplay extends Component {
                           key={key}
                           style={this.getColumnHeaderStyle(key)}
                           onClick={() => setCurrentColumn(key)}
+                          ref={ref => setColumnRef(key, ref)}
                         >
                           {key}
                         </th>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -96,18 +96,16 @@ class DataDisplay extends Component {
           <span style={styles.statementLabel}>
             {this.props.labelColumn || "..."}
           </span>
-          {true && (
-            <span>
-              {" "}
-              based on{" "}
-              <span style={styles.statementFeature}>
-                {this.props.selectedFeatures.length > 0
-                  ? this.props.selectedFeatures.join(", ")
-                  : ".."}
-              </span>
-              {"."}
+          <span>
+            {" "}
+            based on{" "}
+            <span style={styles.statementFeature}>
+              {this.props.selectedFeatures.length > 0
+                ? this.props.selectedFeatures.join(", ")
+                : ".."}
             </span>
-          )}
+            {"."}
+          </span>
         </div>
         {this.state.showRawData && (
           <div style={styles.tableParent} onScroll={() => setCurrentColumn(undefined)}>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,7 +2,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getEmptyCellDetails, setCurrentColumn } from "../redux";
+import { getEmptyCellDetails, setCurrentColumn, setHighlightColumn } from "../redux";
 import { styles } from "../constants";
 
 class DataDisplay extends Component {
@@ -12,7 +12,9 @@ class DataDisplay extends Component {
     selectedFeatures: PropTypes.array,
     emptyCellDetails: PropTypes.array,
     setCurrentColumn: PropTypes.func,
+    setHighlightColumn: PropTypes.func,
     currentColumn: PropTypes.string,
+    highlightColumn: PropTypes.string,
     currentPanel: PropTypes.string,
     setColumnRef: PropTypes.func
   };
@@ -42,19 +44,27 @@ class DataDisplay extends Component {
     let style;
 
     if (key === this.props.currentColumn) {
-      /*if (key === this.props.labelColumn) {
+      if (key === this.props.labelColumn) {
         style = styles.dataDisplayHeaderLabelSelected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayHeaderFeatureSelected;
-      } else */ {
+      } else {
         style = styles.dataDisplayHeaderSelected;
       }
+    } else if (key === this.props.highlightColumn) {
+      if (key === this.props.labelColumn) {
+        style = styles.dataDisplayHeaderLabelUnselected;
+      } else if (this.props.selectedFeatures.includes(key)) {
+        style = styles.dataDisplayHeaderFeatureUnselected;
+      } else {
+        style = styles.dataDisplayHeaderHighlighted;
+      }
     } else {
-      /* if (false && key === this.props.labelColumn) {
+      if (false && key === this.props.labelColumn) {
         style = styles.dataDisplayHeaderLabelUnselected;
       } else if (false && this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayHeaderFeatureUnselected;
-      } else */ {
+      } else {
         style = styles.dataDisplayHeaderUnselected;
       }
     }
@@ -66,19 +76,27 @@ class DataDisplay extends Component {
     let style;
 
     if (key === this.props.currentColumn) {
-      /* if (key === this.props.labelColumn) {
+      if (key === this.props.labelColumn) {
         style = styles.dataDisplayCellLabelSelected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayCellFeatureSelected;
-      } else */ {
+      } else {
         style = styles.dataDisplayCellSelected;
       }
-    } else {
-      /* if (key === this.props.labelColumn) {
+    } else if (key === this.props.highlightColumn) {
+      if (key === this.props.labelColumn) {
         style = styles.dataDisplayCellLabelUnselected;
       } else if (this.props.selectedFeatures.includes(key)) {
         style = styles.dataDisplayCellFeatureUnselected;
-      } else */ {
+      } else {
+        style = styles.dataDisplayCellHighlighted;
+      }
+    } else {
+      if (key === this.props.labelColumn) {
+        style = styles.dataDisplayCellLabelUnselected;
+      } else if (this.props.selectedFeatures.includes(key)) {
+        style = styles.dataDisplayCellFeatureUnselected;
+      } else {
         style = styles.dataDisplayCellUnselected;
       }
     }
@@ -87,7 +105,7 @@ class DataDisplay extends Component {
   };
 
   render() {
-    const { data, setCurrentColumn, currentPanel, setColumnRef } = this.props;
+    const { data, setCurrentColumn, currentPanel, setColumnRef, setHighlightColumn } = this.props;
 
     return (
       <div id="data-display" style={styles.panel}>
@@ -120,6 +138,8 @@ class DataDisplay extends Component {
                           style={this.getColumnHeaderStyle(key)}
                           onClick={() => setCurrentColumn(key)}
                           ref={ref => setColumnRef(key, ref)}
+                          onMouseEnter={() => setHighlightColumn(key)}
+                          onMouseLeave={() => setHighlightColumn(undefined)}
                         >
                           {key}
                         </th>
@@ -139,6 +159,8 @@ class DataDisplay extends Component {
                                 key={key}
                                 style={this.getColumnCellStyle(key)}
                                 onClick={() => setCurrentColumn(key)}
+                                onMouseEnter={() => setHighlightColumn(key)}
+                                onMouseLeave={() => setHighlightColumn(undefined)}
                               >
                                 {row[key]}
                               </td>
@@ -171,11 +193,15 @@ export default connect(
     selectedFeatures: state.selectedFeatures,
     emptyCellDetails: getEmptyCellDetails(state),
     currentColumn: state.currentColumn,
+    highlightColumn: state.highlightColumn,
     currentPanel: state.currentPanel
   }),
   dispatch => ({
     setCurrentColumn(column) {
       dispatch(setCurrentColumn(column));
+    },
+    setHighlightColumn(column) {
+      dispatch(setHighlightColumn(column));
     }
   })
 )(DataDisplay);

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -9,19 +9,16 @@ import {
   addSelectedFeature,
   removeSelectedFeature
 } from "../redux";
-import { ColumnTypes, styles } from "../constants.js";
-import { Bar } from "react-chartjs-2";
+import { styles } from "../constants.js";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 
 class PhraseBuilder extends Component {
   static propTypes = {
     labelColumn: PropTypes.string,
-    currentColumnData: PropTypes.object,
     setLabelColumn: PropTypes.func.isRequired,
     addSelectedFeature: PropTypes.func.isRequired,
     removeSelectedFeature: PropTypes.func.isRequired,
-    rangesByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
     hideSpecifyColumns: PropTypes.bool,
     selectableLabels: PropTypes.array,
@@ -43,26 +40,11 @@ class PhraseBuilder extends Component {
 
   render() {
     const {
-      currentColumnData,
-      rangesByColumn,
       labelColumn,
       selectedFeatures,
       selectableLabels,
       selectableFeatures
     } = this.props;
-
-    if (
-      currentColumnData &&
-      currentColumnData.dataType === ColumnTypes.CATEGORICAL
-    ) {
-      barData.labels = Object.values(currentColumnData.uniqueOptions);
-      barData.datasets[0].data = barData.labels.map(option => {
-        return currentColumnData.frequencies[option];
-      });
-      barData.datasets[0].label = currentColumnData.id;
-    }
-
-    const maxLabelsInHistogram = 4;
 
     return (
       <div

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -1,0 +1,146 @@
+/* React component to handle setting datatype for selected columns. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import {
+  getSelectableLabels,
+  getSelectableFeatures,
+  setLabelColumn,
+  addSelectedFeature,
+  removeSelectedFeature
+} from "../redux";
+import { ColumnTypes, styles } from "../constants.js";
+import { Bar } from "react-chartjs-2";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+
+class PhraseBuilder extends Component {
+  static propTypes = {
+    labelColumn: PropTypes.string,
+    currentColumnData: PropTypes.object,
+    setLabelColumn: PropTypes.func.isRequired,
+    addSelectedFeature: PropTypes.func.isRequired,
+    removeSelectedFeature: PropTypes.func.isRequired,
+    rangesByColumn: PropTypes.object,
+    setCurrentColumn: PropTypes.func,
+    hideSpecifyColumns: PropTypes.bool,
+    selectableLabels: PropTypes.array,
+    selectableFeatures: PropTypes.array,
+    selectedFeatures: PropTypes.array
+  };
+
+  handleChangeLabelSelect = event => {
+    this.props.setLabelColumn(event.target.value);
+  };
+
+  handleChangeFeatureSelect = event => {
+    this.props.addSelectedFeature(event.target.value);
+  };
+
+  removeSelectedFeature = feature => {
+    this.props.removeSelectedFeature(feature);
+  };
+
+  render() {
+    const {
+      currentColumnData,
+      rangesByColumn,
+      labelColumn,
+      selectedFeatures,
+      selectableLabels,
+      selectableFeatures
+    } = this.props;
+
+    if (
+      currentColumnData &&
+      currentColumnData.dataType === ColumnTypes.CATEGORICAL
+    ) {
+      barData.labels = Object.values(currentColumnData.uniqueOptions);
+      barData.datasets[0].data = barData.labels.map(option => {
+        return currentColumnData.frequencies[option];
+      });
+      barData.datasets[0].label = currentColumnData.id;
+    }
+
+    const maxLabelsInHistogram = 4;
+
+    return (
+      <div
+        id="phrase-builder"
+        style={{
+          ...styles.panel,
+          ...styles.rightPanel,
+          ...styles.phraseBuilder
+        }}
+      >
+        <div style={styles.phraseBuilderHeader}>Predict...</div>
+        <select
+          value={labelColumn}
+          onChange={this.handleChangeLabelSelect}
+          style={{ fontSize: 24, marginTop: 10, padding: 6 }}
+        >
+          <option>{""}</option>
+          {selectableLabels.map((feature, index) => {
+            return (
+              <option key={index} value={feature}>
+                {feature}
+              </option>
+            );
+          })}
+        </select>
+        <br />
+        <div style={styles.phraseBuilderHeader}>Based on...</div>
+        {selectedFeatures.map((feature, index) => {
+          return (
+            <div key={index} style={{ padding: 10, paddingBottom: 0, position: "relative" }}>
+              {feature}
+              <div
+                onClick={() => this.removeSelectedFeature(feature)}
+                style={styles.phraseBuilderFeatureRemove}
+              >
+                <FontAwesomeIcon icon={faTimes} />
+              </div>
+            </div>
+          );
+        })}
+        {/*<div>+ Add feature</div>*/}
+        <select
+          value={""}
+          onChange={this.handleChangeFeatureSelect}
+          style={{ fontSize: 24, marginTop: 10, padding: 6 }}
+        >
+          <option key="default" value="" disabled>
+            + Add feature
+          </option>
+          {selectableFeatures.map((feature, index) => {
+            return (
+              <option key={index} value={feature}>
+                {feature}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    labelColumn: state.labelColumn,
+    selectedFeatures: state.selectedFeatures,
+    selectableLabels: getSelectableLabels(state),
+    selectableFeatures: getSelectableFeatures(state)
+  }),
+  dispatch => ({
+    setLabelColumn(labelColumn) {
+      dispatch(setLabelColumn(labelColumn));
+    },
+    addSelectedFeature(labelColumn) {
+      dispatch(addSelectedFeature(labelColumn));
+    },
+    removeSelectedFeature(labelColumn) {
+      dispatch(removeSelectedFeature(labelColumn));
+    }
+  })
+)(PhraseBuilder);

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -77,7 +77,7 @@ class PhraseBuilder extends Component {
         <select
           value={labelColumn}
           onChange={this.handleChangeLabelSelect}
-          style={{ fontSize: 24, marginTop: 10, padding: 6 }}
+          style={styles.phraseBuilderSelect}
         >
           <option>{""}</option>
           {selectableLabels.map((feature, index) => {
@@ -92,7 +92,7 @@ class PhraseBuilder extends Component {
         <div style={styles.phraseBuilderHeader}>Based on...</div>
         {selectedFeatures.map((feature, index) => {
           return (
-            <div key={index} style={{ padding: 10, paddingBottom: 0, position: "relative" }}>
+            <div key={index} style={styles.phraseBuilderFeature}>
               {feature}
               <div
                 onClick={() => this.removeSelectedFeature(feature)}
@@ -103,11 +103,10 @@ class PhraseBuilder extends Component {
             </div>
           );
         })}
-        {/*<div>+ Add feature</div>*/}
         <select
           value={""}
           onChange={this.handleChangeFeatureSelect}
-          style={{ fontSize: 24, marginTop: 10, padding: 6 }}
+          style={styles.phraseBuilderSelect}
         >
           <option key="default" value="" disabled>
             + Add feature

--- a/src/UIComponents/ScatterPlot.jsx
+++ b/src/UIComponents/ScatterPlot.jsx
@@ -82,7 +82,7 @@ class ScatterPlot extends Component {
 
     return (
       scatterPlotData && (
-        <div id="scatter-plot">
+        <div id="scatter-plot" style={styles.halfPanel}>
           <div style={styles.largeText}>Correlation Information</div>
           <div style={styles.scrollableContents}>
             <div style={{ ...styles.scrollingContents, height: 300 }}>

--- a/src/UIComponents/ScatterPlot.jsx
+++ b/src/UIComponents/ScatterPlot.jsx
@@ -82,10 +82,7 @@ class ScatterPlot extends Component {
 
     return (
       scatterPlotData && (
-        <div
-          id="scatter-plot"
-          style={{ ...styles.panel, ...styles.rightPanel }}
-        >
+        <div id="scatter-plot">
           <div style={styles.largeText}>Correlation Information</div>
           <div style={styles.scrollableContents}>
             <div style={{ ...styles.scrollingContents, height: 300 }}>

--- a/src/UIComponents/ScatterPlot.jsx
+++ b/src/UIComponents/ScatterPlot.jsx
@@ -82,7 +82,7 @@ class ScatterPlot extends Component {
 
     return (
       scatterPlotData && (
-        <div id="scatter-plot" style={styles.halfPanel}>
+        <div id="scatter-plot">
           <div style={styles.largeText}>Correlation Information</div>
           <div style={styles.scrollableContents}>
             <div style={{ ...styles.scrollingContents, height: 300 }}>

--- a/src/constants.js
+++ b/src/constants.js
@@ -363,5 +363,30 @@ export const styles = {
   floatLeft: {
     float: "left",
     margin: 20
+  },
+
+  phraseBuilder: {
+    fontSize: 24
+  },
+
+  phraseBuilderHeader: {
+    backgroundColor: "grey",
+    color: "white",
+    padding: 15
+  },
+
+  popupClose: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    cursor: "pointer"
+  },
+
+  phraseBuilderFeatureRemove: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    cursor: "pointer",
+    fontSize: 12
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -388,5 +388,19 @@ export const styles = {
     right: 10,
     cursor: "pointer",
     fontSize: 12
+  },
+
+  phraseBuilderSelect: {
+    fontSize: 24,
+    marginTop: 10,
+    padding: 6,
+    cursor: "pointer"
+  },
+
+  phraseBuilderFeature: { padding: 10, paddingBottom: 0, position: "relative" },
+
+  halfPanel: {
+    float: "left",
+    width: "50%"
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -238,6 +238,11 @@ export const styles = {
     color: "white"
   },
 
+  dataDisplayHeaderHighlighted: {
+    backgroundColor: "#64fff16b",
+    color: "white"
+  },
+
   dataDisplayCell: {
     paddingLeft: 20,
     textAlign: "right"
@@ -261,6 +266,9 @@ export const styles = {
     backgroundColor: featureColor
   },
   dataDisplayCellUnselected: {},
+
+  dataDisplayCellHighlighted: { backgroundColor: "#64fff16b" },
+
   crossTabCell0: {
     backgroundColor: "rgba(255,100,100, 0)"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -111,6 +111,14 @@ export const styles = {
     flexDirection: "column"
   },
 
+  popupPanel: {
+    position: "absolute",
+    border: "1px solid",
+    top: 90,
+    height: "initial",
+    zIndex: 1
+  },
+
   scrollableContents: {
     overflow: "hidden"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const processMode = mode => {
       // Also retrieve model metadata and set column data types.
       parseJSON(assetPath + item.metadataPath);
 
-      store.dispatch(setCurrentPanel("dataDisplayLabel"));
+      store.dispatch(setCurrentPanel("dataDisplay"));
     }
 
     // Select a trainer immediately.

--- a/src/redux.js
+++ b/src/redux.js
@@ -1224,6 +1224,10 @@ export function getScatterPlotData(state) {
     return null;
   }
 
+  if (state.labelColumn === state.currentColumn) {
+    return null;
+  }
+
   // For each row, record the X (feature value) and Y (label value).
   const data = [];
   for (let row of state.data) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -61,6 +61,7 @@ const SET_TRAINED_MODEL_DETAILS = "SET_TRAINED_MODEL_DETAILS";
 const SET_TRAINED_MODEL_DETAIL = "SET_TRAINED_MODEL_DETAIL";
 const SET_CURRENT_PANEL = "SET_CURRENT_PANEL";
 const SET_CURRENT_COLUMN = "SET_CURRENT_COLUMN";
+const SET_HIGHLIGHT_COLUMN = "SET_HIGHLIGHT_COLUMN";
 const SET_RESULTS_PHASE = "SET_RESULTS_PHASE";
 const SET_SAVE_STATUS = "SET_SAVE_STATUS";
 const SET_COLUMN_REF = "SET_COLUMN_REF";
@@ -201,6 +202,10 @@ export function setCurrentPanel(currentPanel) {
 
 export function setCurrentColumn(currentColumn) {
   return { type: SET_CURRENT_COLUMN, currentColumn };
+}
+
+export function setHighlightColumn(highlightColumn) {
+  return { type: SET_HIGHLIGHT_COLUMN, highlightColumn };
 }
 
 export function setResultsPhase(phase) {
@@ -467,6 +472,12 @@ export default function rootReducer(state = initialState, action) {
       ...state,
       currentPanel: action.currentPanel,
       currentColumn: undefined
+    };
+  }
+  if (action.type === SET_HIGHLIGHT_COLUMN) {
+    return {
+      ...state,
+      highlightColumn: action.highlightColumn
     };
   }
   if (action.type === SET_CURRENT_COLUMN) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -989,8 +989,7 @@ export function getPredictAvailable(state) {
 const panelList = [
   { id: "selectDataset", label: "Import" },
   { id: "specifyColumns", label: "Columns" },
-  { id: "dataDisplayLabel", label: "Label" },
-  { id: "dataDisplayFeatures", label: "Features" },
+  { id: "dataDisplay", label: "Data" },
   { id: "selectTrainer", label: "Trainer" },
   { id: "trainModel", label: "Train" },
   { id: "results", label: "Results" },
@@ -1010,18 +1009,6 @@ function isPanelEnabled(state, panelId) {
 
   if (panelId === "specifyColumns") {
     if (state.data.length === 0) {
-      return false;
-    }
-  }
-
-  if (panelId === "dataDisplayLabel") {
-    if (state.data.length === 0) {
-      return false;
-    }
-  }
-
-  if (panelId === "dataDisplayFeatures") {
-    if (!state.labelColumn) {
       return false;
     }
   }
@@ -1096,7 +1083,7 @@ export function getPanelButtons(state) {
       ? { panel: "trainModel", text: "Train" }
       : null;
   } else if (state.currentPanel === "selectTrainer") {
-    prev = { panel: "dataDisplayFeatures", text: "Back" };
+    prev = { panel: "dataDisplay", text: "Back" };
     next = isPanelEnabled(state, "trainModel")
       ? { panel: "trainModel", text: "Train" }
       : null;
@@ -1106,7 +1093,7 @@ export function getPanelButtons(state) {
       next = { panel: "results", text: "Continue" };
     }
   } else if (state.currentPanel === "results") {
-    prev = { panel: "dataDisplayFeatures", text: "Back" };
+    prev = { panel: "dataDisplay", text: "Back" };
     next = isPanelEnabled(state, "saveModel")
       ? { panel: "saveModel", text: "Save" }
       : { panel: "continue", text: "Continue" };


### PR DESCRIPTION
Implementing the newer design for `DataDisplay` which features the label & feature selection on the right, and a popup for the column data and graphs.  The popup also gets the `CrossTab` when a label is selected.

I'm a bit dubious about the logic for positioning the popup, but it seems to work.  Currently, the popup gets hidden when the data is scrolled.

https://user-images.githubusercontent.com/2205926/110903953-1785b300-82bd-11eb-9ec0-e5cd4b6e4196.mov

