### PR TITLE
ort selected features

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -297,17 +297,16 @@ export default function rootReducer(state = initialState, action) {
       }
     };
   }
-
   if (action.type === ADD_SELECTED_FEATURE) {
     if (!state.selectedFeatures.includes(action.selectedFeature)) {
+      const newFeatures = [...state.selectedFeatures, action.selectedFeature];
       return {
         ...state,
-        selectedFeatures: [...state.selectedFeatures, action.selectedFeature],
+        selectedFeatures: newFeatures.sort(),
         currentColumn: undefined
       };
     }
   }
-
   if (action.type === REMOVE_SELECTED_FEATURE) {
     return {
       ...state,


### PR DESCRIPTION
Sort selected features.  Order of feature selection, was curiously sometimes affecting accuracy. Investigation documentation [here](https://docs.google.com/document/d/1Qi8A4JV5ymB74o2pfuAUo5fZpKp2Iu_FxZ-nQCUX0Og/edit#).

Order of feature selection should not affect the outcome of the algorithm, and it's confusing to teachers and students when it does.  Consistency between runs with the same selected features is important. To preserve that consistency we're sorting the selected features at the recommendation of the AI consultant, which unblocks the curriculum team for this specific example: 

BEFORE: 

https://user-images.githubusercontent.com/12300669/115455339-d3f16380-a1ef-11eb-98e9-5f3d1febc792.mp4


AFTER: 

https://user-images.githubusercontent.com/12300669/115455181-9c82b700-a1ef-11eb-9ba8-4f90b5139fd8.mov

