### PR TITLE
Added setup details and how to verify symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn install
 yarn start
 ```
 
-The app will be running at [http://localhost:8080](http://localhost:8080).
+The app will be running at http://localhost:8080.
 
 ### Running a local standalone server
 
@@ -44,7 +44,7 @@ Borrowing one step from above:
 yarn start
 ```
 
-The app will be running at [http://localhost:8080](http://localhost:8080).
+The app will be running at http://localhost:8080.
 
 ### First time integration with local Code Studio
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Then commit the changed `package.json` and `yarn.lock` files so that the officia
 
 ### Verify symlink exists between code-dot-org repo and ML playground
 In main repo: 
- ``` 
+``` 
  cd apps/node_modules/@code-dot-org 
  ls -l 
- ```
-In the output, you should see something like this: ``` ml-playground -> ../../../../../.config/yarn/link/@code-dot-org/ml-playground ```
+```
+In the output, you should see something like this: `ml-playground -> ../../../../../.config/yarn/link/@code-dot-org/ml-playground`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In main repo:
 bin/dashboard-server 
 ``` 
 
-In main repo's `apps/` directory, run 
+In main repo's `apps/` directory: 
 ``` 
 yarn start 
 ```
@@ -92,9 +92,9 @@ In this repo:
 yarn run build
 ```
 
-Then the main repo's `apps` build will pick up changes. 
+Then the local Code Studio apps build will pick up changes. 
 
-See ML-playground changes at http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1.
+See AI Lab changes at http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1.
 
 Note that running `yarn start` will erase this build, and so for now it seems best to alternate between using `yarn start` for testing the standalone build, and using `yarn run build` to make a single build for consumption by the main repo.
 
@@ -128,7 +128,7 @@ yarn
 
 Then commit the changed `package.json` and `yarn.lock` files so that the official build pipeline uses the new version.
 
-### Verify symlink exists between code-dot-org repo and ML playground
+### Verifying a symlink exists between the main repo and ML playground
 In main repo: 
 ``` 
  cd apps/node_modules/@code-dot-org 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,6 @@ yarn link @code-dot-org/ml-playground
 
 This will set up a symlink in main repo's `apps/node_modules/` to point at your local changes. 
 
-Run 
-
-```
-yarn run build
-```
-
-in this repo, and then the main repo's `apps` build should pick the changes up next time it builds.
-
-If you are running `yarn start` for continuous builds in the main repo, it will pick up the changes once the build in this repo has completed.
 
 ### Building changes for a local Code Studio
 In main repo:
@@ -91,7 +82,7 @@ In this repo:
 yarn run build
 ```
 
-Then the local Code Studio apps build will pick up changes.
+Then the main repo's `apps` build will pick up changes. 
 
 See ML-playground changes at  [http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1](http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1).
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ yarn link @code-dot-org/ml-playground
 
 This will set up a symlink in main repo's `apps/node_modules/` to point at your local changes. 
 
+Run 
+
+```
+yarn run build
+```
+
+in this repo, and then the main repo's `apps` build should pick the changes up next time it builds.
+
+If you are running `yarn start` for continuous builds in the main repo, it will pick up the changes once the build in this repo has completed.
+
 
 ### Building changes for a local Code Studio
 In main repo:
@@ -75,7 +85,7 @@ In main repo's `apps/` directory, run
 yarn start 
 ```
 
-If you see an error, run ``` yarn ``` before running ``` yarn start ``` again.
+If you see an error, run `yarn` before running `yarn start` again.
 
 In this repo:
 ```
@@ -84,7 +94,7 @@ yarn run build
 
 Then the main repo's `apps` build will pick up changes. 
 
-See ML-playground changes at  [http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1](http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1).
+See ML-playground changes at http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1.
 
 Note that running `yarn start` will erase this build, and so for now it seems best to alternate between using `yarn start` for testing the standalone build, and using `yarn run build` to make a single build for consumption by the main repo.
 
@@ -124,4 +134,4 @@ In main repo:
  cd apps/node_modules/@code-dot-org 
  ls -l 
  ```
-In the output, you should see: ``` ml-playground -> ../../../../../.config/yarn/link/@code-dot-org/ml-playground ```
+In the output, you should see something like this: ``` ml-playground -> ../../../../../.config/yarn/link/@code-dot-org/ml-playground ```

--- a/README.md
+++ b/README.md
@@ -73,14 +73,27 @@ in this repo, and then the main repo's `apps` build should pick the changes up n
 If you are running `yarn start` for continuous builds in the main repo, it will pick up the changes once the build in this repo has completed.
 
 ### Building changes for a local Code Studio
+In main repo:
 
-Borrowing one step from above:
+``` 
+bin/dashboard-server 
+``` 
 
+In main repo's `apps/` directory, run 
+``` 
+yarn start 
+```
+
+If you see an error, run ``` yarn ``` before running ``` yarn start ``` again.
+
+In this repo:
 ```
 yarn run build
 ```
 
 Then the local Code Studio apps build will pick up changes.
+
+See ML-playground changes at  [http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1](http://localhost-studio.code.org:3000/s/allthethings/stage/43/puzzle/1).
 
 Note that running `yarn start` will erase this build, and so for now it seems best to alternate between using `yarn start` for testing the standalone build, and using `yarn run build` to make a single build for consumption by the main repo.
 
@@ -113,3 +126,11 @@ yarn
 ```
 
 Then commit the changed `package.json` and `yarn.lock` files so that the official build pipeline uses the new version.
+
+### Verify symlink exists between code-dot-org repo and ML playground
+In main repo: 
+ ``` 
+ cd apps/node_modules/@code-dot-org 
+ ls -l 
+ ```
+In the output, you should see: ``` ml-playground -> ../../../../../.config/yarn/link/@code-dot-org/ml-playground ```


### PR DESCRIPTION
I cleaned up the **First time integration with local Code Studio** section: 
![Screen Shot 2021-03-24 at 3 23 51 PM](https://user-images.githubusercontent.com/40412372/112391372-0a04fb80-8cb5-11eb-93ee-c659652bf875.png)



I added some setup details under the section **Building changes for a local Code Studio**
![Screen Shot 2021-03-24 at 3 11 22 PM](https://user-images.githubusercontent.com/40412372/112390265-40417b80-8cb3-11eb-8a5c-cd41bf268eb2.png)


I also added a section on how to verify the symlink is still there.  
![Screen Shot 2021-03-24 at 3 11 10 PM](https://user-images.githubusercontent.com/40412372/112390253-39b30400-8cb3-11eb-8270-e82541101896.png)


Would it be more readable if there are numbered steps or is it okay the way it is? 

