### PR TITLE
Fix jump to features

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -1139,6 +1139,8 @@ export function getPanelButtons(state) {
     prev = null;
     next = isPanelEnabled(state, "dataDisplayLabel")
       ? { panel: "dataDisplayLabel", text: "Continue" }
+      : isPanelEnabled(state, "dataDisplayFeatures")
+      ? { panel: "dataDisplayFeatures", text: "Continue" }
       : null;
   } else if (state.currentPanel === "dataDisplayLabel") {
     prev = isPanelEnabled(state, "selectDataset")


### PR DESCRIPTION
The "Continue" button is now shown after a dataset is chosen and `hideSelectLabel` is used; it will jump directly to features.