### PR TITLE
Hide CrossTab messaging for numerical comparisons

### DIFF
--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -40,7 +40,7 @@ class CrossTab extends Component {
 
     return (
       <div id="cross-tab">
-        {!showTable && (
+        {crossTabData && !showTable && (
           <div>
             The currently-selected data is too large to show in a table.
           </div>


### PR DESCRIPTION
We were incorrectly showing messaging about the CrossTab being too large when we should not have been; both columns in question were numerical, so there shouldn't have been anything about CrossTab shown at all.