### PR TITLE
Fix Results' stick headers

### DIFF
--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -49,7 +49,7 @@ class ResultsTable extends Component {
                 >
                   <span style={styles.largeText}>{"Actual"}</span>
                   {this.props.isRegression && (
-                    <div style={styles.smallText}>{"+/- 3% of range"}</div>
+                    <div style={styles.smallTextNoMargin}>{"+/- 3% of range"}</div>
                   )}
                 </th>
                 <th

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,6 +105,10 @@ export const styles = {
     marginBottom: 8
   },
 
+  smallTextNoMargin: {
+    fontSize: 12
+  },
+
   footerText: {
     fontSize: 13,
     marginTop: 12
@@ -332,11 +336,13 @@ export const styles = {
   resultsTableFirstHeader: {
     top: 0,
     backgroundColor: "white",
-    color: "rgb(30, 30, 30)"
+    color: "rgb(30, 30, 30)",
+    verticalAlign: "top",
+    height: 45
   },
 
   resultsTableSecondHeader: {
-    top: "30px",
+    top: "47px",
     color: "white"
   },
 


### PR DESCRIPTION
The initial work to make the Results header sticky worked for categorical columns, but made an assumption that the first row's height was going to be 30px when setting the top sticky position of the second row.  However, when there is a numerical column, the first row is actually taller than that.

This is a simple fix that always assumes a taller first row, which happens with a numerical column.  Now, the second header row remains in a fixed location rather than scrolls a bit.

A more comprehensive fix would be to adjust the height depending whether that taller first row is needed, but we can consider that as we further refine this screen.

With numerical column:

![Screen Shot 2021-04-22 at 12 19 52 PM](https://user-images.githubusercontent.com/2205926/115647059-0b3b3f80-a2d8-11eb-9d4d-cfc645ec1aea.png)

Without numerical column:

![Screen Shot 2021-04-22 at 12 24 59 PM](https://user-images.githubusercontent.com/2205926/115647064-0d9d9980-a2d8-11eb-868a-545acfa37e21.png)
