### PR TITLE
Save dataset details

### DIFF
--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -2,7 +2,11 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { setTrainedModelDetail, getSelectedColumnDescriptions } from "../redux";
+import {
+  setTrainedModelDetail,
+  getSelectedColumnDescriptions,
+  getPresetDataDescription
+} from "../redux";
 import { styles, saveMessages, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
 
@@ -13,7 +17,8 @@ class SaveModel extends Component {
     trainedModelDetails: PropTypes.object,
     labelColumn: PropTypes.string,
     columnDescriptions: PropTypes.array,
-    saveStatus: PropTypes.string
+    saveStatus: PropTypes.string,
+    presetDataDescription: PropTypes.string
   };
 
   constructor(props) {
@@ -71,6 +76,13 @@ class SaveModel extends Component {
       text: "What will you name the model? (required)"
     };
 
+    const dataDescriptionField = {
+      id: "datasetDescription",
+      text: "Describe the dataset.",
+      placeholder: "How was the data collected? Who collected it? When was it collected?",
+      answer: this.props.presetDataDescription
+    };
+
     const arrowIcon = this.state.showColumnDescriptions
       ? 'fa fa-caret-up' : 'fa fa-caret-down';
 
@@ -90,6 +102,26 @@ class SaveModel extends Component {
                   }
                   maxLength={ModelNameMaxLength}
                 />
+              </div>
+            </div>
+            <div key={dataDescriptionField.id} style={styles.cardRow}>
+              <label>{dataDescriptionField.text}</label>
+              <div>
+              {!dataDescriptionField.answer && (
+                <div>
+                  <textarea
+                    rows="4"
+                    onChange={event =>
+                      this.handleChange(event, dataDescriptionField.id, false)
+                    }
+                    placeholder={dataDescriptionField.placeholder}
+                    style={styles.saveInputsWidth}
+                  />
+                </div>
+              )}
+              {dataDescriptionField.answer && (
+                <div>{dataDescriptionField.answer}</div>
+              )}
               </div>
             </div>
             <div>
@@ -168,7 +200,8 @@ export default connect(
     trainedModelDetails: state.trainedModelDetails,
     labelColumn: state.labelColumn,
     columnDescriptions: getSelectedColumnDescriptions(state),
-    saveStatus: state.saveStatus
+    saveStatus: state.saveStatus,
+    presetDataDescription: getPresetDataDescription(state)
   }),
   dispatch => ({
     setTrainedModelDetail(field, value, isColumn) {

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -106,7 +106,6 @@ class SaveModel extends Component {
             </div>
             <div key={dataDescriptionField.id} style={styles.cardRow}>
               <label>{dataDescriptionField.text}</label>
-              <div>
               {!dataDescriptionField.answer && (
                 <div>
                   <textarea
@@ -122,7 +121,6 @@ class SaveModel extends Component {
               {dataDescriptionField.answer && (
                 <div>{dataDescriptionField.answer}</div>
               )}
-              </div>
             </div>
             <div>
               <span onClick={this.toggleColumnDescriptions}>

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import {
   setTrainedModelDetail,
   getSelectedColumnDescriptions,
-  getPresetDataDescription
+  getDataDescription
 } from "../redux";
 import { styles, saveMessages, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
@@ -18,7 +18,7 @@ class SaveModel extends Component {
     labelColumn: PropTypes.string,
     columnDescriptions: PropTypes.array,
     saveStatus: PropTypes.string,
-    presetDataDescription: PropTypes.string
+    dataDescription: PropTypes.string
   };
 
   constructor(props) {
@@ -80,7 +80,7 @@ class SaveModel extends Component {
       id: "datasetDescription",
       text: "Describe the dataset.",
       placeholder: "How was the data collected? Who collected it? When was it collected?",
-      answer: this.props.presetDataDescription
+      answer: this.props.dataDescription
     };
 
     const arrowIcon = this.state.showColumnDescriptions
@@ -201,7 +201,7 @@ export default connect(
     labelColumn: state.labelColumn,
     columnDescriptions: getSelectedColumnDescriptions(state),
     saveStatus: state.saveStatus,
-    presetDataDescription: getPresetDataDescription(state)
+    dataDescription: getDataDescription(state)
   }),
   dispatch => ({
     setTrainedModelDetail(field, value, isColumn) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -971,7 +971,7 @@ export function getEmptyCellDetails(state) {
   return emptyCellLocations;
 }
 
-export function getPresetDataDescription(state) {
+export function getDataDescription(state) {
   // If this a dataset from the internal collection that already has a description, use that.
   if (
     state.metadata
@@ -987,6 +987,13 @@ export function getPresetDataDescription(state) {
   } else {
     return undefined;
   }
+}
+
+function getDatasetDetails(state) {
+  const datasetDetails = {}
+  datasetDetails.description = getDataDescription(state);
+  datasetDetails.numRows = state.data.length;
+  return datasetDetails;
 }
 
 export function getTrainedModelDataToSave(state) {
@@ -1013,6 +1020,7 @@ export function getTrainedModelDataToSave(state) {
     dataToSave.columns = state.trainedModelDetails.columns;
   }
 
+  dataToSave.datasetDetails = getDatasetDetails(state);
   dataToSave.potentialUses = state.trainedModelDetails.potentialUses;
   dataToSave.potentialMisuses = state.trainedModelDetails.potentialMisuses;
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -971,6 +971,24 @@ export function getEmptyCellDetails(state) {
   return emptyCellLocations;
 }
 
+export function getPresetDataDescription(state) {
+  // If this a dataset from the internal collection that already has a description, use that.
+  if (
+    state.metadata
+    && state.metadata
+    && state.metadata.card
+    && state.metadata.card.description
+  ) {
+    return state.metadata.card.description;
+  } else if (
+    state.trainedModelDetails && state.trainedModelDetails.datasetDescription
+  ) {
+    return state.trainedModelDetails.datasetDescription;
+  } else {
+    return undefined;
+  }
+}
+
 export function getTrainedModelDataToSave(state) {
   const dataToSave = {};
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -1016,10 +1016,6 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.potentialUses = state.trainedModelDetails.potentialUses;
   dataToSave.potentialMisuses = state.trainedModelDetails.potentialMisuses;
 
-  dataToSave.identifySubgroup = !!state.trainedModelDetails.identifySubgroup;
-  dataToSave.representSubgroup = !!state.trainedModelDetails.representSubgroup;
-  dataToSave.decisionsLife = !!state.trainedModelDetails.decisionsLife;
-
   dataToSave.selectedTrainer = getSelectedTrainer(state);
   dataToSave.selectedFeatures = state.selectedFeatures;
   dataToSave.featureNumberKey = state.featureNumberKey;

--- a/src/redux.js
+++ b/src/redux.js
@@ -975,7 +975,6 @@ export function getDataDescription(state) {
   // If this a dataset from the internal collection that already has a description, use that.
   if (
     state.metadata
-    && state.metadata
     && state.metadata.card
     && state.metadata.card.description
   ) {


### PR DESCRIPTION
If there is not already a description associated with the dataset for the trained model, we ask users to write one in a new field in the model save form.

![Screen Shot 2021-04-13 at 12 48 41 PM](https://user-images.githubusercontent.com/12300669/114616245-a008c200-9c74-11eb-9269-595d954e9be6.png)

If there is already a description associated with the dataset, from the metadata, we now display it on the model save form. 

![Screen Shot 2021-04-13 at 4 24 05 PM](https://user-images.githubusercontent.com/12300669/114616381-c9c1e900-9c74-11eb-94ec-f49c94c1eaf8.png)

This PR also modified `dataToSave` by removing the no longer in use checkbox fields and adding in `dataSetDetails` which includes the description of the dataset and number of rows. 

![Screen Shot 2021-04-13 at 4 26 23 PM](https://user-images.githubusercontent.com/12300669/114616599-0e4d8480-9c75-11eb-9fc0-712a240abe14.png)
