### PR TITLE
Update dropdown test scenarios

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,6 @@
       <option value="minimal">minimal</option>
       <option value="intro-ai-tacos">intro-ai-tacos</option>
       <option value="intro-ai-foods">intro-ai-foods</option>
-      <option value="intro-ai-safari">intro-ai-safari</option>
       <option value="safari">safari</option>
       <option value="zoo">zoo</option>
       <option value="final-project">final-project</option>

--- a/public/index.html
+++ b/public/index.html
@@ -38,14 +38,12 @@
       <option disabled selected value="/">Jump to mode...</option>
       <option value="">default</option>
       <option value="minimal">minimal</option>
-      <option value="load-foods">load foods</option>
-      <option value="preload-metadata">preload metadata</option>
-      <option value="ml-knn-train">ml-knn-train</option>
-      <option value="ml-knn-ailab">ml-knn-ailab</option>
-      <option value="ml-svm-train">ml-svm-train</option>
-      <option value="ml-svm-ailab">ml-svm-ailab</option>
-      <option value="ml-mini-project-ailab">ml-mini-project-ailab</option>
-      <option value="ml-final-project-ailab">ml-final-project-ailab</option>
+      <option value="intro-ai-tacos">intro-ai-tacos</option>
+      <option value="intro-ai-foods">intro-ai-foods</option>
+      <option value="intro-ai-safari">intro-ai-safari</option>
+      <option value="safari">safari</option>
+      <option value="zoo">zoo</option>
+      <option value="final-project">final-project</option>
     </select>
     <div id="root"></div>
     <script src="mainDev.js"></script>

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -11,47 +11,53 @@ const sampleModes = {
     hideChooseReserve: true,
     hideModelCard: true,
     hideColumnClicking: true,
-    hideSelectLabel: true,
+    hideSelectLabel: true
   },
 
   "intro-ai-tacos": {
-    datasets:["tacos_toy"],
-    hideSelectLabel:true,
-    hideSpecifyColumns:true,
-    hideChooseReserve:true,
-    hideModelCard:true,
-    hideSave:true
+    datasets: ["tacos_toy"],
+    hideSelectLabel: true,
+    hideSpecifyColumns: true,
+    hideChooseReserve: true,
+    hideModelCard: true,
+    hideSave: true
   },
 
   "intro-ai-foods": {
-    datasets:["boba_toy", "cookies_toy", "naan_toy", "poke_toy", "poutine_toy", "raspado_toy", "salad_toy", "salsa_toy"],
-    hideSelectLabel:true,
-    hideSpecifyColumns:true,
-    hideChooseReserve:true,
-    hideModelCard:true,
-    hideSave:true
+    datasets: [
+      "boba_toy",
+      "cookies_toy",
+      "naan_toy",
+      "poke_toy",
+      "poutine_toy",
+      "raspado_toy",
+      "salad_toy",
+      "salsa_toy"
+    ],
+    hideSelectLabel: true,
+    hideSpecifyColumns: true,
+    hideChooseReserve: true,
+    hideModelCard: true,
+    hideSave: true
   },
 
-  "safari": {
-    datasets:["safari_toy"],
-    hideSelectLabel:true,
-    hideSpecifyColumns:true,
-    hideChooseReserve:true,
-    hideModelCard:true,
-    hideSave:true,
-    hideSelectTrainer:"knnRegress"
+  safari: {
+    datasets: ["safari_toy"],
+    hideSelectLabel: true,
+    hideSpecifyColumns: true,
+    hideChooseReserve: true,
+    hideModelCard: true,
+    hideSave: true,
+    hideSelectTrainer: "knnRegress"
   },
 
-  "zoo": {
-    datasets:["zoo"],
-    hideSpecifyColumns:true,
-    hideChooseReserve:true
+  zoo: {
+    datasets: ["zoo"],
+    hideSpecifyColumns: true,
+    hideChooseReserve: true
   },
 
-  "final-project": {
-
-  }
-
+  "final-project": {}
 };
 
 // Look for a ?mode= parameter on the URL

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -5,7 +5,7 @@ import queryString from "query-string";
 // A list of sample modes.  Should match the dropdown in index.html.
 const sampleModes = {
   minimal: {
-    datasets: ["candy"],
+    datasets: ["tacos_toy"],
     hideSpecifyColumns: true,
     hideSelectTrainer: "knnClassify",
     hideChooseReserve: true,
@@ -14,51 +14,44 @@ const sampleModes = {
     hideSelectLabel: true,
   },
 
-  "preload-metadata": {
-    hideSpecifyColumns: true,
-    hideSelectTrainer: "knnClassify",
-    hideChooseReserve: true
+  "intro-ai-tacos": {
+    datasets:["tacos_toy"],
+    hideSelectLabel:true,
+    hideSpecifyColumns:true,
+    hideChooseReserve:true,
+    hideModelCard:true,
+    hideSave:true
   },
 
-  "load-foods": { datasets: ["foods"] },
-
-  "ml-knn-train": {
-    datasets: ["candy", "titanic", "foods"],
-    hideSelectLabel: true,
-    hideSpecifyColumns: true,
-    hideChooseReserve: true,
-    hideModelCard: true,
-    hideSave: true
+  "intro-ai-foods": {
+    datasets:["boba_toy", "cookies_toy", "naan_toy", "poke_toy", "poutine_toy", "raspado_toy", "salad_toy", "salsa_toy"],
+    hideSelectLabel:true,
+    hideSpecifyColumns:true,
+    hideChooseReserve:true,
+    hideModelCard:true,
+    hideSave:true
   },
 
-  "ml-knn-ailab": {
-    datasets: ["candy", "titanic", "foods"],
-    hideSelectLabel: true,
-    hideSpecifyColumns: true,
-    hideChooseReserve: true,
-    hideModelCard: true
+  "safari": {
+    datasets:["safari_toy"],
+    hideSelectLabel:true,
+    hideSpecifyColumns:true,
+    hideChooseReserve:true,
+    hideModelCard:true,
+    hideSave:true,
+    hideSelectTrainer:"knnRegress"
   },
 
-  "ml-svm-train": {
-    datasets: ["candy"],
-    hideChooseReserve: true,
-    hideModelCard: true
+  "zoo": {
+    datasets:["zoo"],
+    hideSpecifyColumns:true,
+    hideChooseReserve:true
   },
 
-  "ml-svm-ailab": {
-    datasets: ["candy", "titanic", "foods"],
-    hideChooseReserve: true,
-    hideModelCard: true
-  },
+  "final-project": {
 
-  "ml-mini-project-ailab": {
-    datasets: ["candy", "titanic", "foods"],
-    hideSelectTrainer: "knnClassify"
-  },
-
-  "ml-final-project-ailab": {
-    hideSelectTrainer: "knnClassify"
   }
+
 };
 
 // Look for a ?mode= parameter on the URL


### PR DESCRIPTION
Updated the test scenarios from the outside-of-levelbuilder version of AI Lab to match the inside-of-levelbuilder parameterized levels - see screenshot below (sorry it's so big - I don't know how to quickly resize images in this flavor of markdown).

Each place in the dropdown matches a level used in the curriculum. Now, if we need to test changes that might affect paramaterized levels, these dropdowns should accurately reflect all of the level types in the curriculum. 

I put this together after the [Dataset Cleanup PR](https://github.com/code-dot-org/ml-playground/pull/137) - I wanted to verify the changes didn't have an unexpected impact on parameterized levels (they don't - everything looks great) and realized it made sense to update these now that the curriculum is more finalized.

Testing story: verified that it works correctly on my local machine.

![Capture (Small)](https://user-images.githubusercontent.com/68714964/113805183-e8742d00-9714-11eb-80c3-9899ab4bbe32.PNG)
