### PR TITLE
Delete code related to trainer selection

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,6 +8,9 @@ export const MLTypes = {
   REGRESSION: "regression"
 };
 
+export const RegressionTrainer = "knnRegress";
+export const ClassificationTrainer = "knnClassify";
+
 export const REGRESSION_ERROR_TOLERANCE = 5;
 
 export const ResultsGrades = {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import rootReducer, {
   setCurrentPanel,
   setSelectedCSV,
   setSelectedJSON,
-  setSelectedTrainer,
   setInstructionsKeyCallback,
   setSaveStatus,
   setReserveLocation
@@ -70,11 +69,6 @@ const processMode = mode => {
         store.dispatch(setCurrentPanel("dataDisplayLabel"));
       }
       panelSet = true;
-    }
-
-    // Select a trainer immediately.
-    if (mode.hideSelectTrainer) {
-      store.dispatch(setSelectedTrainer(mode.hideSelectTrainer));
     }
 
     if (mode.randomizeTestData) {

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -7,7 +7,6 @@ const sampleModes = {
   minimal: {
     datasets: ["tacos_toy"],
     hideSpecifyColumns: true,
-    hideSelectTrainer: "knnClassify",
     hideChooseReserve: true,
     hideModelCard: true,
     hideColumnClicking: true,
@@ -16,7 +15,6 @@ const sampleModes = {
 
   "preload-metadata": {
     hideSpecifyColumns: true,
-    hideSelectTrainer: "knnClassify",
     hideChooseReserve: true
   },
 
@@ -53,8 +51,7 @@ const sampleModes = {
     hideSpecifyColumns: true,
     hideChooseReserve: true,
     hideModelCard: true,
-    hideSave: true,
-    hideSelectTrainer: "knnRegress"
+    hideSave: true
   },
 
   zoo: {

--- a/src/train.js
+++ b/src/train.js
@@ -13,33 +13,7 @@ import {
   setAccuracyCheckExamples,
   setAccuracyCheckLabels
 } from "./redux";
-import { ColumnTypes, MLTypes, TestDataLocations } from "./constants.js";
-
-export const availableTrainers = {
-  knnClassify: {
-    name: "KNN Classifier",
-    description:
-      "Uses the K-Nearest Neighbor algorithm to classify an example as one of N options.",
-    mlType: MLTypes.CLASSIFICATION,
-    labelType: ColumnTypes.CATEGORICAL
-  },
-  knnRegress: {
-    name: "KNN Regression",
-    description:
-      "Uses the K-Nearest Neighbor algorithm to predict a floating point label.",
-    mlType: MLTypes.REGRESSION,
-    labelType: ColumnTypes.NUMERICAL
-  }
-};
-
-export const defaultRegressionTrainer = "knnRegress";
-export const defaultClassificationTrainer = "knnClassify";
-
-export const getMLType = trainerName => {
-  if (availableTrainers[trainerName]) {
-    return availableTrainers[trainerName].mlType;
-  }
-};
+import { ColumnTypes, TestDataLocations } from "./constants.js";
 
 /* Builds a hash that maps a feature's categorical options to numbers because
   the ML algorithms only accept numerical inputs.


### PR DESCRIPTION
Previous iterations of the tool included an additional algorithm (SVM) and a feature where users could select which algorithm they wanted to use. Now that we are exclusively using KNN, and inferring classification or regression based on label column data type (numerical labels use regression, categorical columns use classification) we can remove the code related to selecting a trainer.  

This PR includes: 

- Removing references to the levelbuilder param `hideSelectTrainer` because the trainer selection is no long available so the param is no longer needed. 
- Removing the `selectedTrainer` piece of state and related reducer action 
- Removing the `getMLType` helper function because it is redundant with `isRegression` which is now based on data type of label column
- Removing the `availableTrainers` object, which is not used outside of the newly deleted `getMLType` function
- Renaming `deafultRegressionTrainer` to `RegressionTrainer` (similar for classification) and moving it to the constants.js file both to avoid and import from train.js into redux.js and because default implies the default of many possible, but we just have one regression trainer and one classification trainer. 