### PR TITLE
Restrict label and feature selection to columns with less than 50 unique values

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -11,7 +11,7 @@ import {
   getRangesByColumn,
   setCurrentColumn
 } from "../redux";
-import { ColumnTypes, styles } from "../constants.js";
+import { ColumnTypes, styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
 import { Bar } from "react-chartjs-2";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
@@ -214,7 +214,8 @@ class ColumnInspector extends Component {
               </form>
 
               {currentPanel === "dataDisplayLabel" &&
-                currentColumnData.id !== labelColumn && (
+                currentColumnData.id !== labelColumn &&
+                !currentColumnData.hasTooManyUniqueOptions && (
                   <button
                     type="button"
                     onClick={e =>
@@ -227,7 +228,8 @@ class ColumnInspector extends Component {
                 )}
 
               {currentPanel === "dataDisplayFeatures" &&
-                !selectedFeatures.includes(currentColumnData.id) && (
+                !selectedFeatures.includes(currentColumnData.id) &&
+                !currentColumnData.hasTooManyUniqueOptions && (
                   <button
                     type="button"
                     onClick={e => this.addFeature(e, currentColumnData.id)}
@@ -235,6 +237,14 @@ class ColumnInspector extends Component {
                   >
                     Add feature
                   </button>
+                )}
+
+                {currentColumnData.hasTooManyUniqueOptions && (
+                  <span>
+                    Categorical columns with more than {UNIQUE_OPTIONS_MAX}
+                    {" "} unique values can not be selected as the label or
+                    {" "} features.
+                  </span>
                 )}
             </div>
           </div>

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -242,8 +242,8 @@ class ColumnInspector extends Component {
                 {currentColumnData.hasTooManyUniqueOptions && (
                   <span>
                     Categorical columns with more than {UNIQUE_OPTIONS_MAX}
-                    {" "} unique values can not be selected as the label or
-                    {" "} features.
+                    {" "} unique values can not be selected as the label or a
+                    {" "} feature.
                   </span>
                 )}
             </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -27,6 +27,8 @@ export const TestDataLocations = {
 
 export const ModelNameMaxLength = 150;
 
+export const UNIQUE_OPTIONS_MAX = 50;
+
 export const saveMessages = {
   success: "Your model was saved!",
   failure: "There was an error. Your model did not save. Please try again.",

--- a/src/redux.js
+++ b/src/redux.js
@@ -18,7 +18,8 @@ import {
   ClassificationTrainer,
   TestDataLocations,
   ResultsGrades,
-  REGRESSION_ERROR_TOLERANCE
+  REGRESSION_ERROR_TOLERANCE,
+  UNIQUE_OPTIONS_MAX
 } from "./constants.js";
 
 // Action types
@@ -606,7 +607,8 @@ export function getCurrentColumnData(state) {
     uniqueOptions: getUniqueOptions(state, state.currentColumn),
     range: getRange(state, state.currentColumn),
     frequencies: getOptionFrequencies(state, state.currentColumn),
-    description: getColumnDescription(state, state.currentColumn)
+    description: getColumnDescription(state, state.currentColumn),
+    hasTooManyUniqueOptions: hasTooManyUniqueOptions(state, state.currentColumn)
   };
 }
 
@@ -640,6 +642,20 @@ export function getSelectedNumericalFeatures(state) {
 
 export function getNumericalColumns(state) {
   return filterColumnsByType(state, ColumnTypes.NUMERICAL);
+}
+
+/*
+  Categorical columns with too many unique values are unlikley to make
+  accurate models, and we don't want to overflow the metadata column for saved
+  models.
+*/
+function hasTooManyUniqueOptions(state, column) {
+  if (state.columnsByDataType[column] === ColumnTypes.CATEGORICAL) {
+    const uniqueOptionsCount =
+      getUniqueOptions(state, state.currentColumn).length;
+    return uniqueOptionsCount > UNIQUE_OPTIONS_MAX;
+  }
+  return false;
 }
 
 export function getSelectableFeatures(state) {


### PR DESCRIPTION
In this PR I restrict label and feature selection to categorical columns with less than 50 unique values; no restrictions for numerical columns. Rather than a "Select label" or "Select feature" button, the user will now see a message explaining why that column can not be selected. 

![limit unique values ](https://user-images.githubusercontent.com/12300669/118538145-d3c78380-b71b-11eb-9fc8-124101baf6c9.png)

This is to alleviate to related issues, one technical and one curricular/product. 

1.) The metadata column of the UserMLModels table is a text field that can hold 65,535 characters. In the metadata field we store all the possible values for selected features and label so we can display that information in the Model Card in App Lab and as values in the autogenerated test input dropdowns. Features with many possible values - such as predicting budget based on director and start with the movies dataset exceed the maximum limit for metadata size. 

2.) Categorical columns with a many unique options don't provide much meaningful information to this type of machine learning algorithm and thus create very inaccurate models. Early classroom tests revealed students wanted to try to predict columns such as pokemon name - all unique values - which is more consistent with ideas about "look up" rather than "classification"; explicitly preventing students from selecting label or feature columns with too many unique options constrains users to scenarios that are more aligned with the task at hand. 

