### PR TITLE
Change "Continue" to "Finish" on Results screen when hideSave is enabled

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -1143,7 +1143,7 @@ export function getPanelButtons(state) {
       : null;
     next = isPanelAvailable(state, "saveModel")
       ? { panel: "saveModel", text: "Continue" }
-      : { panel: "continue", text: "Continue" };
+      : { panel: "continue", text: "Finish" };
   } else if (state.currentPanel === "saveModel") {
     prev = { panel: "results", text: "Back" };
     next = isPanelAvailable(state, "save")


### PR DESCRIPTION
The next button should say "Continue" when going to the next panel and "Finish" when leaving an AI Lab level. The next button now says "Finish" on the Results screen when the hideSave flag is enabled. 

Before:
<img width="1425" alt="Screen Shot 2021-05-06 at 10 26 23 PM" src="https://user-images.githubusercontent.com/40412372/117403480-176cf280-aebd-11eb-81d4-16c1eba487ab.png">

After:
<img width="1434" alt="Screen Shot 2021-05-06 at 10 47 20 PM" src="https://user-images.githubusercontent.com/40412372/117403502-218ef100-aebd-11eb-811e-238745d7c2ce.png">

