### PR TITLE
Remove two instructions

### DIFF
--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -93,14 +93,6 @@ class DataDisplay extends Component {
 
     return (
       <div id="data-display" style={styles.panel}>
-        <div style={styles.largeText}>
-          {currentPanel === "dataDisplayLabel" && (
-            <div>Explore columns and choose a label:</div>
-          )}
-          {currentPanel === "dataDisplayFeatures" && (
-            <div>Explore pairs and choose features:</div>
-          )}
-        </div>
         <div
           style={styles.tableParent}
           onScroll={() => setCurrentColumn(undefined)}


### PR DESCRIPTION
With the main TopInstructions now doing instructional duties, the instructions above the DataDisplay can now be removed.