### PR TITLE
Fix testing and results table mismatch

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -23,7 +23,6 @@ class Predict extends Component {
     testData: PropTypes.object,
     setTestData: PropTypes.func.isRequired,
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    confidence: PropTypes.number,
     getPredictAvailable: PropTypes.bool,
     rangesByColumn: PropTypes.object
   };
@@ -115,9 +114,6 @@ class Predict extends Component {
             <div>A.I. predicts:</div>
             <div style={styles.contents}>
               {this.props.labelColumn}: {this.props.predictedLabel}
-              {this.props.confidence && (
-                <p>Confidence: {this.props.confidence}</p>
-              )}
             </div>
           </div>
         )}
@@ -130,7 +126,6 @@ export default connect(
   state => ({
     testData: state.testData,
     predictedLabel: getConvertedPredictedLabel(state),
-    confidence: state.prediction.confidence,
     labelColumn: state.labelColumn,
     selectedNumericalFeatures: getSelectedNumericalFeatures(state),
     selectedCategoricalFeatures: getSelectedCategoricalFeatures(state),

--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -242,7 +242,6 @@ export const allDatasets = [
 ];
 
 export function getAvailableDatasets(specificDatasets) {
-  return allDatasets;
   // Filter datasets by a specified array (in Levelbuilder) or filter out toy datasets.
   let availableDatasets = (specificDatasets && specificDatasets.length > 1) ?
     allDatasets.filter(dataset => specificDatasets.includes(dataset.id)) :

--- a/src/datasetManifest.js
+++ b/src/datasetManifest.js
@@ -242,6 +242,7 @@ export const allDatasets = [
 ];
 
 export function getAvailableDatasets(specificDatasets) {
+  return allDatasets;
   // Filter datasets by a specified array (in Levelbuilder) or filter out toy datasets.
   let availableDatasets = (specificDatasets && specificDatasets.length > 1) ?
     allDatasets.filter(dataset => specificDatasets.includes(dataset.id)) :

--- a/src/redux.js
+++ b/src/redux.js
@@ -1026,16 +1026,14 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.potentialUses = state.trainedModelDetails.potentialUses;
   dataToSave.potentialMisuses = state.trainedModelDetails.potentialMisuses;
 
-  dataToSave.selectedTrainer =
-    isRegression(state)
-      ? RegressionTrainer
-      : ClassificationTrainer;
+  dataToSave.selectedTrainer = isRegression(state)
+    ? RegressionTrainer
+    : ClassificationTrainer;
   dataToSave.featureNumberKey = state.featureNumberKey;
   dataToSave.label = getColumnDataToSave(state, state.labelColumn);
   dataToSave.features = getFeaturesToSave(state);
   dataToSave.summaryStat = getSummaryStat(state);
-  dataToSave.trainedModel =
-    state.trainedModel
+  dataToSave.trainedModel = state.trainedModel
     ? state.trainedModel.toJSON()
     : null;
   dataToSave.kValue = state.kValue;

--- a/src/redux.js
+++ b/src/redux.js
@@ -243,7 +243,7 @@ const initialState = {
   accuracyCheckLabels: [],
   accuracyCheckPredictedLabels: [],
   testData: {},
-  prediction: {},
+  prediction: undefined,
   modelSize: undefined,
   trainedModel: undefined,
   trainedModelDetails: {},
@@ -394,7 +394,7 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       testData: action.testData,
-      prediction: {}
+      prediction: undefined
     };
   }
   if (action.type === SET_PREDICTION) {
@@ -488,7 +488,7 @@ export default function rootReducer(state = initialState, action) {
         currentPanel: action.currentPanel,
         instructionsOverlayActive: showedOverlay,
         testData: {},
-        prediction: {},
+        prediction: undefined,
         resultsTab: ResultsGrades.CORRECT
       };
     }
@@ -812,7 +812,7 @@ export function getConvertedLabel(state, rawLabel) {
 }
 
 export function getConvertedPredictedLabel(state) {
-  return getConvertedLabel(state, state.prediction.predictedLabel);
+  return getConvertedLabel(state, state.prediction);
 }
 
 export function getConvertedLabels(state, rawLabels = []) {
@@ -1034,7 +1034,10 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.label = getColumnDataToSave(state, state.labelColumn);
   dataToSave.features = getFeaturesToSave(state);
   dataToSave.summaryStat = getSummaryStat(state);
-  dataToSave.trainedModel = state.trainedModel.toJSON();
+  dataToSave.trainedModel =
+    state.trainedModel
+    ? state.trainedModel.toJSON()
+    : null;
   dataToSave.kValue = state.kValue;
 
   return dataToSave;

--- a/src/redux.js
+++ b/src/redux.js
@@ -1034,7 +1034,7 @@ export function getTrainedModelDataToSave(state) {
   dataToSave.label = getColumnDataToSave(state, state.labelColumn);
   dataToSave.features = getFeaturesToSave(state);
   dataToSave.summaryStat = getSummaryStat(state);
-  dataToSave.trainedModel = state.trainedModel;
+  dataToSave.trainedModel = state.trainedModel.toJSON();
   dataToSave.kValue = state.kValue;
 
   return dataToSave;

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -97,9 +97,8 @@ export default class KNNTrainer {
   }
 
   predict(testValues) {
-    let prediction = {};
     const state = store.getState();
-    prediction.predictedLabel = state.trainedModel.predict(testValues);
+    const prediction = state.trainedModel.predict(testValues);
     store.dispatch(setPrediction(prediction));
   }
 }

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -44,7 +44,7 @@ export default class KNNTrainer {
           state.trainingLabels,
           {k: kValue}
         );
-        var model = this.knn.toJSON();
+        var model = this.knn;
         const predictedLabels = this.batchPredict(state.accuracyCheckExamples);
         const accuracy = this.getAccuracyPercent();
         if (accuracy > bestAccuracy) {
@@ -62,7 +62,7 @@ export default class KNNTrainer {
         state.trainingLabels,
         {k: defaultK}
       );
-      bestModel = this.knn.toJSON();
+      bestModel = this.knn
       bestK = defaultK;
     }
     store.dispatch(setKValue(bestK));
@@ -98,7 +98,8 @@ export default class KNNTrainer {
 
   predict(testValues) {
     let prediction = {};
-    prediction.predictedLabel = this.knn.predict([testValues])[0];
+    const state = store.getState();
+    prediction.predictedLabel = state.trainedModel.predict(testValues);
     store.dispatch(setPrediction(prediction));
   }
 }


### PR DESCRIPTION
When we started trying multiple K values, it created bug. The bug presented as an inconsistency between predictions in the results table and the testing panel given the same feature values.  The batch prediction for the results table was using the best model with the optimized K value, but the test panel with the single prediction was incorrectly using the model that was most recently created. This bug was tricky to catch because sometimes the best model was the last model which concealed the issue. Now we are correctly using the best model with the optimal K value in both scenarios. 

Additionally, this PR includes a little bit of clean up - prediction no longer needs to be nested in an object because confidence is not a field we actually use. 