### PR TITLE
Fix Predict panel when returning with different features

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -503,6 +503,14 @@ export default function rootReducer(state = initialState, action) {
       };
     }
 
+    if (action.currentPanel === "results") {
+      return {
+        ...state,
+        currentPanel: action.currentPanel,
+        testData: {}
+      };
+    }
+
     return {
       ...state,
       currentPanel: action.currentPanel,


### PR DESCRIPTION
We weren't clearing out the state when returning to Predict (as featured on the Results screen) which was leading to the Predict button being incorrectly disabled when there were fewer features selected upon the later visit.