### PR TITLE
Use main-next branch for GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: main
+    branch: main-next
   verbose: true


### PR DESCRIPTION
We are using the main-next branch for our "next generation" UI refresh for AI Lab.  We will use that branch for https://code-dot-org.github.io/ml-playground/ for a while.