### PR TITLE
Clear prediction when navigating back to Results

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -1152,7 +1152,7 @@ function isPanelEnabled(state, panelId) {
   return true;
 }
 
-function  isPanelAvailable(state, panelId) {
+function isPanelAvailable(state, panelId) {
   const mode = state.mode;
 
   if (panelId === "selectDataset") {

--- a/src/redux.js
+++ b/src/redux.js
@@ -507,7 +507,8 @@ export default function rootReducer(state = initialState, action) {
       return {
         ...state,
         currentPanel: action.currentPanel,
-        testData: {}
+        testData: {},
+        prediction: {}
       };
     }
 
@@ -1151,7 +1152,7 @@ function isPanelEnabled(state, panelId) {
   return true;
 }
 
-function isPanelAvailable(state, panelId) {
+function  isPanelAvailable(state, panelId) {
   const mode = state.mode;
 
   if (panelId === "selectDataset") {


### PR DESCRIPTION
The prediction wasn't cleared after testing the model and navigating back to the Results page. 

Before: 

https://user-images.githubusercontent.com/40412372/113618597-c4c5bf80-960c-11eb-9d82-d1dad768ea75.mov

After: 

https://user-images.githubusercontent.com/40412372/113618635-d14a1800-960c-11eb-8366-bab95ae10e9f.mov

