### PR TITLE
Expose continuous feature ranges in app lab

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -45,7 +45,6 @@ const ADD_SELECTED_FEATURE = "ADD_SELECTED_FEATURE";
 const REMOVE_SELECTED_FEATURE = "REMOVE_SELECTED_FEATURE";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
-const SET_RANGES_BY_COLUMN = "SET_RANGES_BY_COLUMN";
 const SET_PERCENT_DATA_TO_RESERVE = "SET_PERCENT_DATA_TO_RESERVE";
 const SET_RESERVE_LOCATION = "SET_RESERVE_LOCATION";
 const SET_ACCURACY_CHECK_EXAMPLES = "SET_ACCURACY_CHECK_EXAMPLES";
@@ -140,10 +139,6 @@ export function setLabelColumn(labelColumn) {
 */
 export function setFeatureNumberKey(featureNumberKey) {
   return { type: SET_FEATURE_NUMBER_KEY, featureNumberKey };
-}
-
-export function setRangesByColumn(rangesByColumn) {
-  return { type: SET_RANGES_BY_COLUMN, rangesByColumn };
 }
 
 export function setPercentDataToReserve(percentDataToReserve) {
@@ -242,7 +237,6 @@ const initialState = {
   selectedFeatures: [],
   labelColumn: undefined,
   featureNumberKey: {},
-  rangesByColumn: {},
   trainingExamples: [],
   trainingLabels: [],
   percentDataToReserve: 10,
@@ -371,12 +365,6 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       featureNumberKey: action.featureNumberKey
-    };
-  }
-  if (action.type === SET_RANGES_BY_COLUMN) {
-    return {
-      ...state,
-      rangesByColumn: action.rangesByColumn
     };
   }
   if (action.type === SET_TRAINING_EXAMPLES) {
@@ -701,6 +689,14 @@ export function getUniqueOptionsByColumn(state) {
   return uniqueOptionsByColumn;
 }
 
+export function getExtremumsByColumn(state) {
+  let extremumsByColumn = {};
+  getNumericalColumns(state).map(
+    column => (extremumsByColumn[column] = getRange(state, column, false))
+  );
+  return extremumsByColumn;
+}
+
 export function getRangesByColumn(state) {
   let rangesByColumn = {};
   getNumericalColumns(state).map(
@@ -709,11 +705,15 @@ export function getRangesByColumn(state) {
   return rangesByColumn;
 }
 
-export function getRange(state, column) {
+export function getRange(state, column, shouldReturnRange = true) {
   let range = {};
   range.max = Math.max(...state.data.map(row => parseFloat(row[column])));
   range.min = Math.min(...state.data.map(row => parseFloat(row[column])));
-  range.range = range.max - range.min;
+
+  if (shouldReturnRange) {
+    range.range = range.max - range.min;
+  }
+
   return range;
 }
 
@@ -1009,7 +1009,7 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.selectedTrainer = getSelectedTrainer(state);
   dataToSave.selectedFeatures = state.selectedFeatures;
   dataToSave.featureNumberKey = state.featureNumberKey;
-  dataToSave.rangesByColumn = getRangesByColumn(state);
+  dataToSave.extremumsByColumn = getExtremumsByColumn(state);
   dataToSave.labelColumn = state.labelColumn;
   dataToSave.summaryStat = getSummaryStat(state);
   dataToSave.trainedModel = state.trainedModel;

--- a/src/redux.js
+++ b/src/redux.js
@@ -45,6 +45,7 @@ const ADD_SELECTED_FEATURE = "ADD_SELECTED_FEATURE";
 const REMOVE_SELECTED_FEATURE = "REMOVE_SELECTED_FEATURE";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
+const SET_RANGES_BY_COLUMN = "SET_RANGES_BY_COLUMN";
 const SET_PERCENT_DATA_TO_RESERVE = "SET_PERCENT_DATA_TO_RESERVE";
 const SET_RESERVE_LOCATION = "SET_RESERVE_LOCATION";
 const SET_ACCURACY_CHECK_EXAMPLES = "SET_ACCURACY_CHECK_EXAMPLES";
@@ -139,6 +140,10 @@ export function setLabelColumn(labelColumn) {
 */
 export function setFeatureNumberKey(featureNumberKey) {
   return { type: SET_FEATURE_NUMBER_KEY, featureNumberKey };
+}
+
+export function setRangesByColumn(rangesByColumn) {
+  return { type: SET_RANGES_BY_COLUMN, rangesByColumn };
 }
 
 export function setPercentDataToReserve(percentDataToReserve) {
@@ -237,6 +242,7 @@ const initialState = {
   selectedFeatures: [],
   labelColumn: undefined,
   featureNumberKey: {},
+  rangesByColumn: {},
   trainingExamples: [],
   trainingLabels: [],
   percentDataToReserve: 10,
@@ -365,6 +371,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       featureNumberKey: action.featureNumberKey
+    };
+  }
+  if (action.type === SET_RANGES_BY_COLUMN) {
+    return {
+      ...state,
+      rangesByColumn: action.rangesByColumn
     };
   }
   if (action.type === SET_TRAINING_EXAMPLES) {
@@ -997,6 +1009,7 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.selectedTrainer = getSelectedTrainer(state);
   dataToSave.selectedFeatures = state.selectedFeatures;
   dataToSave.featureNumberKey = state.featureNumberKey;
+  dataToSave.rangesByColumn = getRangesByColumn(state);
   dataToSave.labelColumn = state.labelColumn;
   dataToSave.summaryStat = getSummaryStat(state);
   dataToSave.trainedModel = state.trainedModel;


### PR DESCRIPTION
Added rangesByColumn to saved model data in order to show the min and max values in app lab. 

![Screen Shot 2021-03-25 at 1 27 59 PM](https://user-images.githubusercontent.com/40412372/112539247-ff5a6d00-8d6d-11eb-865d-c51f78c5c2a3.png)


Related PR: https://github.com/code-dot-org/code-dot-org/pull/39756



Updated screenshot that shows the most recent push: 
![Screen Shot 2021-03-29 at 3 22 29 PM](https://user-images.githubusercontent.com/40412372/112908503-7bbdba80-90a4-11eb-9c45-753a8138c513.png)

