### PR TITLE
Use dataset metadata to determine column type if it's known

### DIFF
--- a/src/jsonReaderWrapper.js
+++ b/src/jsonReaderWrapper.js
@@ -25,11 +25,7 @@ const updateData = result => {
   const state = store.getState();
 
   for (const field of metadata.fields) {
-    // Use the metadata's column type if the user will not see the UI to select column type.
-    const fieldType =
-      state.mode && state.mode.hideSpecifyColumns
-        ? field.type
-        : ColumnTypes.CATEGORICAL;
+    const fieldType = field.type ? field.type : ColumnTypes.CATEGORICAL;
     store.dispatch(setColumnsByDataType(field.id, fieldType));
   }
 


### PR DESCRIPTION
Previously, we were only using the column data type specified in the JSON metadata if the mode to hideSpecifyColumns was true.  This meant that we were defaulting to categorical even when a column's metadata listed the data type as numerical in cases where we weren't hiding column specification. For example, in [the abalone dataset numerical columns were showing as categorical](https://codedotorg.slack.com/archives/C016VGH1BT6/p1619810596194100).  Now we use the column's data type metadata if it exists regardless of mode. 


![Screen Shot 2021-04-30 at 5 26 26 PM](https://user-images.githubusercontent.com/12300669/116756616-66f18100-a9da-11eb-8ef4-41263880a380.png)
