### PR TITLE
Fix preloaded single dataset param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const processMode = mode => {
       // Also retrieve model metadata and set column data types.
       parseJSON(assetPath + item.metadataPath);
 
-      store.dispatch(setCurrentPanel("dataDisplay"));
+      store.dispatch(setCurrentPanel("dataDisplayLabel"));
     }
 
     // Select a trainer immediately.


### PR DESCRIPTION
Levels with a single pre-selected dataset (e.g. [this one](https://levelbuilder-studio.code.org/s/ai-classroom-test/stage/1/puzzle/1)) were broken because we were setting the current panel to "dataDisplay"; however, after a refactor in #109 "dataDisplay" as current panel option no longer existed so nothing showed up! 

BEFORE: 

![Screen Shot 2021-03-17 at 8 09 06 PM](https://user-images.githubusercontent.com/12300669/111554554-f8739f00-875c-11eb-857e-af5f01c1bc9d.png)


Instead, we now have two screens: "dataDisplayLabel" and "dataDisplayFeatures".  If we have a preselected dataset, now we set the current panel to "dataDisplayLabel" and the correct content shows up. 

AFTER: 
![Screen Shot 2021-03-17 at 8 09 44 PM](https://user-images.githubusercontent.com/12300669/111554551-f6114500-875c-11eb-829e-2584cecc810f.png)
