### PR TITLE
Delete old fields from data to save

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -644,14 +644,6 @@ export function getUniqueOptionsByColumn(state) {
   return uniqueOptionsByColumn;
 }
 
-export function getExtremumsByColumn(state) {
-  let extremumsByColumn = {};
-  getNumericalColumns(state).map(
-    column => (extremumsByColumn[column] = getRange(state, column, false))
-  );
-  return extremumsByColumn;
-}
-
 export function getRangesByColumn(state) {
   let rangesByColumn = {};
   getNumericalColumns(state).map(
@@ -952,34 +944,12 @@ export function getTrainedModelDataToSave(state) {
 
   dataToSave.name = state.trainedModelDetails.name;
 
-  // If the first column has a description, assume descriptions are in the
-  // metadata for that dataset and use them; otherwise, use manually entered
-  // column descriptions.
-  if (
-    state.metadata &&
-    state.metadata.fields &&
-    state.metadata.fields[0].description
-  ) {
-    dataToSave.columns = [];
-    for (const columnDescription of getSelectedColumnDescriptions(state)) {
-      dataToSave.columns.push({
-        id: columnDescription.id,
-        description: columnDescription.description
-      });
-    }
-  } else {
-    dataToSave.columns = state.trainedModelDetails.columns;
-  }
-
   dataToSave.datasetDetails = getDatasetDetails(state);
   dataToSave.potentialUses = state.trainedModelDetails.potentialUses;
   dataToSave.potentialMisuses = state.trainedModelDetails.potentialMisuses;
 
   dataToSave.selectedTrainer = getSelectedTrainer(state);
-  dataToSave.selectedFeatures = state.selectedFeatures;
   dataToSave.featureNumberKey = state.featureNumberKey;
-  dataToSave.extremumsByColumn = getExtremumsByColumn(state);
-  dataToSave.labelColumn = state.labelColumn;
   dataToSave.label = getColumnDataToSave(state, state.labelColumn);
   dataToSave.features = getFeaturesToSave(state);
   dataToSave.summaryStat = getSummaryStat(state);


### PR DESCRIPTION
Continuation of #144 

The new `features` and `label` fields on the `dataToSave` contain information that is duplicated from `labelColumn`, `columns`, `extremumsByColumn` and `selectedFeatures`. Now that we are using the new fields in App Lab ([#40166](https://github.com/code-dot-org/code-dot-org/pull/40166), [#40100](https://github.com/code-dot-org/code-dot-org/pull/40100)) we can delete the old, redundant fields. 