### PR TITLE
Save dataset name for metrics

### DIFF
--- a/public/datasets/abalone.json
+++ b/public/datasets/abalone.json
@@ -1,4 +1,5 @@
 {
+  "name": "abalone",
   "card": {
     "description": "This dataset contains various attributes of different abalone, a type of marine snails. The goal is to predict the number of rings in the abalone's shell, which is an indicator of its age.",
     "source": "UCI (archive.ics.uci.edu/ml/datasets/Abalone)",

--- a/public/datasets/auto_mpg.json
+++ b/public/datasets/auto_mpg.json
@@ -1,4 +1,5 @@
 {
+  "name": "auto_mpg",
   "card": {
     "description": "A small dataset of different car statistics, originally from 1983, used to predict their MPG (miles per gallon). This dataset is unlikely to get great accuracy scores on a KNN regression, but it could make a useful model nonetheless: how can you take a general pattern in the model and use that to determine which features contribute to higher miles per gallon? How might you change the dataset to get a more accurate model - for example, changing MPG from a numerical column to a categorical one with intervals of 5 MPG?",
     "source": "UCI (http://archive.ics.uci.edu/ml/datasets/Auto+MPG)",

--- a/public/datasets/basketball_shots.json
+++ b/public/datasets/basketball_shots.json
@@ -1,4 +1,5 @@
 {
+  "name": "basketball_shots",
   "card": {
     "description": "This dataset contains every 3-point attempt made during the NCAA 2017 tournament. With this data it's possible to predict whether the shot was made or missed.",
     "source": "NCAA (https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=ncaa_basketball)",

--- a/public/datasets/bike_sharing.json
+++ b/public/datasets/bike_sharing.json
@@ -1,4 +1,5 @@
 {
+  "name": "bike_sharing",
   "card": {
     "description": "Daily rental data from Washington, D.C.'s Capital Bikeshare system from 2011 and 2012, along with weather data for those days.",
     "source": "UCI Machine Learning (https://archive.ics.uci.edu/ml/datasets/Bike+Sharing+Dataset)",

--- a/public/datasets/billionaires.json
+++ b/public/datasets/billionaires.json
@@ -1,4 +1,5 @@
 {
+  "name": "billionaires",
   "card": {
     "description": "Multi-decade data on individual billionaires, ranked for each year, with features like age, industry, family wealth, and wealth type (e.g. company founder in the finance industry).",
     "source": "CORGIS Dataset Project https://corgis-edu.github.io/corgis/csv/billionaires/()",

--- a/public/datasets/boba_toy.json
+++ b/public/datasets/boba_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "boba_toy",
   "card": {
     "description": "Survey of customers in a bubble tea cafe on whether or not they like certain bubble tea combinations",
     "source": "Code.org",

--- a/public/datasets/breakfast_toy.json
+++ b/public/datasets/breakfast_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "breakfast_toy",
   "card": {
     "description": "Determines your ideal breakfast based on several quiz questions",
     "source": "Code.org",

--- a/public/datasets/car_evaluation.json
+++ b/public/datasets/car_evaluation.json
@@ -1,4 +1,5 @@
 {
+  "name": "car_evaluation",
   "card": {
     "description": "A dataset of cars ranked on 'acceptability', based on features like price, safety, and number of passengers. The rankings come from a decision model designed by Marko Bohanec.",
     "source": "UCI (http://archive.ics.uci.edu/ml/datasets/Car+Evaluation)",

--- a/public/datasets/census_part.json
+++ b/public/datasets/census_part.json
@@ -1,4 +1,5 @@
 {
+  "name": "census_part",
   "card": {
     "description": "Data from the 1994 US census, with income, personal, and job data. Used to predict whether a person's income is over $50,000",
     "source": "UCI Machine Learning (https://archive.ics.uci.edu/ml/datasets/Adult)",

--- a/public/datasets/cookies_toy.json
+++ b/public/datasets/cookies_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "cookies_toy",
   "card": {
     "description": "Survey of customers in a cookie store on whether or not they like certain cookie combinations",
     "source": "Code.org",

--- a/public/datasets/drink_toy.json
+++ b/public/datasets/drink_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "drink_toy",
   "card": {
     "description": "Results of a quiz to determine your favorite drink from several questions",
     "source": "Code.org",

--- a/public/datasets/exoplanets.json
+++ b/public/datasets/exoplanets.json
@@ -1,71 +1,71 @@
 {
-    "card": {
-      "description": "This dataset is a list of exoplanets, which are planets orbiting other stars. With this data, it's possible to estimate the size of an exoplanet as well as other characteristics.",
-      "source": "https://exoplanetarchive.ipac.caltech.edu/",
-      "lastUpdated": "2021",
-      "context": {
-        "createdBy": "California Institute of Technology",
-        "potentialUses": "Estimate the size or mass of an exoplanet based on the size, age or other aspects of the star it orbits.",
-        "potentialMisuses": "Trying to make guesses as to whether a planet could support life."
-      }
+  "name": "exoplanets",
+  "card": {
+    "description": "This dataset is a list of exoplanets, which are planets orbiting other stars. With this data, it's possible to estimate the size of an exoplanet as well as other characteristics.",
+    "source": "https://exoplanetarchive.ipac.caltech.edu/",
+    "lastUpdated": "2021",
+    "context": {
+      "createdBy": "California Institute of Technology",
+      "potentialUses": "Estimate the size or mass of an exoplanet based on the size, age or other aspects of the star it orbits.",
+      "potentialMisuses": "Trying to make guesses as to whether a planet could support life."
+    }
+  },
+  "defaultLabelColumn": "Mass in earths",
+  "fields": [
+    {
+      "type": "categorical",
+      "id": "Star host name",
+      "description": "The name of the start this exoplanet is orbiting."
     },
-    "defaultLabelColumn": "Mass in earths",
-    "fields": [
-      {
-        "type": "categorical",
-        "id": "Star host name",
-        "description": "The name of the start this exoplanet is orbiting."
-      },
-      {
-        "type": "numerical",
-        "id": "Number of stars",
-        "description": "Number of stars in the exoplanet's system."
-      },
-      {
-        "type": "numerical",
-        "id": "Number of planets",
-        "description": "Number of planets in the exoplanet's system."
-      },
-      {
-        "type": "numerical",
-        "id": "Discovery year",
-        "description": "The year this exoplanet was discovered."
-      },
-      {
-        "type": "numerical",
-        "id": "Orbit length in earth days",
-        "description": "How long it takes for this planet to make a complete orbit around its host star, measured in earth days."
-      },
-      {
-        "type": "numerical",
-        "id": "Size in earths",
-        "description": "The relative size of this exoplanet in comparison to earth."
-      },
-      {
-        "type": "numerical",
-        "id": "Mass in earths",
-        "description": "The relative mass of this exoplanet in comparison to earth."
-      },
-      {
-        "type": "numerical",
-        "id": "Star temperature in kelvin",
-        "description": "The temperature of the host star in kelvin."
-      },
-      {
-        "type": "numerical",
-        "id": "Star size in suns",
-        "description": "The relative size of the host star in comparison to the sun."
-      },
-      {
-        "type": "numerical",
-        "id": "Star mass in suns",
-        "description": "The relative mass of the host star in comparison to the sun."
-      },
-      {
-        "type": "numerical",
-        "id": "Star age in billions of years",
-        "description": "The age of the host star."
-      }
-    ]
-  }
-  
+    {
+      "type": "numerical",
+      "id": "Number of stars",
+      "description": "Number of stars in the exoplanet's system."
+    },
+    {
+      "type": "numerical",
+      "id": "Number of planets",
+      "description": "Number of planets in the exoplanet's system."
+    },
+    {
+      "type": "numerical",
+      "id": "Discovery year",
+      "description": "The year this exoplanet was discovered."
+    },
+    {
+      "type": "numerical",
+      "id": "Orbit length in earth days",
+      "description": "How long it takes for this planet to make a complete orbit around its host star, measured in earth days."
+    },
+    {
+      "type": "numerical",
+      "id": "Size in earths",
+      "description": "The relative size of this exoplanet in comparison to earth."
+    },
+    {
+      "type": "numerical",
+      "id": "Mass in earths",
+      "description": "The relative mass of this exoplanet in comparison to earth."
+    },
+    {
+      "type": "numerical",
+      "id": "Star temperature in kelvin",
+      "description": "The temperature of the host star in kelvin."
+    },
+    {
+      "type": "numerical",
+      "id": "Star size in suns",
+      "description": "The relative size of the host star in comparison to the sun."
+    },
+    {
+      "type": "numerical",
+      "id": "Star mass in suns",
+      "description": "The relative mass of the host star in comparison to the sun."
+    },
+    {
+      "type": "numerical",
+      "id": "Star age in billions of years",
+      "description": "The age of the host star."
+    }
+  ]
+}

--- a/public/datasets/global_happiness_raw.json
+++ b/public/datasets/global_happiness_raw.json
@@ -1,4 +1,5 @@
 {
+  "name": "global_happines_raw",
   "card": {
     "description": "2019 Global Happiness report rankings, where countries are rated on different attributes that contribute to a total happiness score then ranked. The features in this dataset are taken from the years 2008 to 2018, which were averaged together for the report to create scores. This 'raw' data contains more rows than the 'Global Happiness 2019' dataset, but may give different results.",
     "source": "United Nations (https://worldhappiness.report/ed/2019/)",

--- a/public/datasets/heart.json
+++ b/public/datasets/heart.json
@@ -1,4 +1,5 @@
 {
+  "name": "heart",
   "card": {
     "description": "A dataset of test results for heart disease patients, used to predict whether or not someone may have heart disease.",
     "source": "UCI (http://archive.ics.uci.edu/ml/datasets/Heart+Disease)",

--- a/public/datasets/icecream_toppings_toy.json
+++ b/public/datasets/icecream_toppings_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "icecream_toppings_toy",
   "card": {
     "description": "Survey of customers in an ice cream shop on whether or not they like certain ice cream combinations",
     "source": "Code.org",

--- a/public/datasets/insurance_cost.json
+++ b/public/datasets/insurance_cost.json
@@ -1,4 +1,5 @@
 {
+  "name": "insurance_cost",
   "card": {
     "description": "Insurance costs along with factors like number of children, location, smoker/nonsmoker status, age, sex, BMI",
     "source": "https://www.kaggle.com/mirichoi0218/insurance",

--- a/public/datasets/jeans.json
+++ b/public/datasets/jeans.json
@@ -1,76 +1,76 @@
 {
-    "card": {
-      "description": "This dataset contains measurement data about popular brands of jeans.",
-      "source": "https://pudding.cool/",
-      "lastUpdated": "2019",
-      "context": {
-        "createdBy": "The Pudding",
-        "potentialUses": "Predict the price of a pair of jeans based on who they're for, the size of the pockets, etc.",
-        "potentialMisuses": ""
-      }
+  "name": "jeans",
+  "card": {
+    "description": "This dataset contains measurement data about popular brands of jeans.",
+    "source": "https://pudding.cool/",
+    "lastUpdated": "2019",
+    "context": {
+      "createdBy": "The Pudding",
+      "potentialUses": "Predict the price of a pair of jeans based on who they're for, the size of the pockets, etc.",
+      "potentialMisuses": ""
+    }
+  },
+  "defaultLabelColumn": "Price in dollars",
+  "fields": [
+    {
+      "type": "categorical",
+      "id": "Brand",
+      "description": "The brand of jeans."
     },
-    "defaultLabelColumn": "Price in dollars",
-    "fields": [
-      {
-        "type": "categorical",
-        "id": "Brand",
-        "description": "The brand of jeans."
-      },
-      {
-        "type": "categorical",
-        "id": "Style",
-        "description": "The fit or style of jeans, e.g. skinny or boot cut."
-      },
-      {
-        "type": "categorical",
-        "id": "Mens or womens",
-        "description": "Whether the jeans were sold to target men or women."
-      },
-      {
-        "type": "numerical",
-        "id": "Cotton contents",
-        "description": "Amount of cotton in the fabric, where 0 means no cotton at all, and 1 means 100% cotton."
-      },
-      {
-        "type": "numerical",
-        "id": "Price in dollars",
-        "description": "The price of the jeans in US dollars."
-      },
-      {
-        "type": "numerical",
-        "id": "Max height of front pocket",
-        "description": "The height of the front pocket from its deepest part."
-      },
-      {
-        "type": "numerical",
-        "id": "Min height of front pocket",
-        "description": "The height of the front pocket from its most shallow part."
-      },
-      {
-        "type": "numerical",
-        "id": "Front rivet height",
-        "description": "Front pocket openings curve down towards the side of the leg, ending in a rivet. This number measures the distance from the top of the pocket to that rivet."
-      },
-      {
-        "type": "numerical",
-        "id": "Max width of back pocket",
-        "description": "The width of the front pocket from its widest part."
-      },
-      {
-        "type": "numerical",
-        "id": "Min width of back pocket",
-        "description": "The width of the front pocket from its narrowest part."
-      },
-      {
-        "type": "numerical",
-        "id": "Max height of back pocket",
-        "description": "The height of the front pocket from its deepest part."
-      },
-      {
-        "type": "numerical",
-        "id": "Min height of back pocket",
-        "description": "The height of the front pocket from its shallowest part."
-      }
-    ]
-  }
-  
+    {
+      "type": "categorical",
+      "id": "Style",
+      "description": "The fit or style of jeans, e.g. skinny or boot cut."
+    },
+    {
+      "type": "categorical",
+      "id": "Mens or womens",
+      "description": "Whether the jeans were sold to target men or women."
+    },
+    {
+      "type": "numerical",
+      "id": "Cotton contents",
+      "description": "Amount of cotton in the fabric, where 0 means no cotton at all, and 1 means 100% cotton."
+    },
+    {
+      "type": "numerical",
+      "id": "Price in dollars",
+      "description": "The price of the jeans in US dollars."
+    },
+    {
+      "type": "numerical",
+      "id": "Max height of front pocket",
+      "description": "The height of the front pocket from its deepest part."
+    },
+    {
+      "type": "numerical",
+      "id": "Min height of front pocket",
+      "description": "The height of the front pocket from its most shallow part."
+    },
+    {
+      "type": "numerical",
+      "id": "Front rivet height",
+      "description": "Front pocket openings curve down towards the side of the leg, ending in a rivet. This number measures the distance from the top of the pocket to that rivet."
+    },
+    {
+      "type": "numerical",
+      "id": "Max width of back pocket",
+      "description": "The width of the front pocket from its widest part."
+    },
+    {
+      "type": "numerical",
+      "id": "Min width of back pocket",
+      "description": "The width of the front pocket from its narrowest part."
+    },
+    {
+      "type": "numerical",
+      "id": "Max height of back pocket",
+      "description": "The height of the front pocket from its deepest part."
+    },
+    {
+      "type": "numerical",
+      "id": "Min height of back pocket",
+      "description": "The height of the front pocket from its shallowest part."
+    }
+  ]
+}

--- a/public/datasets/medical_priority.json
+++ b/public/datasets/medical_priority.json
@@ -1,4 +1,5 @@
 {
+  "name": "medical_priority",
   "card": {
     "description": "Data collected by a hospital on all patients who entered an emergency room over the course of one month",
     "source": "Code.org Generated Dataset",

--- a/public/datasets/movies.json
+++ b/public/datasets/movies.json
@@ -1,4 +1,5 @@
 {
+  "name": "movies",
   "card": {
     "description": "A dataset of movies released from 1986-2016, with box office numbers, ratings, IMDB scores, and more.",
     "source": "Kaggle (https://www.kaggle.com/danielgrijalvas/movies)",

--- a/public/datasets/naan_toy.json
+++ b/public/datasets/naan_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "naan_toy",
   "card": {
     "description": "Survey of customers in an Indian restaurant on whether or not they like certain naan combinations",
     "source": "Code.org",

--- a/public/datasets/nutrition.json
+++ b/public/datasets/nutrition.json
@@ -1,4 +1,5 @@
 {
+  "name": "nutrition",
   "card": {
     "description": "A dataset compiled by the USDA of various food items and their nutritional content: calories, minerals, vitamins, and a whole lot more.",
     "source": "CORGIS Datasets Project (https://corgis-edu.github.io/corgis/csv/food/)",

--- a/public/datasets/pizza_toppings_toy.json
+++ b/public/datasets/pizza_toppings_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "pizza_toppings_toy",
   "card": {
     "description": "Survey of customers in a pizza parlor on whether or not they like certain pizza combinations",
     "source": "Code.org",

--- a/public/datasets/poke_toy.json
+++ b/public/datasets/poke_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "poke_toy",
   "card": {
     "description": "Survey of customers in a poke shop on whether or not they like certain poke combinations",
     "source": "Code.org",

--- a/public/datasets/poutine_toy.json
+++ b/public/datasets/poutine_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "poutine_toy",
   "card": {
     "description": "Survey of customers in a diner on whether or not they like certain poutine combinations",
     "source": "Code.org",

--- a/public/datasets/raspado_toy.json
+++ b/public/datasets/raspado_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "raspado_toy",
   "card": {
     "description": "Survey of customers in a raspado shop on whether or not they like certain raspado combinations",
     "source": "Code.org",

--- a/public/datasets/safari_toy.json
+++ b/public/datasets/safari_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "safari_toy",
   "card": {
     "description": "Data collected from 'African Safari Tours', a company that offers tours of the Serengeti plains in Africa.",
     "source": "Code.org",

--- a/public/datasets/salad_toy.json
+++ b/public/datasets/salad_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "salad_toy",
   "card": {
     "description": "Survey of customers in a restaurant on whether or not they like certain salad combinations",
     "source": "Code.org",

--- a/public/datasets/salsa_toy.json
+++ b/public/datasets/salsa_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "salsa_toy",
   "card": {
     "description": "Survey of customers in a taco shop on whether or not they like certain salsa combinations",
     "source": "Code.org",

--- a/public/datasets/songs.json
+++ b/public/datasets/songs.json
@@ -1,61 +1,61 @@
 {
-    "card": {
-      "description": "A random selection of popular songs with and Billboard Top 100 chart information as well as other characteristics.",
-      "source": "http://doi.org/10.5281/zenodo.3258042",
-      "lastUpdated": "2021",
-      "context": {
-        "createdBy": "Eva Zangerle",
-        "potentialUses": "Predict how big of a hit a song was based on its genre and other factors.",
-        "potentialMisuses": ""
-      }
+  "name": "songs",
+  "card": {
+    "description": "A random selection of popular songs with and Billboard Top 100 chart information as well as other characteristics.",
+    "source": "http://doi.org/10.5281/zenodo.3258042",
+    "lastUpdated": "2021",
+    "context": {
+      "createdBy": "Eva Zangerle",
+      "potentialUses": "Predict how big of a hit a song was based on its genre and other factors.",
+      "potentialMisuses": ""
+    }
+  },
+  "defaultLabelColumn": "Billboard rank peak",
+  "fields": [
+    {
+      "id": "Genre",
+      "type": "categorical",
+      "description": "The genre of the song."
     },
-    "defaultLabelColumn": "Billboard rank peak",
-    "fields": [
-      {
-        "id": "Genre",
-        "type": "categorical",
-        "description": "The genre of the song."
-      },
-      {
-        "id": "Artist",
-        "type": "categorical",
-        "description": "The artist's name."
-      },
-      {
-        "id": "Title",
-        "type": "categorical",
-        "description": "Title of the song."
-      },
-      {
-        "id": "Loudness score",
-        "type": "numerical",
-        "description": "A scoring of the song's loudness, where low negative numbers like -13 mean relatively quiet, and high negative numbers like -5 mean relatively loud"
-      },
-      {
-        "id": "Tempo in beats per minute",
-        "type": "numerical",
-        "description": "Tempo of the song in beats per minute (BPM). Higher numbers mean faster, more energetic songs."
-      },
-      {
-        "id": "Duration in seconds",
-        "type": "numerical",
-        "description": "Length of the song in seconds."
-      },
-      {
-        "id": "Year",
-        "type": "numerical",
-        "description": "The year the song was released."
-      },
-      {
-        "id": "Weeks on the Billboard Top 100",
-        "type": "numerical",
-        "description": "The total number of weeks the songs was listed on the Billboard Top 100."
-      },
-      {
-        "id": "Billboard rank peak",
-        "type": "numerical",
-        "description": "The highest position the song reached on the Billboard Top 100."
-      }
-    ]
-  }
-  
+    {
+      "id": "Artist",
+      "type": "categorical",
+      "description": "The artist's name."
+    },
+    {
+      "id": "Title",
+      "type": "categorical",
+      "description": "Title of the song."
+    },
+    {
+      "id": "Loudness score",
+      "type": "numerical",
+      "description": "A scoring of the song's loudness, where low negative numbers like -13 mean relatively quiet, and high negative numbers like -5 mean relatively loud"
+    },
+    {
+      "id": "Tempo in beats per minute",
+      "type": "numerical",
+      "description": "Tempo of the song in beats per minute (BPM). Higher numbers mean faster, more energetic songs."
+    },
+    {
+      "id": "Duration in seconds",
+      "type": "numerical",
+      "description": "Length of the song in seconds."
+    },
+    {
+      "id": "Year",
+      "type": "numerical",
+      "description": "The year the song was released."
+    },
+    {
+      "id": "Weeks on the Billboard Top 100",
+      "type": "numerical",
+      "description": "The total number of weeks the songs was listed on the Billboard Top 100."
+    },
+    {
+      "id": "Billboard rank peak",
+      "type": "numerical",
+      "description": "The highest position the song reached on the Billboard Top 100."
+    }
+  ]
+}

--- a/public/datasets/student_alcohol_consumption.json
+++ b/public/datasets/student_alcohol_consumption.json
@@ -1,4 +1,5 @@
 {
+  "name": "student_alcohol_consumption",
   "card": {
     "description": "Contains individual responses to a social survey of Portuguese secondary school students, tracking social, gender, and study information.",
     "source": "Kaggle (https://www.kaggle.com/uciml/student-alcohol-consumption)",

--- a/public/datasets/student_survey.json
+++ b/public/datasets/student_survey.json
@@ -1,4 +1,5 @@
 {
+  "name": "student_survey",
   "card": {
     "description": "A dataset of survey responses gathered by Slovakian students at FSEV UK. Questions were asked about music, culture, their own phobias, and their demographic information. Most responses are rankings on a scale from 1 to 5. For example, the question 'Do you enjoy listening to music?' offered a scale from 1 (Strongly disagree) to 5 (Strongly agree). This dataset has a huge amount of questions to explore.",
     "source": "Kaggle (https://www.kaggle.com/miroslavsabo/young-people-survey)",

--- a/public/datasets/taco_toppings_toy.json
+++ b/public/datasets/taco_toppings_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "taco_toppings_toy",
   "card": {
     "description": "Survey of customers in a taco shop on whether or not they like certain taco combinations",
     "source": "Code.org",

--- a/public/datasets/thanksgiving.json
+++ b/public/datasets/thanksgiving.json
@@ -1,4 +1,5 @@
 {
+  "name": "thanksgiving",
   "card": {
     "description": "A survey from FiveThrityEight, asking people across the United States what foods they have for Thanksgiving dinner.",
     "source": "FiveThirtyEight (https://github.com/fivethirtyeight/data/tree/master/thanksgiving-2015) ",

--- a/public/datasets/workout_toy.json
+++ b/public/datasets/workout_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "workout_toy",
   "card": {
     "description": "Survey results from a quiz that determines your ideal workout based on several questions",
     "source": "Code.org",

--- a/public/datasets/zoo.json
+++ b/public/datasets/zoo.json
@@ -1,4 +1,5 @@
 {
+  "name": "zoo",
   "card": {
     "description": "A small dataset of different animal attributes (whether they have hair, feathers, teeth, and more) used for classification purposes. Almost all features are Yes/No except for Animal Name, Class, and Number of Legs.",
     "source": "UCI (http://archive.ics.uci.edu/ml/datasets/Zoo)",

--- a/src/redux.js
+++ b/src/redux.js
@@ -223,7 +223,7 @@ const initialState = {
   csvfile: undefined,
   jsonfile: undefined,
   data: [],
-  metadata: undefined,
+  metadata: {},
   highlightDataset: undefined,
   highlightColumn: undefined,
   columnsByDataType: {},
@@ -987,6 +987,7 @@ export function getDataDescription(state) {
 
 export function getDatasetDetails(state) {
   const datasetDetails = {};
+  datasetDetails.name = state.metadata.name;
   datasetDetails.description = getDataDescription(state);
   datasetDetails.numRows = state.data.length;
   datasetDetails.isUserUploaded = isUserUploadedDataset(state);


### PR DESCRIPTION
We'd like to be able to track which dataset was used to train a saved model for metrics. There are a handful of gnarly ways we could've inferred which in-house dataset was used from the metadata we were already saving with each trained model, but this is felt much cleaner and easier to query. I added name to the datasetDetails object already included in the data we save. 