### PR TITLE
Optional parameter to hide column clicking

### DIFF
--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -9,7 +9,8 @@ const sampleModes = {
     hideSpecifyColumns: true,
     hideSelectTrainer: "knnClassify",
     hideChooseReserve: true,
-    hideModelCard: true
+    hideModelCard: true,
+    hideColumnClicking: true
   },
 
   "preload-metadata": {

--- a/src/redux.js
+++ b/src/redux.js
@@ -496,18 +496,23 @@ export default function rootReducer(state = initialState, action) {
   }
   if (action.type === SET_CURRENT_COLUMN) {
     if (!getShowColumnClicking(state)) {
-      // Do nothing.
+      // If no column clicking, do nothing.
+      return state;
+    }
+    if (
+      state.currentPanel === "dataDisplayFeatures" &&
+      action.currentColumn === state.labelColumn
+    ) {
+      // If doing feature selection, and the label column is clicked, do nothing.
+      return state;
     } else if (state.currentColumn === action.currentColumn) {
+      // If column is selected, then deselect.
       return {
         ...state,
         currentColumn: undefined
       };
-    } else if (
-      state.currentPanel !== "dataDisplayFeatures" ||
-      action.currentColumn !== state.labelColumn
-    ) {
-      // We don't do this if we are on the feature-selection panel
-      // and the user chose the column that is already the label.
+    } else {
+      // Select the column.
       return {
         ...state,
         currentColumn: action.currentColumn

--- a/src/redux.js
+++ b/src/redux.js
@@ -487,13 +487,17 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_HIGHLIGHT_COLUMN) {
-    return {
-      ...state,
-      highlightColumn: action.highlightColumn
-    };
+    if (getShowColumnClicking(state)) {
+      return {
+        ...state,
+        highlightColumn: action.highlightColumn
+      };
+    }
   }
   if (action.type === SET_CURRENT_COLUMN) {
-    if (state.currentColumn === action.currentColumn) {
+    if (!getShowColumnClicking(state)) {
+      // Do nothing.
+    } else if (state.currentColumn === action.currentColumn) {
       return {
         ...state,
         currentColumn: undefined
@@ -986,6 +990,10 @@ export function getShowSelectLabels(state) {
 
 export function getSpecifiedDatasets(state) {
   return state.mode && state.mode.datasets;
+}
+
+export function getShowColumnClicking(state) {
+  return !(state.mode && state.mode.hideColumnClicking);
 }
 
 export function getShowChooseReserve(state) {


### PR DESCRIPTION
This adds a new optional parameter called `hideColumnClicking` which will disable column hovering and clicking, which means no popups with column metadata.  We suspect this might be necessary in earlier levels.
