### PR TITLE
Levelbuilders can set randomizeTestData

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ import rootReducer, {
   setSelectedJSON,
   setSelectedTrainer,
   setInstructionsKeyCallback,
-  setSaveStatus
+  setSaveStatus,
+  setReserveLocation
 } from "./redux";
 import { allDatasets } from "./datasetManifest";
 import { parseCSV } from "./csvReaderWrapper";

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import rootReducer, {
 import { allDatasets } from "./datasetManifest";
 import { parseCSV } from "./csvReaderWrapper";
 import { parseJSON } from "./jsonReaderWrapper";
+import { TestDataLocations } from "./constants";
 
 export const store = createStore(rootReducer);
 
@@ -73,6 +74,10 @@ const processMode = mode => {
     // Select a trainer immediately.
     if (mode.hideSelectTrainer) {
       store.dispatch(setSelectedTrainer(mode.hideSelectTrainer));
+    }
+
+    if (mode.randomizeTestData) {
+      store.dispatch(setReserveLocation(TestDataLocations.RANDOM))
     }
   }
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -39,6 +39,7 @@ const REMOVE_SELECTED_FEATURE = "REMOVE_SELECTED_FEATURE";
 const SET_LABEL_COLUMN = "SET_LABEL_COLUMN";
 const SET_FEATURE_NUMBER_KEY = "SET_FEATURE_NUMBER_KEY";
 const SET_PERCENT_DATA_TO_RESERVE = "SET_PERCENT_DATA_TO_RESERVE";
+const SET_RESERVE_LOCATION = "SET_RESERVE_LOCATION";
 const SET_ACCURACY_CHECK_EXAMPLES = "SET_ACCURACY_CHECK_EXAMPLES";
 const SET_ACCURACY_CHECK_LABELS = "SET_ACCURACY_CHECK_LABELS";
 const SET_ACCURACY_CHECK_PREDICTED_LABELS =
@@ -127,6 +128,10 @@ export function setFeatureNumberKey(featureNumberKey) {
 
 export function setPercentDataToReserve(percentDataToReserve) {
   return { type: SET_PERCENT_DATA_TO_RESERVE, percentDataToReserve };
+}
+
+export function setReserveLocation(reserveLocation) {
+  return { type: SET_RESERVE_LOCATION, reserveLocation };
 }
 
 export function setAccuracyCheckExamples(accuracyCheckExamples) {
@@ -354,6 +359,12 @@ export default function rootReducer(state = initialState, action) {
       percentDataToReserve: action.percentDataToReserve
     };
   }
+  if (action.type === SET_RESERVE_LOCATION) {
+   return {
+     ...state,
+     reserveLocation: action.reserveLocation
+   };
+ }
   if (action.type === SET_ACCURACY_CHECK_EXAMPLES) {
     return {
       ...state,

--- a/src/train.js
+++ b/src/train.js
@@ -147,6 +147,10 @@ const prepareTrainingData = () => {
   const trainingLabels = updatedState.data
     .map(row => extractLabel(updatedState, row))
     .filter(label => label !== undefined && label !== "" && !isNaN(label));
+  /*
+  KNN uses the entire training dataset to build the model, thus we're setting
+  the training examples and labels prior to reserving test data.
+  */
   store.dispatch(setTrainingExamples(trainingExamples));
   store.dispatch(setTrainingLabels(trainingLabels));
   /*
@@ -173,9 +177,7 @@ const prepareTrainingData = () => {
     while (numReserved < numToReserve) {
       let randomIndex = getRandomInt(trainingExamples.length - 1);
       accuracyCheckExamples.push(trainingExamples[randomIndex]);
-      trainingExamples.splice(randomIndex, 1);
       accuracyCheckLabels.push(trainingLabels[randomIndex]);
-      trainingLabels.splice(randomIndex, 1);
       numReserved++;
     }
   }


### PR DESCRIPTION
This change re-introduces the redux actions to setReserveLocation which customizes whether the test data come from the beginning or end of the dataset or is randomly selected. This was reintroduced to allow levelbuilders to add `randomizeTestData = true` in the mode JSON for a level. 
