### PR TITLE
Save whether the dataset is userUploaded or not

### DIFF
--- a/src/UIComponents/GenerateResults.jsx
+++ b/src/UIComponents/GenerateResults.jsx
@@ -2,7 +2,6 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import train from "../train";
 import { readyToTrain } from "../redux";
 import { styles, getFadeOpacity } from "../constants";
 import aiBotClosed from "@public/images/ai-bot/ai-bot-closed.png";

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -44,7 +44,7 @@ class TrainModel extends Component {
     );
 
     this.setState({ animationTimer });
-  };
+  }
 
   updateAnimation = () => {
     if (this.state.frame === 15) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -988,6 +988,7 @@ export function getDatasetDetails(state) {
   const datasetDetails = {};
   datasetDetails.description = getDataDescription(state);
   datasetDetails.numRows = state.data.length;
+  datasetDetails.isUserUploaded = isUserUploadedDataset(state);
   return datasetDetails;
 }
 
@@ -1014,13 +1015,10 @@ export function getFeaturesToSave(state) {
 
 export function getTrainedModelDataToSave(state) {
   const dataToSave = {};
-
   dataToSave.name = state.trainedModelDetails.name;
-
   dataToSave.datasetDetails = getDatasetDetails(state);
   dataToSave.potentialUses = state.trainedModelDetails.potentialUses;
   dataToSave.potentialMisuses = state.trainedModelDetails.potentialMisuses;
-
   dataToSave.selectedTrainer = isRegression(state)
     ? RegressionTrainer
     : ClassificationTrainer;


### PR DESCRIPTION
We'd like to be able to query for models that are trained on student-uploaded data to get a sense of how often the upload functionality is used and to ultimately get a clearer idea about the kinds of datasets students are creating and uploading. To make this metric easier to track, this PR adds an `isUserUploaded` boolean to the metadata we save for each model. 