### PR TITLE
Adjust error tolerance for regression

### DIFF
--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -8,7 +8,12 @@ import {
   getAccuracyGrades,
   isRegression
 } from "../redux";
-import { styles, colors, ResultsGrades } from "../constants";
+import {
+  styles,
+  colors,
+  ResultsGrades,
+  REGRESSION_ERROR_TOLERANCE
+} from "../constants";
 
 class ResultsTable extends Component {
   static propTypes = {
@@ -49,7 +54,9 @@ class ResultsTable extends Component {
                 >
                   <span style={styles.largeText}>{"Actual"}</span>
                   {this.props.isRegression && (
-                    <div style={styles.smallTextNoMargin}>{"+/- 3% of range"}</div>
+                    <div style={styles.smallTextNoMargin}>
+                      {`+/- ${REGRESSION_ERROR_TOLERANCE}% of range`}
+                    </div>
                   )}
                 </th>
                 <th

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,8 @@ export const MLTypes = {
   REGRESSION: "regression"
 };
 
+export const REGRESSION_ERROR_TOLERANCE = 5;
+
 export const ResultsGrades = {
   CORRECT: "correct",
   INCORRECT: "incorrect"

--- a/src/redux.js
+++ b/src/redux.js
@@ -21,7 +21,8 @@ import {
   ColumnTypes,
   MLTypes,
   TestDataLocations,
-  ResultsGrades
+  ResultsGrades,
+  REGRESSION_ERROR_TOLERANCE
 } from "./constants.js";
 
 // Action types
@@ -794,7 +795,7 @@ export function getAccuracyRegression(state) {
   let grades = [];
   const maxMin = getRange(state, state.labelColumn);
   const range = Math.abs(maxMin.max - maxMin.min);
-  const errorTolerance = range * 0.03;
+  const errorTolerance = range * REGRESSION_ERROR_TOLERANCE/100;
   const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
   for (let i = 0; i < numPredictedLabels; i++) {
     const diff = Math.abs(

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -36,7 +36,7 @@ const resultsState = {
   labelColumn: 'height',
   labelColumnCategorical: 'sun',
   accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
-  accuracyCheckLabels: [3.9, 3.8, 2.6, 2.5, 1.6, 0.9]
+  accuracyCheckLabels: [5.9, 3.8, 2.6, 2.5, 1.6, 0.7]
 };
 
 const resultsStateClassification = {
@@ -161,8 +161,7 @@ describe('redux functions', () => {
       ResultsGrades.CORRECT,
       ResultsGrades.INCORRECT
     ]);
-    // error tolerance of +/- 0.09, 4/6 correct
+    // error tolerance of +/- 0.15, 4/6 correct
     expect(accuracy.percentCorrect).toBe("66.67");
   });
 });
-


### PR DESCRIPTION
Previously, regression predictions were considered correct if they were within +/- 3% of the expected value. In this PR, I adjusted that tolerance range to +/- 5%.  I also extracted the tolerance into a variable so if we need to change it again, we can make that change in one place instead of two. 

![update error tolerance](https://user-images.githubusercontent.com/12300669/117328861-0c38a900-ae62-11eb-90ec-d19d3de2ff55.png)
