### PR TITLE
Styling updates

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
       #root {
         position: fixed;
         top: 40px;
-        bottom: 20px;
+        bottom: 48px;
         left: 20px;
         right: 20px;
       }

--- a/src/App.js
+++ b/src/App.js
@@ -55,7 +55,6 @@ class PanelButtons extends Component {
               style={styles.navButton}
               onClick={this.onClickPrev}
             >
-              &#9664; &nbsp;
               {panelButtons.prev.text}
             </button>
           </div>
@@ -69,7 +68,6 @@ class PanelButtons extends Component {
               onClick={this.onClickNext}
             >
               {panelButtons.next.text}
-              &nbsp; &#9654;
             </button>
           </div>
         )}

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -28,7 +28,7 @@ class DataDisplay extends Component {
         >
           <DataTable setColumnRef={setColumnRef} />
         </div>
-        <div style={styles.mediumText}>
+        <div style={styles.footerText}>
           There are {this.props.data.length} rows of data.
         </div>
       </div>

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import Statement from "./Statement";
 import DataTable from "./DataTable";
 import { setCurrentColumn } from "../redux";
 import { styles } from "../constants";
@@ -22,6 +23,7 @@ class DataDisplay extends Component {
 
     return (
       <div id="data-display" style={styles.panel}>
+        <Statement />
         <div
           style={styles.tableParent}
           onScroll={() => setCurrentColumn(undefined)}

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -23,62 +23,22 @@ class DataTable extends Component {
   getColumnHeaderStyle = key => {
     let style;
 
-    if (key === this.props.currentColumn) {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayHeaderLabelSelected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayHeaderFeatureSelected;
-      } else {
-        style = styles.dataDisplayHeaderSelected;
-      }
-    } else if (key === this.props.highlightColumn) {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayHeaderLabelUnselected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayHeaderFeatureUnselected;
-      } else {
-        style = styles.dataDisplayHeaderHighlighted;
-      }
-    } else {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayHeaderLabelUnselected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayHeaderFeatureUnselected;
-      } else {
-        style = styles.dataDisplayHeaderUnselected;
-      }
+    if (key === this.props.labelColumn) {
+      style = styles.dataDisplayHeaderLabel;
+    } else if (this.props.selectedFeatures.includes(key)) {
+      style = styles.dataDisplayHeaderFeature;
     }
 
-    return { ...styles.tableHeader, ...styles.dataDisplayHeaderUnselected, ...style };
+    return { ...styles.dataDisplayHeader, ...style };
   };
 
   getColumnCellStyle = key => {
     let style;
 
     if (key === this.props.currentColumn) {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayCellLabelSelected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayCellFeatureSelected;
-      } else {
-        style = styles.dataDisplayCellSelected;
-      }
+      style = styles.dataDisplayCellSelected;
     } else if (key === this.props.highlightColumn) {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayCellLabelUnselected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayCellFeatureUnselected;
-      } else {
-        style = styles.dataDisplayCellHighlighted;
-      }
-    } else {
-      if (key === this.props.labelColumn) {
-        style = styles.dataDisplayCellLabelUnselected;
-      } else if (this.props.selectedFeatures.includes(key)) {
-        style = styles.dataDisplayCellFeatureUnselected;
-      } else {
-        style = styles.dataDisplayCellUnselected;
-      }
+      style = styles.dataDisplayCellHighlighted;
     }
 
     return { ...styles.dataDisplayCell, ...style };

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -49,7 +49,7 @@ class DataTable extends Component {
       }
     }
 
-    return { ...style, ...styles.tableHeader };
+    return { ...styles.tableHeader, ...styles.dataDisplayHeaderUnselected, ...style };
   };
 
   getColumnCellStyle = key => {
@@ -81,7 +81,7 @@ class DataTable extends Component {
       }
     }
 
-    return { ...style, ...styles.tableCell };
+    return { ...styles.dataDisplayCell, ...style };
   };
 
   getColumns = () => {

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -81,7 +81,7 @@ class PhraseBuilder extends Component {
 
             {currentPanel === "dataDisplayFeatures" && (
               <div>
-                <div style={styles.phraseBuilderSelectReadonly}>
+                <div style={styles.phraseBuilderLabel}>
                   {labelColumn}
                 </div>
                 <br />

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -59,7 +59,7 @@ class PhraseBuilder extends Component {
       >
         <div style={styles.scrollableContents}>
           <div style={styles.scrollingContents}>
-            <div style={styles.phraseBuilderHeader}>Predict...</div>
+            <div style={styles.phraseBuilderHeader}>Label:</div>
             {currentPanel === "dataDisplayLabel" && (
               <select
                 value={labelColumn === null ? "" : labelColumn}
@@ -86,7 +86,7 @@ class PhraseBuilder extends Component {
                 </div>
                 <br />
                 <div>
-                  <div style={styles.phraseBuilderHeader}>Based on...</div>
+                  <div style={styles.phraseBuilderHeader}>Features:</div>
                   {selectedFeatures.map((feature, index) => {
                     return (
                       <div key={index} style={styles.phraseBuilderFeature}>

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -66,7 +66,9 @@ class PhraseBuilder extends Component {
                 onChange={this.handleChangeLabelSelect}
                 style={styles.phraseBuilderSelect}
               >
-                <option>{""}</option>
+                <option key="default" value="" disabled>
+                  Choose Label
+                </option>
                 {selectableLabels.map((feature, index) => {
                   return (
                     <option key={index} value={feature}>

--- a/src/UIComponents/PhraseBuilder.jsx
+++ b/src/UIComponents/PhraseBuilder.jsx
@@ -62,7 +62,7 @@ class PhraseBuilder extends Component {
             <div style={styles.phraseBuilderHeader}>Label:</div>
             {currentPanel === "dataDisplayLabel" && (
               <select
-                value={labelColumn === null ? "" : labelColumn}
+                value={!labelColumn ? "" : labelColumn}
                 onChange={this.handleChangeLabelSelect}
                 style={styles.phraseBuilderSelect}
               >
@@ -81,12 +81,9 @@ class PhraseBuilder extends Component {
 
             {currentPanel === "dataDisplayFeatures" && (
               <div>
-                <div style={styles.phraseBuilderLabel}>
-                  {labelColumn}
-                </div>
-                <br />
+                <div style={styles.phraseBuilderLabel}>{labelColumn}</div>
                 <div>
-                  <div style={styles.phraseBuilderHeader}>Features:</div>
+                  <div style={styles.phraseBuilderHeaderSecond}>Features:</div>
                   {selectedFeatures.map((feature, index) => {
                     return (
                       <div key={index} style={styles.phraseBuilderFeature}>

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -88,14 +88,20 @@ class Predict extends Component {
           </div>
         </div>
         <br />
-        <button
-          type="button"
-          style={styles.regularButton}
-          onClick={this.onClickPredict}
-          disabled={!this.props.getPredictAvailable}
-        >
-          Predict
-        </button>
+        <div>
+          <button
+            type="button"
+            style={
+              !this.props.getPredictAvailable
+                ? styles.disabledButton
+                : undefined
+            }
+            onClick={this.onClickPredict}
+            disabled={!this.props.getPredictAvailable}
+          >
+            Predict
+          </button>
+        </div>
         {this.props.predictedLabel && (
           <div>
             <p />

--- a/src/UIComponents/Results.jsx
+++ b/src/UIComponents/Results.jsx
@@ -11,6 +11,7 @@ import {
 import { styles } from "../constants";
 import aiBotHead from "@public/images/ai-bot/ai-bot-head.png";
 import aiBotBody from "@public/images/ai-bot/ai-bot-body.png";
+import Statement from "./Statement";
 import ResultsTable from "./ResultsTable";
 
 class Results extends Component {
@@ -42,6 +43,7 @@ class Results extends Component {
   render() {
     return (
       <div id="results" style={styles.panel}>
+        <Statement />
         {this.props.resultsPhase === 0 && (
           <div style={{ ...styles.trainBot, margin: "0 auto" }}>
             <img

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -46,7 +46,10 @@ class ResultsTable extends Component {
                     ...styles.resultsTableFirstHeader
                   }}
                 >
-                  <span style={styles.largeText}>{"A.I. Prediction"}</span>
+                  <span style={styles.largeText}>{"Actual"}</span>
+                  {this.props.isRegression && (
+                    <div style={styles.smallText}>{"+/- 3% of range"}</div>
+                  )}
                 </th>
                 <th
                   style={{
@@ -54,10 +57,7 @@ class ResultsTable extends Component {
                     ...styles.resultsTableFirstHeader
                   }}
                 >
-                  <span style={styles.largeText}>{"Actual"}</span>
-                  {this.props.isRegression && (
-                    <div style={styles.smallText}>{"+/- 3% of range"}</div>
-                  )}
+                  <span style={styles.largeText}>{"A.I. Prediction"}</span>
                 </th>
                 <th
                   colSpan={featureCount}
@@ -122,10 +122,10 @@ class ResultsTable extends Component {
                       );
                     })}
                     <td style={styles.tableCell}>
-                      {this.props.accuracyCheckPredictedLabels[index]}
+                      {this.props.accuracyCheckLabels[index]}
                     </td>
                     <td style={styles.tableCell}>
-                      {this.props.accuracyCheckLabels[index]}
+                      {this.props.accuracyCheckPredictedLabels[index]}
                     </td>
                     {this.props.accuracyGrades[index] ===
                       ResultsGrades.CORRECT && (

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -33,12 +33,13 @@ class ResultsTable extends Component {
                 <th
                   colSpan={featureCount}
                   style={{
-                    ...styles.largeText,
                     ...styles.tableHeader,
                     ...styles.resultsTableFirstHeader
                   }}
                 >
-                  Features
+                  <span style={styles.largeText}>
+                    Features
+                  </span>
                 </th>
                 <th
                   style={{

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { setTrainedModelDetail, getSelectedColumnDescriptions } from "../redux";
 import { styles, saveMessages, ModelNameMaxLength } from "../constants";
+import Statement from "./Statement";
 
 class SaveModel extends Component {
   static propTypes = {
@@ -77,6 +78,7 @@ class SaveModel extends Component {
 
     return (
       <div style={styles.panel}>
+        <Statement />
         <div style={styles.scrollableContentsTinted}>
           <div style={styles.scrollingContents}>
             <div key={nameField.id} style={styles.cardRow}>

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -7,7 +7,8 @@ import {
   setSelectedCSV,
   setSelectedJSON,
   resetState,
-  getSpecifiedDatasets
+  getSpecifiedDatasets,
+  setHighlightDataset
 } from "../redux";
 import { parseCSV } from "../csvReaderWrapper";
 import { parseJSON } from "../jsonReaderWrapper";
@@ -19,11 +20,13 @@ class SelectDataset extends Component {
     setSelectedName: PropTypes.func.isRequired,
     setSelectedCSV: PropTypes.func.isRequired,
     setSelectedJSON: PropTypes.func.isRequired,
+    setHighlightDataset: PropTypes.func.isRequired,
     csvfile: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     jsonfile: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     resetState: PropTypes.func.isRequired,
     specifiedDatasets: PropTypes.arrayOf(PropTypes.string),
-    name: PropTypes.string
+    name: PropTypes.string,
+    highlightDataset: PropTypes.string
   };
 
   constructor(props) {
@@ -100,11 +103,17 @@ class SelectDataset extends Component {
                 <div
                   style={{
                     ...styles.selectDatasetItem,
+                    ...(this.props.highlightDataset === dataset.name &&
+                      styles.selectDatasetItemHighlighted),
                     ...(this.props.name === dataset.name &&
                       styles.selectDatasetItemSelected)
                   }}
                   key={dataset.id}
                   onClick={() => this.handleDatasetClick(dataset.id)}
+                  onMouseEnter={() =>
+                    this.props.setHighlightDataset(dataset.name)
+                  }
+                  onMouseLeave={() => this.props.setHighlightDataset(undefined)}
                 >
                   <img
                     src={assetPath + dataset.imagePath}
@@ -147,7 +156,8 @@ export default connect(
     csvfile: state.csvfile,
     jsonfile: state.jsonfile,
     specifiedDatasets: getSpecifiedDatasets(state),
-    name: state.name
+    name: state.name,
+    highlightDataset: state.highlightDataset
   }),
   dispatch => ({
     resetState() {
@@ -161,6 +171,9 @@ export default connect(
     },
     setSelectedJSON(jsonfilePath) {
       dispatch(setSelectedJSON(jsonfilePath));
+    },
+    setHighlightDataset(id) {
+      dispatch(setHighlightDataset(id));
     }
   })
 )(SelectDataset);

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -120,7 +120,7 @@ class SelectDataset extends Component {
                     style={styles.selectDatasetImage}
                     draggable={false}
                   />
-                  <div>{dataset.name}</div>
+                  <div style={styles.selectDatasetText}>{dataset.name}</div>
                 </div>
               );
             })}

--- a/src/UIComponents/Statement.jsx
+++ b/src/UIComponents/Statement.jsx
@@ -1,0 +1,52 @@
+/* React component to display a statement about our model. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { styles } from "../constants";
+
+class Statement extends Component {
+  static propTypes = {
+    data: PropTypes.array,
+    labelColumn: PropTypes.string,
+    selectedFeatures: PropTypes.array
+  };
+
+  render() {
+    const {
+      data,
+      labelColumn,
+      selectedFeatures
+    } = this.props;
+
+    if (data.length === 0) {
+      return null;
+    }
+
+    return (
+      <div style={styles.statement} id="statement">
+        Predict{" "}
+        <span style={styles.statementLabel}>
+          {labelColumn || "..."}
+        </span>
+        <span>
+          {" "}
+          based on{" "}
+          <span style={styles.statementFeature}>
+            {selectedFeatures.length > 0
+              ? selectedFeatures.join(", ")
+              : ".."}
+          </span>
+          {"."}
+        </span>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    data: state.data,
+    labelColumn: state.labelColumn,
+    selectedFeatures: state.selectedFeatures
+  })
+)(Statement);

--- a/src/UIComponents/Statement.jsx
+++ b/src/UIComponents/Statement.jsx
@@ -34,9 +34,11 @@ class Statement extends Component {
           <span style={styles.statementFeature}>
             {selectedFeatures.length > 0
               ? selectedFeatures.join(", ")
-              : ".."}
+              : "..."}
           </span>
-          {"."}
+          {selectedFeatures.length > 0 && (
+            "."
+          )}
         </span>
       </div>
     );

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -8,6 +8,7 @@ import { styles } from "../constants";
 import aiBotHead from "@public/images/ai-bot/ai-bot-head.png";
 import aiBotBody from "@public/images/ai-bot/ai-bot-body.png";
 import labBackground from "@public/images/lab-background-light.png";
+import Statement from "./Statement";
 import DataTable from "./DataTable";
 
 const framesPerCycle = 40;
@@ -82,22 +83,7 @@ class TrainModel extends Component {
           backgroundImage: "url(" + labBackground + ")"
         }}
       >
-        <div style={styles.statement}>
-          Predict{" "}
-          <span style={styles.statementLabel}>
-            {this.props.labelColumn || "..."}
-          </span>
-          <span>
-            {" "}
-            based on{" "}
-            <span style={styles.statementFeature}>
-              {this.props.selectedFeatures.length > 0
-                ? this.props.selectedFeatures.join(", ")
-                : ".."}
-            </span>
-            {"."}
-          </span>
-        </div>
+        <Statement/>
 
         <div style={styles.trainModelContainer}>
           <div style={styles.trainModelDataTable}>

--- a/src/constants.js
+++ b/src/constants.js
@@ -102,10 +102,14 @@ export const styles = {
     marginBottom: 8
   },
 
+  footerText: {
+    fontSize: 13,
+    marginTop: 12
+  },
+
   panel: {
-    padding: 20,
+    padding: 10,
     backgroundColor: "white", // rgb(230,230,230)",
-    borderRadius: 5,
     overflow: "hidden",
     height: "100%",
     boxSizing: "border-box",
@@ -127,19 +131,19 @@ export const styles = {
 
   scrollableContentsTinted: {
     overflow: "hidden",
-    borderRadius: 5,
+    borderRadius: 0,
     backgroundColor: "rgb(206, 206, 206)"
   },
 
   scrollingContents: {
-    padding: 15,
+    //padding: 15,
     overflow: "scroll",
     height: "100%",
     boxSizing: "border-box"
   },
 
   contents: {
-    borderRadius: 5,
+    borderRadius: 0,
     backgroundColor: "rgb(206, 206, 206)",
     padding: 15
   },
@@ -185,12 +189,16 @@ export const styles = {
     float: "left",
     boxSizing: "border-box",
     border: "solid 4px rgba(0,0,0,0)",
-    borderRadius: 10,
-    height: 240
+    borderRadius: 0,
+    height: 220
+  },
+
+  selectDatasetItemHighlighted: {
+    backgroundColor: "#d6f2fa",
   },
 
   selectDatasetItemSelected: {
-    border: "solid 4px white"
+    backgroundColor: "#94e3fa",
   },
 
   selectDatasetImage: {
@@ -226,7 +234,12 @@ export const styles = {
     fontSize: 12
   },
 
-  dataDisplayHeaderUnselected: {
+  dataDisplayHeader: {
+    paddingLeft: 20,
+    textAlign: "right",
+    position: "sticky",
+    top: 0,
+    fontSize: 12,
     backgroundColor: "white",
     color: "#4d575f",
     borderStyle: "solid solid solid solid",
@@ -235,21 +248,14 @@ export const styles = {
     padding: 7,
     fontSize: 14
   },
-  dataDisplayHeaderHighlighted: {
-    backgroundColor: "#64fff16b",
-    color: "white",
-    borderStyle: "solid solid solid solid",
-    borderWidth: 1,
-    borderColor: "#00adbc #00adbc grey #00adbc",
-    padding: 7
+
+  dataDisplayHeaderLabel: {
+    backgroundColor: labelColor,
+    color: "white"
   },
-  dataDisplayHeaderSelected: {
-    color: "black",
-    backgroundColor: "white",
-    borderStyle: "solid solid solid solid",
-    borderWidth: 1,
-    borderColor: "#00adbc #00adbc #00adbc green",
-    padding: 7
+  dataDisplayHeaderFeature: {
+    backgroundColor: featureColor,
+    color: "white"
   },
 
   dataDisplayCell: {
@@ -261,39 +267,20 @@ export const styles = {
     backgroundColor: "#f2f2f2",
     borderStyle: "solid solid solid solid",
     borderWidth: 1,
-    borderColor: "white" // "#c6cacd"
+    borderColor: "white"
   },
   dataDisplayCellHighlighted: {
-    backgroundColor: "#d6f2fa", // #64fff16b",
-    borderStyle: "solid none",
-    borderWidth: 1,
-    borderColor: "#d6f2fa", // "#c6cacd" // "#c6cacd #00adbc #c6cacd #00adbc"
-    cursor: "pointer"
-  },
-  dataDisplayCellSelected: {
-    color: "black",
     backgroundColor: "#d6f2fa",
     borderStyle: "solid none",
     borderWidth: 1,
-    borderColor: "#d6f2fa" // "#bae5f1" // "#c6cacd" // "#c6cacd #00adbc #c6cacd #00adbc"
+    borderColor: "#d6f2fa",
+    cursor: "pointer"
   },
-
-  dataDisplayHeaderLabelSelected: {
-    backgroundColor: labelColor,
-    color: "yellow"
-  },
-  dataDisplayHeaderFeatureSelected: {
-    backgroundColor: featureColor,
-    color: "yellow"
-  },
-
-  dataDisplayHeaderLabelUnselected: {
-    backgroundColor: labelColor,
-    color: "white"
-  },
-  dataDisplayHeaderFeatureUnselected: {
-    backgroundColor: featureColor,
-    color: "white"
+  dataDisplayCellSelected: {
+    backgroundColor: "#94e3fa",
+    borderStyle: "solid none",
+    borderWidth: 1,
+    borderColor: "#94e3fa"
   },
 
   tableCell: {
@@ -301,21 +288,11 @@ export const styles = {
     textAlign: "right",
     fontSize: 12
   },
-  dataDisplayCellLabelSelected: {
-    backgroundColor: labelColorSemi,
-    color: "yellow"
-  },
-  dataDisplayCellFeatureSelected: {
-    backgroundColor: featureColor,
-    color: "yellow"
-  },
+  dataDisplayCellLabelSelected: {},
+  dataDisplayCellFeatureSelected: {},
 
-  dataDisplayCellLabelUnselected: {
-    backgroundColor: labelColorSemi
-  },
-  dataDisplayCellFeatureUnselected: {
-    backgroundColor: featureColor
-  },
+  dataDisplayCellLabelUnselected: {},
+  dataDisplayCellFeatureUnselected: {},
   dataDisplayCellUnselected: {},
 
   crossTabCell0: {
@@ -484,13 +461,28 @@ export const styles = {
     width: "100%"
   },
 
-  phraseBuilderSelectReadonly: {
+  phraseBuilderLabel: {
     fontSize: 16,
     marginTop: 10,
-    padding: 6
+    paddingTop: 13,
+    paddingLeft: 13,
+    height: 43,
+    backgroundColor: labelColor,
+    color: "white",
+    boxSizing: "border-box"
   },
 
-  phraseBuilderFeature: { padding: 10, paddingBottom: 0, position: "relative" },
+  phraseBuilderFeature: {
+    fontSize: 16,
+    marginTop: 10,
+    paddingTop: 13,
+    paddingLeft: 13,
+    height: 43,
+    backgroundColor: featureColor,
+    color: "white",
+    boxSizing: "border-box",
+    position: "relative"
+  },
 
   saveInputsWidth: {
     width: "95%"

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,8 +34,8 @@ const labelColorSemi = "rgba(254, 96, 3, 0.4)";
 const featureColor = "rgb(75, 155, 213)";
 
 export const colors = {
-  feature: "rgb(70, 186, 168)",
-  label: "rgb(186, 168, 70)"
+  feature: featureColor,
+  label: labelColor
 };
 
 export const styles = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -205,6 +205,11 @@ export const styles = {
     width: "100%"
   },
 
+  selectDatasetText: {
+    fontSize: 14,
+    marginTop: 10
+  },
+
   specifyColumnsItem: {
     display: "inline-block",
     width: "20%"
@@ -437,6 +442,13 @@ export const styles = {
     backgroundColor: "grey",
     color: "white",
     padding: 15
+  },
+
+  phraseBuilderHeaderSecond: {
+    backgroundColor: "grey",
+    color: "white",
+    padding: 15,
+    marginTop: 30
   },
 
   popupClose: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -131,7 +131,8 @@ export const styles = {
   scrollableContentsTinted: {
     overflow: "hidden",
     borderRadius: 0,
-    backgroundColor: "rgb(206, 206, 206)"
+    backgroundColor: "rgb(206, 206, 206)",
+    padding: 10
   },
 
   scrollingContents: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -325,7 +325,8 @@ export const styles = {
   },
 
   resultsTableSecondHeader: {
-    top: "30px"
+    top: "30px",
+    color: "white"
   },
 
   previousButton: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -205,7 +205,8 @@ export const styles = {
   displayTable: {
     whiteSpace: "nowrap",
     borderSpacing: 0,
-    width: "100%"
+    width: "100%",
+    borderCollapse: "collapse"
   },
 
   tableParent: {
@@ -225,6 +226,58 @@ export const styles = {
     fontSize: 12
   },
 
+  dataDisplayHeaderUnselected: {
+    backgroundColor: "white",
+    color: "#4d575f",
+    borderStyle: "solid solid solid solid",
+    borderWidth: 1,
+    borderColor: "white", // #c6cacd",
+    padding: 7,
+    fontSize: 14
+  },
+  dataDisplayHeaderHighlighted: {
+    backgroundColor: "#64fff16b",
+    color: "white",
+    borderStyle: "solid solid solid solid",
+    borderWidth: 1,
+    borderColor: "#00adbc #00adbc grey #00adbc",
+    padding: 7
+  },
+  dataDisplayHeaderSelected: {
+    color: "black",
+    backgroundColor: "white",
+    borderStyle: "solid solid solid solid",
+    borderWidth: 1,
+    borderColor: "#00adbc #00adbc #00adbc green",
+    padding: 7
+  },
+
+  dataDisplayCell: {
+    padding: 3,
+    paddingLeft: 20,
+    textAlign: "right",
+    fontSize: 12,
+    color: "#4d575f",
+    backgroundColor: "#f2f2f2",
+    borderStyle: "solid solid solid solid",
+    borderWidth: 1,
+    borderColor: "white" // "#c6cacd"
+  },
+  dataDisplayCellHighlighted: {
+    backgroundColor: "#d6f2fa", // #64fff16b",
+    borderStyle: "solid none",
+    borderWidth: 1,
+    borderColor: "#d6f2fa", // "#c6cacd" // "#c6cacd #00adbc #c6cacd #00adbc"
+    cursor: "pointer"
+  },
+  dataDisplayCellSelected: {
+    color: "black",
+    backgroundColor: "#d6f2fa",
+    borderStyle: "solid none",
+    borderWidth: 1,
+    borderColor: "#d6f2fa" // "#bae5f1" // "#c6cacd" // "#c6cacd #00adbc #c6cacd #00adbc"
+  },
+
   dataDisplayHeaderLabelSelected: {
     backgroundColor: labelColor,
     color: "yellow"
@@ -233,10 +286,7 @@ export const styles = {
     backgroundColor: featureColor,
     color: "yellow"
   },
-  dataDisplayHeaderSelected: {
-    color: "yellow",
-    backgroundColor: "black"
-  },
+
   dataDisplayHeaderLabelUnselected: {
     backgroundColor: labelColor,
     color: "white"
@@ -245,14 +295,7 @@ export const styles = {
     backgroundColor: featureColor,
     color: "white"
   },
-  dataDisplayHeaderUnselected: {
-    backgroundColor: "black",
-    color: "white"
-  },
-  dataDisplayHeaderHighlighted: {
-    backgroundColor: "#64fff16b",
-    color: "white"
-  },
+
   tableCell: {
     paddingLeft: 20,
     textAlign: "right",
@@ -266,10 +309,7 @@ export const styles = {
     backgroundColor: featureColor,
     color: "yellow"
   },
-  dataDisplayCellSelected: {
-    color: "yellow",
-    backgroundColor: "grey"
-  },
+
   dataDisplayCellLabelUnselected: {
     backgroundColor: labelColorSemi
   },
@@ -277,8 +317,6 @@ export const styles = {
     backgroundColor: featureColor
   },
   dataDisplayCellUnselected: {},
-
-  dataDisplayCellHighlighted: { backgroundColor: "#64fff16b" },
 
   crossTabCell0: {
     backgroundColor: "rgba(255,100,100, 0)"

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,7 +29,7 @@ export const saveMessages = {
   name: "Please name your model."
 };
 
-const labelColor = "rgb(254, 96, 3)"; // was 186
+const labelColor = "rgb(254, 96, 3)";
 const featureColor = "rgb(75, 155, 213)";
 
 export const colors = {
@@ -108,7 +108,7 @@ export const styles = {
 
   panel: {
     padding: 10,
-    backgroundColor: "white", // rgb(230,230,230)",
+    backgroundColor: "white",
     overflow: "hidden",
     height: "100%",
     boxSizing: "border-box",
@@ -136,7 +136,6 @@ export const styles = {
   },
 
   scrollingContents: {
-    //padding: 15,
     overflow: "scroll",
     height: "100%",
     boxSizing: "border-box"
@@ -168,7 +167,7 @@ export const styles = {
     marginLeft: 10,
     width: "calc(30% - 20px)",
     padding: 20,
-    backgroundColor: "white", // rgb(230,230,230)",
+    backgroundColor: "white",
     borderRadius: 5,
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 18,
@@ -247,7 +246,7 @@ export const styles = {
     color: "#4d575f",
     borderStyle: "solid",
     borderWidth: 1,
-    borderColor: "white", // #c6cacd",
+    borderColor: "white",
     padding: 7,
     fontSize: 14
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -169,7 +169,6 @@ export const styles = {
     width: "calc(30% - 20px)",
     padding: 20,
     backgroundColor: "white", // rgb(230,230,230)",
-    //border: "solid 1px black",
     borderRadius: 5,
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 18,
@@ -246,7 +245,7 @@ export const styles = {
     top: 0,
     backgroundColor: "white",
     color: "#4d575f",
-    borderStyle: "solid solid solid solid",
+    borderStyle: "solid",
     borderWidth: 1,
     borderColor: "white", // #c6cacd",
     padding: 7,
@@ -269,20 +268,20 @@ export const styles = {
     fontSize: 12,
     color: "#4d575f",
     backgroundColor: "#f2f2f2",
-    borderStyle: "solid solid solid solid",
+    borderStyle: "solid",
     borderWidth: 1,
     borderColor: "white"
   },
   dataDisplayCellHighlighted: {
     backgroundColor: "#d6f2fa",
-    borderStyle: "solid none",
+    borderStyle: "solid",
     borderWidth: 1,
     borderColor: "#d6f2fa",
     cursor: "pointer"
   },
   dataDisplayCellSelected: {
     backgroundColor: "#94e3fa",
-    borderStyle: "solid none",
+    borderStyle: "solid",
     borderWidth: 1,
     borderColor: "#94e3fa"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -420,7 +420,9 @@ export const styles = {
     marginBottom: 5
   },
 
-  regularButton: { width: "20%" },
+  disabledButton: {
+    opacity: 0.5
+  },
 
   floatLeft: {
     float: "left",

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,7 +30,6 @@ export const saveMessages = {
 };
 
 const labelColor = "rgb(254, 96, 3)"; // was 186
-const labelColorSemi = "rgba(254, 96, 3, 0.4)";
 const featureColor = "rgb(75, 155, 213)";
 
 export const colors = {
@@ -244,7 +243,6 @@ export const styles = {
     textAlign: "right",
     position: "sticky",
     top: 0,
-    fontSize: 12,
     backgroundColor: "white",
     color: "#4d575f",
     borderStyle: "solid solid solid solid",

--- a/src/constants.js
+++ b/src/constants.js
@@ -356,10 +356,8 @@ export const styles = {
   },
 
   statement: {
-    fontSize: 36,
-    backgroundColor: "rgba(255,255,255,0.8)",
-    padding: 10,
-    borderRadius: 5
+    fontSize: 32,
+    paddingBottom: 15
   },
 
   statementLabel: {

--- a/src/redux.js
+++ b/src/redux.js
@@ -1096,7 +1096,7 @@ function isPanelEnabled(state, panelId) {
   }
 
   if (panelId === "selectTrainer") {
-    if (mode && mode.hideSelectTrainer && mode.hideChooseReserve) {
+    if (mode && mode.hideSpecifyColumns && mode.hideChooseReserve) {
       return false;
     }
     if (!uniqLabelFeaturesSelected(state)) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -62,6 +62,7 @@ const SET_TRAINED_MODEL_DETAIL = "SET_TRAINED_MODEL_DETAIL";
 const SET_CURRENT_PANEL = "SET_CURRENT_PANEL";
 const SET_CURRENT_COLUMN = "SET_CURRENT_COLUMN";
 const SET_HIGHLIGHT_COLUMN = "SET_HIGHLIGHT_COLUMN";
+const SET_HIGHLIGHT_DATASET = "SET_HIGHLIGHT_DATASET";
 const SET_RESULTS_PHASE = "SET_RESULTS_PHASE";
 const SET_INSTRUCTIONS_KEY_CALLBACK = "SET_INSTRUCTIONS_KEY_CALLBACK";
 const SET_SAVE_STATUS = "SET_SAVE_STATUS";
@@ -213,6 +214,10 @@ export function setHighlightColumn(highlightColumn) {
   return { type: SET_HIGHLIGHT_COLUMN, highlightColumn };
 }
 
+export function setHighlightDataset(highlightDataset) {
+  return { type: SET_HIGHLIGHT_DATASET, highlightDataset };
+}
+
 export function setResultsPhase(phase) {
   return { type: SET_RESULTS_PHASE, phase };
 }
@@ -233,6 +238,8 @@ const initialState = {
   metadata: undefined,
   selectedTrainer: undefined,
   kValue: undefined,
+  highlightDataset: undefined,
+  highlightColumn: undefined,
   columnsByDataType: {},
   selectedFeatures: [],
   labelColumn: undefined,
@@ -510,6 +517,12 @@ export default function rootReducer(state = initialState, action) {
         ...state,
         highlightColumn: action.highlightColumn
       };
+    }
+  }
+  if (action.type === SET_HIGHLIGHT_DATASET) {
+    return {
+      ...state,
+      highlightDataset: action.highlightDataset
     }
   }
   if (action.type === SET_CURRENT_COLUMN) {
@@ -1173,7 +1186,7 @@ export function getPanelButtons(state) {
       ? { panel: "dataDisplayFeatures", text: "Back" }
       : null;
     next = isPanelEnabled(state, "saveModel")
-      ? { panel: "saveModel", text: "Save" }
+      ? { panel: "saveModel", text: "Continue" }
       : { panel: "continue", text: "Continue" };
   } else if (state.currentPanel === "saveModel") {
     prev = { panel: "results", text: "Back" };

--- a/src/redux.js
+++ b/src/redux.js
@@ -495,16 +495,6 @@ export default function rootReducer(state = initialState, action) {
       state.instructionsKeyCallback(action.currentPanel);
     }
 
-    if (action.currentPanel === "dataDisplayLabel") {
-      return {
-        ...state,
-        currentPanel: action.currentPanel,
-        currentColumn: undefined,
-        labelColumn: "",
-        selectedFeatures: []
-      };
-    }
-
     return {
       ...state,
       currentPanel: action.currentPanel,

--- a/src/redux.js
+++ b/src/redux.js
@@ -511,18 +511,27 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_HIGHLIGHT_COLUMN) {
-    if (getShowColumnClicking(state)) {
-      return {
-        ...state,
-        highlightColumn: action.highlightColumn
-      };
+    if (!getShowColumnClicking(state)) {
+      // If no column clicking, do nothing.
+      return state;
     }
+    if (
+      state.currentPanel === "dataDisplayFeatures" &&
+      action.highlightColumn === state.labelColumn
+    ) {
+      // If doing feature selection, and the label column is clicked, do nothing.
+      return state;
+    }
+    return {
+      ...state,
+      highlightColumn: action.highlightColumn
+    };
   }
   if (action.type === SET_HIGHLIGHT_DATASET) {
     return {
       ...state,
       highlightDataset: action.highlightDataset
-    }
+    };
   }
   if (action.type === SET_CURRENT_COLUMN) {
     if (!getShowColumnClicking(state)) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -495,6 +495,15 @@ export default function rootReducer(state = initialState, action) {
       state.instructionsKeyCallback(action.currentPanel);
     }
 
+    if (action.currentPanel === "dataDisplayLabel") {
+      return {
+        ...state,
+        currentPanel: action.currentPanel,
+        currentColumn: undefined,
+        selectedFeatures: []
+      };
+    }
+
     return {
       ...state,
       currentPanel: action.currentPanel,
@@ -1170,9 +1179,7 @@ export function getPanelButtons(state) {
       next = { panel: "results", text: "Continue" };
     }
   } else if (state.currentPanel === "results") {
-    prev = isPanelEnabled(state, "dataDisplayLabel")
-      ? { panel: "dataDisplayLabel", text: "Back" }
-      : isPanelEnabled(state, "dataDisplayFeatures")
+    prev = isPanelEnabled(state, "dataDisplayFeatures")
       ? { panel: "dataDisplayFeatures", text: "Back" }
       : null;
     next = isPanelEnabled(state, "saveModel")


### PR DESCRIPTION
Some general styling updates have been made.

Also, in particular:

- The statement has been restored to DataDisplay and is also shown in TrainModel, Results, and SaveModel.
- SelectDataset now shows mouse hover highlighting.
- DataDisplay now styles its columns for highlight (due to mouse hover) & selected, and column headers for label & feature.
- The PhraseBuilder now uses the terms label & feature.
- TrainingSettings is now hidden if both `hideSpecifyColumns` & `hideChooseReserve` parameters are set.
- Going back from Results goes to feature selection, while going back from feature selection clears features and goes to label selection, making for a symmetrical forward & back navigation.
- The prediction & actual columns have been swapped so that actual results are closest to the source data.
- The predict button now sizes for its content & goes to half-opacity when disabled.
- Arrows are removed from the navigation buttons.
- The buttons no longer slightly overlap the UI in the standalone version.

### screenshots

![Screen Shot 2021-03-31 at 8 46 10 AM](https://user-images.githubusercontent.com/2205926/113061329-b6882700-9166-11eb-93a0-981a6b056232.png)

![Screen Shot 2021-03-31 at 8 44 00 AM](https://user-images.githubusercontent.com/2205926/113061435-e0414e00-9166-11eb-8a92-133e69594ec2.png)

![Screen Shot 2021-03-31 at 8 44 19 AM](https://user-images.githubusercontent.com/2205926/113061438-e20b1180-9166-11eb-8486-5c4b646dc097.png)

![Screen Shot 2021-03-31 at 8 44 33 AM](https://user-images.githubusercontent.com/2205926/113061442-e3d4d500-9166-11eb-9354-0f866583330c.png)

![Screen Shot 2021-03-31 at 8 44 50 AM](https://user-images.githubusercontent.com/2205926/113061446-e5060200-9166-11eb-8abf-300f74690a4f.png)

![Screen Shot 2021-03-31 at 8 45 02 AM](https://user-images.githubusercontent.com/2205926/113061447-e59e9880-9166-11eb-8101-60d63a03b01e.png)

