### PR TITLE
Adjust screen usage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -84,7 +84,7 @@ export const styles = {
   bodyContainer: {
     height: "100%",
     boxSizing: "border-box",
-    paddingBottom: 100
+    paddingBottom: 50
   },
 
   largeText: {
@@ -310,7 +310,8 @@ export const styles = {
     left: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer"
+    cursor: "pointer",
+    zIndex: 1001
   },
 
   nextButton: {
@@ -318,7 +319,8 @@ export const styles = {
     right: 20,
     bottom: 40,
     fontSize: 30,
-    cursor: "pointer"
+    cursor: "pointer",
+    zIndex: 1001
   },
 
   navButton: {


### PR DESCRIPTION
Use more vertical space, and force the navigation buttons to display over the top of the levelbuilder UI.  (The levelbuilder UI can still be used.)

![Screen Shot 2021-03-18 at 9 37 43 AM](https://user-images.githubusercontent.com/2205926/111547864-0d3d3c00-8737-11eb-8485-1c01d6f63b3b.png)
