### PR TITLE
Remove the result predicted when a user selects different data

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -9,8 +9,7 @@ import {
   getSelectedCategoricalFeatures,
   getUniqueOptionsByColumn,
   getConvertedPredictedLabel,
-  getPredictAvailable,
-  setPrediction
+  getPredictAvailable
 } from "../redux";
 import { styles } from "../constants";
 
@@ -24,15 +23,13 @@ class Predict extends Component {
     setTestData: PropTypes.func.isRequired,
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     confidence: PropTypes.number,
-    getPredictAvailable: PropTypes.bool,
-    setPrediction: PropTypes.func
+    getPredictAvailable: PropTypes.bool
   };
 
   handleChange = (event, feature) => {
     const testData = this.props.testData;
     testData[feature] = event.target.value;
     this.props.setTestData(testData);
-    this.props.setPrediction({});
   };
 
   onClickPredict = () => {
@@ -130,9 +127,6 @@ export default connect(
   dispatch => ({
     setTestData(testData) {
       dispatch(setTestData(testData));
-    },
-    setPrediction(prediction) {
-      dispatch(setPrediction(prediction));
     }
   })
 )(Predict);

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -9,7 +9,8 @@ import {
   getSelectedCategoricalFeatures,
   getUniqueOptionsByColumn,
   getConvertedPredictedLabel,
-  getPredictAvailable
+  getPredictAvailable,
+  setPrediction
 } from "../redux";
 import { styles } from "../constants";
 
@@ -23,13 +24,15 @@ class Predict extends Component {
     setTestData: PropTypes.func.isRequired,
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     confidence: PropTypes.number,
-    getPredictAvailable: PropTypes.bool
+    getPredictAvailable: PropTypes.bool,
+    setPrediction: PropTypes.func
   };
 
   handleChange = (event, feature) => {
     const testData = this.props.testData;
     testData[feature] = event.target.value;
     this.props.setTestData(testData);
+    this.props.setPrediction({});
   };
 
   onClickPredict = () => {
@@ -127,6 +130,9 @@ export default connect(
   dispatch => ({
     setTestData(testData) {
       dispatch(setTestData(testData));
+    },
+    setPrediction(prediction) {
+      dispatch(setPrediction(prediction));
     }
   })
 )(Predict);

--- a/src/redux.js
+++ b/src/redux.js
@@ -391,7 +391,8 @@ export default function rootReducer(state = initialState, action) {
   if (action.type === SET_TEST_DATA) {
     return {
       ...state,
-      testData: action.testData
+      testData: action.testData,
+      prediction: {}
     };
   }
   if (action.type === SET_PREDICTION) {


### PR DESCRIPTION
[Trello task ](https://trello.com/c/I45sSEUf/113-when-user-selects-different-data-in-test-tool-remove-the-result-predicted)

https://user-images.githubusercontent.com/40412372/110993616-6159b200-832c-11eb-8cce-9b68bc5c0780.mov

