### PR TITLE
delete accuracyCheckGrades

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -244,7 +244,6 @@ const initialState = {
   accuracyCheckExamples: [],
   accuracyCheckLabels: [],
   accuracyCheckPredictedLabels: [],
-  accuracyCheckGrades: [],
   testData: {},
   prediction: {},
   modelSize: undefined,


### PR DESCRIPTION
Tiny clean-up to remove unused initial state that I discovered while doing some debugging for a separate issue. We use `getAccuracyGrades` to get this data. 