### PR TITLE
Use Dynamic Instructions overlay

### DIFF
--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -19,7 +19,8 @@ class TrainModel extends Component {
     readyToTrain: PropTypes.bool,
     modelSize: PropTypes.number,
     labelColumn: PropTypes.string,
-    selectedFeatures: PropTypes.array
+    selectedFeatures: PropTypes.array,
+    instructionsOverlayActive: PropTypes.bool
   };
 
   state = {
@@ -49,7 +50,9 @@ class TrainModel extends Component {
       this.setState({ headOpen: true });
     }
 
-    this.setState({ frame: this.state.frame + 1 });
+    if (!this.props.instructionsOverlayActive) {
+      this.setState({ frame: this.state.frame + 1 });
+    }
   };
 
   componentWillUnmount = () => {
@@ -133,5 +136,6 @@ export default connect(state => ({
   readyToTrain: readyToTrain(state),
   modelSize: state.modelSize,
   labelColumn: state.labelColumn,
-  selectedFeatures: state.selectedFeatures
+  selectedFeatures: state.selectedFeatures,
+  instructionsOverlayActive: state.instructionsOverlayActive
 }))(TrainModel);

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ import rootReducer, {
   setSelectedJSON,
   setInstructionsKeyCallback,
   setSaveStatus,
-  setReserveLocation
+  setReserveLocation,
+  setInstructionsDismissed
 } from "./redux";
 import { allDatasets } from "./datasetManifest";
 import { parseCSV } from "./csvReaderWrapper";
@@ -44,6 +45,10 @@ export const initAll = function(options) {
     document.getElementById("root")
   );
 };
+
+export const instructionsDismissed = function() {
+  store.dispatch(setInstructionsDismissed());
+}
 
 // Process an optional mode.
 const processMode = mode => {

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -17,7 +17,8 @@ const sampleModes = {
   "preload-metadata": {
     hideSpecifyColumns: true,
     hideSelectTrainer: "knnClassify",
-    hideChooseReserve: true
+    hideChooseReserve: true,
+    hideInstructionsOverlay: true
   },
 
   "intro-ai-tacos": {
@@ -80,7 +81,8 @@ function saveTrainedModelStub(data, response) {
 }
 
 function setInstructionsKeyStub(instructionsKey, options) {
-  document.getElementById("instructions").innerText = instructionsKey;
+  document.getElementById("instructions").innerText =
+    instructionsKey + (!options.showOverlay ? " (no overlay)" : "");
 }
 
 // Initialize the app.

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -79,7 +79,7 @@ function saveTrainedModelStub(data, response) {
   response({ id: 303, status: "success" });
 }
 
-function setInstructionsKeyStub(instructionsKey) {
+function setInstructionsKeyStub(instructionsKey, options) {
   document.getElementById("instructions").innerText = instructionsKey;
 }
 

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -1,5 +1,5 @@
 import "./assetPath";
-import { initAll } from "./index";
+import { initAll, instructionsDismissed } from "./index";
 import queryString from "query-string";
 
 // A list of sample modes.  Should match the dropdown in index.html.
@@ -78,8 +78,11 @@ function saveTrainedModelStub(data, response) {
 }
 
 function setInstructionsKeyStub(instructionsKey, options) {
-  document.getElementById("instructions").innerText =
+  const element = document.getElementById("instructions");
+
+  element.innerText =
     instructionsKey + (!options.showOverlay ? " (no overlay)" : "");
+  element.onclick = instructionsDismissed;
 }
 
 // Initialize the app.

--- a/src/indexProd.js
+++ b/src/indexProd.js
@@ -1,1 +1,1 @@
-export { initAll } from "./index";
+export { initAll, instructionsDismissed } from "./index";

--- a/src/redux.js
+++ b/src/redux.js
@@ -55,6 +55,7 @@ const SET_RESULTS_PHASE = "SET_RESULTS_PHASE";
 const SET_INSTRUCTIONS_KEY_CALLBACK = "SET_INSTRUCTIONS_KEY_CALLBACK";
 const SET_SAVE_STATUS = "SET_SAVE_STATUS";
 const SET_K_VALUE = "SET_K_VALUE";
+const SET_INSTRUCTIONS_DISMISSED = "SET_INSTRUCTIONS_DISMISSED";
 
 // Action creators
 export function setMode(mode) {
@@ -202,6 +203,10 @@ export function setKValue(kValue) {
   return { type: SET_K_VALUE, kValue };
 }
 
+export function setInstructionsDismissed() {
+  return { type: SET_INSTRUCTIONS_DISMISSED };
+}
+
 const initialState = {
   name: undefined,
   csvfile: undefined,
@@ -233,7 +238,8 @@ const initialState = {
   saveStatus: undefined,
   columnRefs: {},
   kValue: null,
-  viewedPanels: []
+  viewedPanels: [],
+  instructionsOverlayActive: false
 };
 
 // Reducer
@@ -434,6 +440,7 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_CURRENT_PANEL) {
+    let showedOverlay = false;
     if (state.instructionsKeyCallback) {
       const options = {};
       if (
@@ -442,6 +449,7 @@ export default function rootReducer(state = initialState, action) {
       ) {
         options.showOverlay = true;
         state.viewedPanels.push(action.currentPanel);
+        showedOverlay = true;
       }
       state.instructionsKeyCallback(action.currentPanel, options);
     }
@@ -450,6 +458,7 @@ export default function rootReducer(state = initialState, action) {
       return {
         ...state,
         currentPanel: action.currentPanel,
+        instructionsOverlayActive: showedOverlay,
         currentColumn: undefined,
         selectedFeatures: []
       };
@@ -459,6 +468,7 @@ export default function rootReducer(state = initialState, action) {
       return {
         ...state,
         currentPanel: action.currentPanel,
+        instructionsOverlayActive: showedOverlay,
         testData: {},
         prediction: {}
       };
@@ -467,6 +477,7 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       currentPanel: action.currentPanel,
+      instructionsOverlayActive: showedOverlay,
       currentColumn: undefined
     };
   }
@@ -535,6 +546,12 @@ export default function rootReducer(state = initialState, action) {
       ...state,
       kValue: action.kValue
     };
+  }
+  if (action.type === SET_INSTRUCTIONS_DISMISSED) {
+    return {
+      ...state,
+      instructionsOverlayActive: false
+    }
   }
   return state;
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -456,7 +456,10 @@ export default function rootReducer(state = initialState, action) {
   if (action.type === SET_CURRENT_PANEL) {
     if (state.instructionsKeyCallback) {
       const options = {};
-      if (!state.viewedPanels.includes(action.currentPanel)) {
+      if (
+        !(state.mode && state.mode.hideInstructionsOverlay) &&
+        !state.viewedPanels.includes(action.currentPanel)
+      ) {
         options.showOverlay = true;
         state.viewedPanels.push(action.currentPanel);
       }


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/40469 adds support for showing the overlay to dim the rest of the screen when Dynamic Instructions are shown or changed.  With this change, AI Lab will display that overlay each time a scene is shown for the first time.  It also handles a notification from the instructions when the overlay has been dismissed, so that we can pause the action until the overlay is gone; this is demonstrated by not starting the `TrainModel` animation until the overlay is gone.

Level editors can disable this behaviour for a level by setting the `hideInstructionsOverlay` parameter to `true`, as is demonstrated by the `preload-metadata` sample mode.

When running this app standalone, clicking the instruction ID at the top of the screen will simulate dismissing the overlay.