### PR TITLE
Disable navigation buttons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,8 +52,14 @@ class PanelButtons extends Component {
           <div style={styles.previousButton}>
             <button
               type="button"
-              style={styles.navButton}
+              style={{
+                ...styles.navButton,
+                ...(!panelButtons.prev.enabled
+                  ? styles.disabledButton
+                  : undefined)
+              }}
               onClick={this.onClickPrev}
+              disabled={!panelButtons.prev.enabled}
             >
               {panelButtons.prev.text}
             </button>
@@ -64,8 +70,14 @@ class PanelButtons extends Component {
           <div style={styles.nextButton}>
             <button
               type="button"
-              style={styles.navButton}
+              style={{
+                ...styles.navButton,
+                ...(!panelButtons.next.enabled
+                  ? styles.disabledButton
+                  : undefined)
+              }}
               onClick={this.onClickNext}
+              disabled={!panelButtons.next.enabled}
             >
               {panelButtons.next.text}
             </button>

--- a/src/redux.js
+++ b/src/redux.js
@@ -1083,8 +1083,6 @@ const panelList = [
 */
 
 function isPanelEnabled(state, panelId) {
-  const mode = state.mode;
-
   if (panelId === "specifyColumns") {
     if (state.data.length === 0) {
       return false;

--- a/src/redux.js
+++ b/src/redux.js
@@ -1085,12 +1085,6 @@ const panelList = [
 function isPanelEnabled(state, panelId) {
   const mode = state.mode;
 
-  if (panelId === "selectDataset") {
-    if (mode && mode.datasets && mode.datasets.length === 1) {
-      return false;
-    }
-  }
-
   if (panelId === "specifyColumns") {
     if (state.data.length === 0) {
       return false;
@@ -1099,10 +1093,6 @@ function isPanelEnabled(state, panelId) {
 
   if (panelId === "dataDisplayLabel") {
     if (state.data.length === 0) {
-      return false;
-    }
-
-    if (mode && mode.hideSelectLabel) {
       return false;
     }
   }
@@ -1126,9 +1116,6 @@ function isPanelEnabled(state, panelId) {
   }
 
   if (panelId === "selectTrainer") {
-    if (mode && mode.hideSpecifyColumns && mode.hideChooseReserve) {
-      return false;
-    }
     if (!uniqLabelFeaturesSelected(state)) {
       return false;
     }
@@ -1149,14 +1136,38 @@ function isPanelEnabled(state, panelId) {
     }
   }
 
-  if (panelId === "saveModel") {
-    if (mode && mode.hideSave) {
+  if (panelId === "save") {
+    if ([undefined, ""].includes(state.trainedModelDetails.name)) {
       return false;
     }
   }
 
-  if (panelId === "save") {
-    if ([undefined, ""].includes(state.trainedModelDetails.name)) {
+  return true;
+}
+
+function isPanelAvailable(state, panelId) {
+  const mode = state.mode;
+
+  if (panelId === "selectDataset") {
+    if (mode && mode.datasets && mode.datasets.length === 1) {
+      return false;
+    }
+  }
+
+  if (panelId === "dataDisplayLabel") {
+    if (mode && mode.hideSelectLabel) {
+      return false;
+    }
+  }
+
+  if (panelId === "selectTrainer") {
+    if (mode && mode.hideSpecifyColumns && mode.hideChooseReserve) {
+      return false;
+    }
+  }
+
+  if (panelId === "saveModel") {
+    if (mode && mode.hideSave) {
       return false;
     }
   }
@@ -1170,30 +1181,30 @@ export function getPanelButtons(state) {
 
   if (state.currentPanel === "selectDataset") {
     prev = null;
-    next = isPanelEnabled(state, "dataDisplayLabel")
+    next = isPanelAvailable(state, "dataDisplayLabel")
       ? { panel: "dataDisplayLabel", text: "Continue" }
-      : isPanelEnabled(state, "dataDisplayFeatures")
+      : isPanelAvailable(state, "dataDisplayFeatures")
       ? { panel: "dataDisplayFeatures", text: "Continue" }
       : null;
   } else if (state.currentPanel === "dataDisplayLabel") {
-    prev = isPanelEnabled(state, "selectDataset")
+    prev = isPanelAvailable(state, "selectDataset")
       ? { panel: "selectDataset", text: "Back" }
       : null;
-    next = isPanelEnabled(state, "dataDisplayFeatures")
+    next = isPanelAvailable(state, "dataDisplayFeatures")
       ? { panel: "dataDisplayFeatures", text: "Continue" }
       : null;
   } else if (state.currentPanel === "dataDisplayFeatures") {
-    prev = isPanelEnabled(state, "dataDisplayLabel")
+    prev = isPanelAvailable(state, "dataDisplayLabel")
       ? { panel: "dataDisplayLabel", text: "Back" }
       : null;
-    next = isPanelEnabled(state, "selectTrainer")
+    next = isPanelAvailable(state, "selectTrainer")
       ? { panel: "selectTrainer", text: "Continue" }
-      : isPanelEnabled(state, "trainModel")
+      : isPanelAvailable(state, "trainModel")
       ? { panel: "trainModel", text: "Train" }
       : null;
   } else if (state.currentPanel === "selectTrainer") {
     prev = { panel: "dataDisplayFeatures", text: "Back" };
-    next = isPanelEnabled(state, "trainModel")
+    next = isPanelAvailable(state, "trainModel")
       ? { panel: "trainModel", text: "Train" }
       : null;
   } else if (state.currentPanel === "trainModel") {
@@ -1202,17 +1213,24 @@ export function getPanelButtons(state) {
       next = { panel: "results", text: "Continue" };
     }
   } else if (state.currentPanel === "results") {
-    prev = isPanelEnabled(state, "dataDisplayFeatures")
+    prev = isPanelAvailable(state, "dataDisplayFeatures")
       ? { panel: "dataDisplayFeatures", text: "Back" }
       : null;
-    next = isPanelEnabled(state, "saveModel")
+    next = isPanelAvailable(state, "saveModel")
       ? { panel: "saveModel", text: "Continue" }
       : { panel: "continue", text: "Continue" };
   } else if (state.currentPanel === "saveModel") {
     prev = { panel: "results", text: "Back" };
-    next = isPanelEnabled(state, "save")
+    next = isPanelAvailable(state, "save")
       ? { panel: "save", text: "Finish" }
       : null;
+  }
+
+  if (prev) {
+    prev.enabled = isPanelEnabled(state, prev.panel);
+  }
+  if (next) {
+    next.enabled = isPanelEnabled(state, next.panel);
   }
 
   return { prev, next };


### PR DESCRIPTION
This revives an idea used with our [earlier tabs UI](https://github.com/code-dot-org/ml-playground/pull/45), but applies it to the navigation buttons.  Navigation buttons are now shown if they are available (which means they aren't removed entirely due to a parameter) but they are only enabled when the conditions required to enter the destination screen are met.  Previously, the buttons were hidden in either case.

This will allow the curriculum to refer to a button on the screen, even if the button isn't currently enabled.