### PR TITLE
use new isUserUploadedDataset prop to customize save model form 

### DIFF
--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -5,7 +5,8 @@ import { connect } from "react-redux";
 import {
   setTrainedModelDetail,
   getSelectedColumnDescriptions,
-  getDataDescription
+  getDataDescription,
+  isUserUploadedDataset
 } from "../redux";
 import { styles, saveMessages, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
@@ -18,14 +19,15 @@ class SaveModel extends Component {
     labelColumn: PropTypes.string,
     columnDescriptions: PropTypes.array,
     saveStatus: PropTypes.string,
-    dataDescription: PropTypes.string
+    dataDescription: PropTypes.string,
+    isUserUploadedDataset: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      showColumnDescriptions: false
+      showColumnDescriptions: this.props.isUserUploadedDataset
     };
   }
 
@@ -106,7 +108,7 @@ class SaveModel extends Component {
             </div>
             <div key={dataDescriptionField.id} style={styles.cardRow}>
               <label>{dataDescriptionField.text}</label>
-              {!dataDescriptionField.answer && (
+              {this.props.isUserUploadedDataset && (
                 <div>
                   <textarea
                     rows="4"
@@ -118,7 +120,7 @@ class SaveModel extends Component {
                   />
                 </div>
               )}
-              {dataDescriptionField.answer && (
+              {!this.props.isUserUploadedDataset && (
                 <div>{dataDescriptionField.answer}</div>
               )}
             </div>
@@ -199,7 +201,8 @@ export default connect(
     labelColumn: state.labelColumn,
     columnDescriptions: getSelectedColumnDescriptions(state),
     saveStatus: state.saveStatus,
-    dataDescription: getDataDescription(state)
+    dataDescription: getDataDescription(state),
+    isUserUploadedDataset: isUserUploadedDataset(state)
   }),
   dispatch => ({
     setTrainedModelDetail(field, value, isColumn) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -1293,3 +1293,9 @@ function areArraysEqual(array1, array2) {
     })
   );
 }
+
+export function isUserUploadedDataset(state) {
+  // The csvfile for internally curated datasets are strings; those uploaded by
+  // users are objects. Use data type as a proxy to know which case we're in.
+  return typeof state.csvfile === 'object' && state.csvfile !== null;
+}


### PR DESCRIPTION
When the user uploads a dataset `state.csvfile` will be an object; when it's an in-house curated dataset `state.csvfile` will be a string.  Here I use this difference as a shortcut to identify when the user has trained a model using an uploaded dataset so that we can customize the save model form by showing a text box to enter a description of the dataset and uncollapse the column description inputs. In cases where the trained model uses an in-house dataset, we show an uneditable description of the data and the column descriptions are hidden by default. This fixes the bug: "Describe the Data" textbox turns into to an uneditable block of text.

BEFORE 

https://user-images.githubusercontent.com/12300669/116280758-06064680-a757-11eb-9050-8e4f89e694c8.mov



AFTER 

https://user-images.githubusercontent.com/12300669/116280500-bf185100-a756-11eb-9dce-22506fabec60.mov

