### PR TITLE
Refactor to use `getExtrema` 

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -8,7 +8,7 @@ import {
   getCurrentColumnData,
   addSelectedFeature,
   removeSelectedFeature,
-  getRangesByColumn,
+  getExtremumsByColumn,
   setCurrentColumn
 } from "../redux";
 import { ColumnTypes, styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
@@ -54,7 +54,7 @@ class ColumnInspector extends Component {
     setLabelColumn: PropTypes.func.isRequired,
     addSelectedFeature: PropTypes.func.isRequired,
     removeSelectedFeature: PropTypes.func.isRequired,
-    rangesByColumn: PropTypes.object,
+    extremumsByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
     currentPanel: PropTypes.string,
     labelColumn: PropTypes.string,
@@ -91,7 +91,7 @@ class ColumnInspector extends Component {
   render() {
     const {
       currentColumnData,
-      rangesByColumn,
+      extremumsByColumn,
       currentPanel,
       labelColumn,
       selectedFeatures
@@ -189,19 +189,19 @@ class ColumnInspector extends Component {
                     <div>
                       {currentColumnData.range && (
                         <div>
-                          {isNaN(rangesByColumn[currentColumnData.id].min) && (
+                          {isNaN(extremumsByColumn[currentColumnData.id].min) && (
                             <p style={styles.error}>
                               Numerical columns should contain only numbers.
                             </p>
                           )}
-                          {!isNaN(rangesByColumn[currentColumnData.id].min) && (
+                          {!isNaN(extremumsByColumn[currentColumnData.id].min) && (
                             <div style={styles.contents}>
-                              min: {rangesByColumn[currentColumnData.id].min}
+                              min: {extremumsByColumn[currentColumnData.id].min}
                               <br />
-                              max: {rangesByColumn[currentColumnData.id].max}
+                              max: {extremumsByColumn[currentColumnData.id].max}
                               <br />
                               range:{" "}
-                              {rangesByColumn[currentColumnData.id].range}
+                              {extremumsByColumn[currentColumnData.id].range}
                             </div>
                           )}
                         </div>
@@ -257,7 +257,7 @@ class ColumnInspector extends Component {
 export default connect(
   state => ({
     currentColumnData: getCurrentColumnData(state),
-    rangesByColumn: getRangesByColumn(state),
+    extremumsByColumn: getExtremumsByColumn(state),
     currentPanel: state.currentPanel,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -8,7 +8,6 @@ import {
   getCurrentColumnData,
   addSelectedFeature,
   removeSelectedFeature,
-  getExtremaByColumn,
   setCurrentColumn
 } from "../redux";
 import { ColumnTypes, styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
@@ -54,7 +53,6 @@ class ColumnInspector extends Component {
     setLabelColumn: PropTypes.func.isRequired,
     addSelectedFeature: PropTypes.func.isRequired,
     removeSelectedFeature: PropTypes.func.isRequired,
-    extremaByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
     currentPanel: PropTypes.string,
     labelColumn: PropTypes.string,
@@ -91,7 +89,6 @@ class ColumnInspector extends Component {
   render() {
     const {
       currentColumnData,
-      extremaByColumn,
       currentPanel,
       labelColumn,
       selectedFeatures
@@ -187,21 +184,21 @@ class ColumnInspector extends Component {
 
                   {currentColumnData.dataType === ColumnTypes.NUMERICAL && (
                     <div>
-                      {currentColumnData.range && (
+                      {currentColumnData.extrema && (
                         <div>
-                          {isNaN(extremaByColumn[currentColumnData.id].min) && (
+                          {isNaN(currentColumnData.extrema.min) && (
                             <p style={styles.error}>
                               Numerical columns should contain only numbers.
                             </p>
                           )}
-                          {!isNaN(extremaByColumn[currentColumnData.id].min) && (
+                          {!isNaN(currentColumnData.extrema.min) && (
                             <div style={styles.contents}>
-                              min: {extremaByColumn[currentColumnData.id].min}
+                              min: {currentColumnData.extrema.min}
                               <br />
-                              max: {extremaByColumn[currentColumnData.id].max}
+                              max: {currentColumnData.extrema.max}
                               <br />
                               range:{" "}
-                              {extremaByColumn[currentColumnData.id].range}
+                              {currentColumnData.extrema.range}
                             </div>
                           )}
                         </div>
@@ -257,7 +254,6 @@ class ColumnInspector extends Component {
 export default connect(
   state => ({
     currentColumnData: getCurrentColumnData(state),
-    extremaByColumn: getExtremaByColumn(state),
     currentPanel: state.currentPanel,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -8,7 +8,7 @@ import {
   getCurrentColumnData,
   addSelectedFeature,
   removeSelectedFeature,
-  getExtremumsByColumn,
+  getExtremaByColumn,
   setCurrentColumn
 } from "../redux";
 import { ColumnTypes, styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
@@ -54,7 +54,7 @@ class ColumnInspector extends Component {
     setLabelColumn: PropTypes.func.isRequired,
     addSelectedFeature: PropTypes.func.isRequired,
     removeSelectedFeature: PropTypes.func.isRequired,
-    extremumsByColumn: PropTypes.object,
+    extremaByColumn: PropTypes.object,
     setCurrentColumn: PropTypes.func,
     currentPanel: PropTypes.string,
     labelColumn: PropTypes.string,
@@ -91,7 +91,7 @@ class ColumnInspector extends Component {
   render() {
     const {
       currentColumnData,
-      extremumsByColumn,
+      extremaByColumn,
       currentPanel,
       labelColumn,
       selectedFeatures
@@ -189,19 +189,19 @@ class ColumnInspector extends Component {
                     <div>
                       {currentColumnData.range && (
                         <div>
-                          {isNaN(extremumsByColumn[currentColumnData.id].min) && (
+                          {isNaN(extremaByColumn[currentColumnData.id].min) && (
                             <p style={styles.error}>
                               Numerical columns should contain only numbers.
                             </p>
                           )}
-                          {!isNaN(extremumsByColumn[currentColumnData.id].min) && (
+                          {!isNaN(extremaByColumn[currentColumnData.id].min) && (
                             <div style={styles.contents}>
-                              min: {extremumsByColumn[currentColumnData.id].min}
+                              min: {extremaByColumn[currentColumnData.id].min}
                               <br />
-                              max: {extremumsByColumn[currentColumnData.id].max}
+                              max: {extremaByColumn[currentColumnData.id].max}
                               <br />
                               range:{" "}
-                              {extremumsByColumn[currentColumnData.id].range}
+                              {extremaByColumn[currentColumnData.id].range}
                             </div>
                           )}
                         </div>
@@ -257,7 +257,7 @@ class ColumnInspector extends Component {
 export default connect(
   state => ({
     currentColumnData: getCurrentColumnData(state),
-    extremumsByColumn: getExtremumsByColumn(state),
+    extremaByColumn: getExtremaByColumn(state),
     currentPanel: state.currentPanel,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -10,7 +10,7 @@ import {
   getUniqueOptionsByColumn,
   getConvertedPredictedLabel,
   getPredictAvailable,
-  getRangesByColumn
+  getExtremumsByColumn
 } from "../redux";
 import { styles } from "../constants";
 
@@ -25,7 +25,7 @@ class Predict extends Component {
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     confidence: PropTypes.number,
     getPredictAvailable: PropTypes.bool,
-    rangesByColumn: PropTypes.object
+    extremumsByColumn: PropTypes.object
   };
 
   handleChange = (event, feature) => {
@@ -46,8 +46,8 @@ class Predict extends Component {
           <div style={styles.scrollingContents}>
             <form>
               {this.props.selectedNumericalFeatures.map((feature, index) => {
-                let min = this.props.rangesByColumn[feature].min.toFixed(2);
-                let max = this.props.rangesByColumn[feature].max.toFixed(2);
+                let min = this.props.extremumsByColumn[feature].min.toFixed(2);
+                let max = this.props.extremumsByColumn[feature].max.toFixed(2);
 
                 return (
                   <div style={styles.cardRow} key={index}>
@@ -136,7 +136,7 @@ export default connect(
     selectedCategoricalFeatures: getSelectedCategoricalFeatures(state),
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
     getPredictAvailable: getPredictAvailable(state),
-    rangesByColumn: getRangesByColumn(state)
+    extremumsByColumn: getExtremumsByColumn(state)
   }),
   dispatch => ({
     setTestData(testData) {

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -10,7 +10,7 @@ import {
   getUniqueOptionsByColumn,
   getConvertedPredictedLabel,
   getPredictAvailable,
-  getExtremumsByColumn
+  getExtremaByColumn
 } from "../redux";
 import { styles } from "../constants";
 
@@ -25,7 +25,7 @@ class Predict extends Component {
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     confidence: PropTypes.number,
     getPredictAvailable: PropTypes.bool,
-    extremumsByColumn: PropTypes.object
+    extremaByColumn: PropTypes.object
   };
 
   handleChange = (event, feature) => {
@@ -46,8 +46,8 @@ class Predict extends Component {
           <div style={styles.scrollingContents}>
             <form>
               {this.props.selectedNumericalFeatures.map((feature, index) => {
-                let min = this.props.extremumsByColumn[feature].min.toFixed(2);
-                let max = this.props.extremumsByColumn[feature].max.toFixed(2);
+                let min = this.props.extremaByColumn[feature].min.toFixed(2);
+                let max = this.props.extremaByColumn[feature].max.toFixed(2);
 
                 return (
                   <div style={styles.cardRow} key={index}>
@@ -136,7 +136,7 @@ export default connect(
     selectedCategoricalFeatures: getSelectedCategoricalFeatures(state),
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
     getPredictAvailable: getPredictAvailable(state),
-    extremumsByColumn: getExtremumsByColumn(state)
+    extremaByColumn: getExtremaByColumn(state)
   }),
   dispatch => ({
     setTestData(testData) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -643,7 +643,7 @@ export function getCurrentColumnData(state) {
     readOnly: isColumnReadOnly(state, state.currentColumn),
     dataType: state.columnsByDataType[state.currentColumn],
     uniqueOptions: getUniqueOptions(state, state.currentColumn),
-    range: getExtrema(state, state.currentColumn),
+    extrema: getExtrema(state, state.currentColumn),
     frequencies: getOptionFrequencies(state, state.currentColumn),
     description: getColumnDescription(state, state.currentColumn),
     hasTooManyUniqueOptions: hasTooManyUniqueOptions(state, state.currentColumn)
@@ -1011,9 +1011,9 @@ export function getColumnDataToSave(state, column) {
   if (state.columnsByDataType[column] === ColumnTypes.CATEGORICAL) {
     columnData.values = getUniqueOptions(state, column);
   } else if (state.columnsByDataType[column] === ColumnTypes.NUMERICAL) {
-    const maxMin = getExtrema(state, column);
-    columnData.max = maxMin.max;
-    columnData.min = maxMin.min;
+    const {max, min} = getExtrema(state, column);
+    columnData.max = max;
+    columnData.min = min;
   }
   return columnData;
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -643,7 +643,7 @@ export function getCurrentColumnData(state) {
     readOnly: isColumnReadOnly(state, state.currentColumn),
     dataType: state.columnsByDataType[state.currentColumn],
     uniqueOptions: getUniqueOptions(state, state.currentColumn),
-    range: getExtremums(state, state.currentColumn),
+    range: getExtrema(state, state.currentColumn),
     frequencies: getOptionFrequencies(state, state.currentColumn),
     description: getColumnDescription(state, state.currentColumn),
     hasTooManyUniqueOptions: hasTooManyUniqueOptions(state, state.currentColumn)
@@ -733,12 +733,12 @@ export function getUniqueOptionsByColumn(state) {
   return uniqueOptionsByColumn;
 }
 
-export function getExtremumsByColumn(state) {
-  let extremumsByColumn = {};
+export function getExtremaByColumn(state) {
+  let extremaByColumn = {};
   getNumericalColumns(state).map(
-    column => (extremumsByColumn[column] = getExtremums(state, column))
+    column => (extremaByColumn[column] = getExtrema(state, column))
   );
-  return extremumsByColumn;
+  return extremaByColumn;
 }
 
 function getMaximumValue(state, column) {
@@ -753,13 +753,13 @@ function getRange(maximumValue, minimumValue) {
   return Math.abs(maximumValue - minimumValue);
 }
 
-export function getExtremums(state, column) {
-  let extremums = {};
-  extremums.max = getMaximumValue(state, column);
-  extremums.min = getMinimumValue(state, column)
-  extremums.range = getRange(extremums.max, extremums.min);
+export function getExtrema(state, column) {
+  let extrema = {};
+  extrema.max = getMaximumValue(state, column);
+  extrema.min = getMinimumValue(state, column)
+  extrema.range = getRange(extrema.max, extrema.min);
 
-  return extremums;
+  return extrema;
 }
 
 export function getSelectedColumnDescriptions(state) {
@@ -868,7 +868,7 @@ export function getAccuracyRegression(state) {
   let accuracy = {};
   let numCorrect = 0;
   let grades = [];
-  const range = getExtremums(state, state.labelColumn).range;
+  const range = getExtrema(state, state.labelColumn).range;
   const errorTolerance = (range * REGRESSION_ERROR_TOLERANCE) / 100;
   const numPredictedLabels = state.accuracyCheckPredictedLabels.length;
   for (let i = 0; i < numPredictedLabels; i++) {
@@ -1011,7 +1011,7 @@ export function getColumnDataToSave(state, column) {
   if (state.columnsByDataType[column] === ColumnTypes.CATEGORICAL) {
     columnData.values = getUniqueOptions(state, column);
   } else if (state.columnsByDataType[column] === ColumnTypes.NUMERICAL) {
-    const maxMin = getExtremums(state, column);
+    const maxMin = getExtrema(state, column);
     columnData.max = maxMin.max;
     columnData.min = maxMin.min;
   }

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,5 +1,5 @@
 import {
-  getExtremums,
+  getExtrema,
   getAccuracyRegression,
   getAccuracyClassification
 } from '../../src/redux.js';
@@ -148,7 +148,7 @@ describe('redux functions', () => {
   });
 
   test("getAccuracyRegression", async () => {
-    const range = getExtremums(resultsState, resultsState.labelColumn).range;
+    const range = getExtrema(resultsState, resultsState.labelColumn).range;
     expect(range).toBe(3);
     const accuracy = getAccuracyRegression(resultsState);
     expect(accuracy.grades).toEqual([

--- a/test/unit/redux.test.js
+++ b/test/unit/redux.test.js
@@ -1,5 +1,5 @@
 import {
-  getRange,
+  getExtremums,
   getAccuracyRegression,
   getAccuracyClassification
 } from '../../src/redux.js';
@@ -148,9 +148,7 @@ describe('redux functions', () => {
   });
 
   test("getAccuracyRegression", async () => {
-
-    const maxMin = getRange(resultsState, resultsState.labelColumn);
-    const range = Math.abs(maxMin.max - maxMin.min);
+    const range = getExtremums(resultsState, resultsState.labelColumn).range;
     expect(range).toBe(3);
     const accuracy = getAccuracyRegression(resultsState);
     expect(accuracy.grades).toEqual([


### PR DESCRIPTION
Refactoring a bit of Redux code to better align with best practices in "Clean Code": 

- remove a flag argument 
- keep functions small and their purpose singular 
- provide a more descriptive function name 