### PR TITLE
Make results header visible on Code Studio

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -223,6 +223,7 @@ export const styles = {
     position: "sticky",
     top: 0
   },
+
   dataDisplayHeaderLabelSelected: {
     backgroundColor: labelColor,
     color: "yellow"
@@ -298,7 +299,8 @@ export const styles = {
 
   resultsTableFirstHeader: {
     top: 0,
-    backgroundColor: "white"
+    backgroundColor: "white",
+    color: "rgb(30, 30, 30)"
   },
 
   resultsTableSecondHeader: {


### PR DESCRIPTION
Styling on https://studio.code.org is a little different, and the results header was white text on a white background there.