### PR TITLE
Accuracy adjustments 

### DIFF
--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -242,7 +242,6 @@ export const allDatasets = [
 ];
 
 export function getAvailableDatasets(specificDatasets) {
-  return allDatasets;
   // Filter datasets by a specified array (in Levelbuilder) or filter out toy datasets.
   let availableDatasets = (specificDatasets && specificDatasets.length > 1) ?
     allDatasets.filter(dataset => specificDatasets.includes(dataset.id)) :

--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -242,6 +242,7 @@ export const allDatasets = [
 ];
 
 export function getAvailableDatasets(specificDatasets) {
+  return allDatasets;
   // Filter datasets by a specified array (in Levelbuilder) or filter out toy datasets.
   let availableDatasets = (specificDatasets && specificDatasets.length > 1) ?
     allDatasets.filter(dataset => specificDatasets.includes(dataset.id)) :

--- a/src/train.js
+++ b/src/train.js
@@ -179,8 +179,8 @@ const prepareTrainingData = () => {
       numReserved++;
     }
   }
-  store.dispatch(setAccuracyCheckExamples(trainingExamples));
-  store.dispatch(setAccuracyCheckLabels(trainingLabels));
+  store.dispatch(setAccuracyCheckExamples(accuracyCheckExamples));
+  store.dispatch(setAccuracyCheckLabels(accuracyCheckLabels));
 };
 
 const prepareTestData = () => {

--- a/src/train.js
+++ b/src/train.js
@@ -147,8 +147,10 @@ const prepareTrainingData = () => {
   const trainingLabels = updatedState.data
     .map(row => extractLabel(updatedState, row))
     .filter(label => label !== undefined && label !== "" && !isNaN(label));
+  store.dispatch(setTrainingExamples(trainingExamples));
+  store.dispatch(setTrainingLabels(trainingLabels));
   /*
-  Select X% of examples and corresponding labels from the training set to reserve for a post-training accuracy calculation. The accuracy check examples and labels are excluded from the training set when the model is trained and saved to state separately to test the model's accuracy.
+  Select X% of examples and corresponding labels from the training set to use for a post-training accuracy calculation.
   */
   const percent = updatedState.percentDataToReserve / 100;
   const numToReserve = parseInt(trainingExamples.length * percent);
@@ -177,10 +179,8 @@ const prepareTrainingData = () => {
       numReserved++;
     }
   }
-  store.dispatch(setTrainingExamples(trainingExamples));
-  store.dispatch(setTrainingLabels(trainingLabels));
-  store.dispatch(setAccuracyCheckExamples(accuracyCheckExamples));
-  store.dispatch(setAccuracyCheckLabels(accuracyCheckLabels));
+  store.dispatch(setAccuracyCheckExamples(trainingExamples));
+  store.dispatch(setAccuracyCheckLabels(trainingLabels));
 };
 
 const prepareTestData = () => {

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -3,6 +3,7 @@ https://github.com/mljs/knn */
 
 import { store } from "../index.js";
 import {
+  isRegression,
   setModelSize,
   setTrainedModel,
   setPrediction,
@@ -14,7 +15,7 @@ const KNN = require("ml-knn");
 export default class KNNTrainer {
   startTraining() {
     const state = store.getState();
-    const k = Math.round(0.33 * state.data.length);
+    const k = isRegression(state) ? 5 : Math.round(0.33 * state.data.length);
     this.knn = new KNN(state.trainingExamples, state.trainingLabels, {k: k});
     var model = this.knn.toJSON();
     store.dispatch(setTrainedModel(model));

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -14,7 +14,8 @@ const KNN = require("ml-knn");
 export default class KNNTrainer {
   startTraining() {
     const state = store.getState();
-    this.knn = new KNN(state.trainingExamples, state.trainingLabels);
+    const k = Math.round(0.33 * state.data.length);
+    this.knn = new KNN(state.trainingExamples, state.trainingLabels, {k: k});
     var model = this.knn.toJSON();
     store.dispatch(setTrainedModel(model));
     const size = Buffer.byteLength(JSON.stringify(model));


### PR DESCRIPTION
This PR includes two changes to improve accuracy and consistency of the trained models _with known datasets used in the curriculum_.  

1.) We are now training on the whole dataset 

2.) We set the K value as 1/3 of the dataset size 

Lengthy notes [here](https://docs.google.com/document/d/1Qi8A4JV5ymB74o2pfuAUo5fZpKp2Iu_FxZ-nQCUX0Og/edit#). With this change we get the expected accuracy for regression and classification models _using the toy datasets_  (I tested ice cream, pizza, salad, tacos, and safari) with single features and multiple features, regardless of order of feature selection. 

I see this as v1 of a more elaborate approach to using K value options to increase accuracy (in the vein of #161). However, I think this is worth merging the meantime while we build out a well-researched cohesive plan because it will immediately unblock the Curriculum team by addressing the accuracy inconsistencies seen in the datasets used in the curriculum. 
