### PR TITLE
Fix Thanksgiving dataset bug and update Thanksgiving/NCAA formatting

### DIFF
--- a/public/datasets/basketball_shots.csv
+++ b/public/datasets/basketball_shots.csv
@@ -1,4 +1,4 @@
-Away team alias,Home team alias,Time in seconds,Jersey number,Inches from left baseline,Inches from bottom sideline,Made or miss?
+Away team alias,Home team alias,Time in seconds,Jersey number,Inches from left baseline,Inches from bottom sideline,Made or miss
 FSU,MIZZ,556,10,373,335,miss
 FSU,MIZZ,808,15,282,459,miss
 FSU,MIZZ,379,15,339,207,miss

--- a/public/datasets/basketball_shots.json
+++ b/public/datasets/basketball_shots.json
@@ -9,7 +9,7 @@
       "potentialMisuses": ""
     }
   },
-  "defaultLabelColumn": "Made or miss?",
+  "defaultLabelColumn": "Made or miss",
   "fields": [
     {
       "type": "categorical",
@@ -43,7 +43,7 @@
     },
     {
       "type": "categorical",
-      "id": "Made or miss?",
+      "id": "Made or miss",
       "description": "Whether the 3-point shot was made or missed."
     }
   ]

--- a/public/datasets/heart.csv
+++ b/public/datasets/heart.csv
@@ -1,14 +1,14 @@
-﻿age,sex,Chest Pain Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
+﻿age,sex,Chest Test Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
 63,male,None,145,233,TRUE,Normal,150,No,2.3,0,0,Yes
 37,male,Non-Anginal,130,250,FALSE,Some abnormality,187,No,3.5,0,0,Yes
 41,female,Atypical Angina,130,204,FALSE,Normal,172,No,1.4,2,0,Yes
 56,male,Atypical Angina,120,236,FALSE,Some abnormality,178,No,0.8,2,0,Yes
-57,female,Typical Angina,120,354,FALSE,Some abnormality,163,Yes,0.6,2,0,Yes
-57,male,Typical Angina,140,192,FALSE,Some abnormality,148,No,0.4,1,0,Yes
+57,,Typical Angina,120,354,FALSE,Some abnormality,163,Yes,0.6,2,0,Yes
+57,,Typical Angina,140,192,FALSE,Some abnormality,148,No,0.4,1,0,Yes
 56,female,Atypical Angina,140,294,FALSE,Normal,153,No,1.3,1,0,Yes
 44,male,Atypical Angina,120,263,FALSE,Some abnormality,173,No,0,2,0,Yes
-52,male,Non-Anginal,172,199,TRUE,Some abnormality,162,No,0.5,2,0,Yes
-57,male,Non-Anginal,150,168,FALSE,Some abnormality,174,No,1.6,2,0,Yes
+52,male,,172,199,TRUE,Some abnormality,162,No,0.5,2,0,Yes
+57,,Non-Anginal,150,168,FALSE,Some abnormality,174,No,1.6,2,0,Yes
 54,male,Typical Angina,140,239,FALSE,Some abnormality,160,No,1.2,2,0,Yes
 48,female,Non-Anginal,130,275,FALSE,Some abnormality,139,No,0.2,2,0,Yes
 49,male,Atypical Angina,130,266,FALSE,Some abnormality,171,No,0.6,2,0,Yes

--- a/public/datasets/heart.csv
+++ b/public/datasets/heart.csv
@@ -1,14 +1,14 @@
-﻿age,sex,Chest Test Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
+﻿age,sex,Chest Pain Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
 63,male,None,145,233,TRUE,Normal,150,No,2.3,0,0,Yes
 37,male,Non-Anginal,130,250,FALSE,Some abnormality,187,No,3.5,0,0,Yes
 41,female,Atypical Angina,130,204,FALSE,Normal,172,No,1.4,2,0,Yes
 56,male,Atypical Angina,120,236,FALSE,Some abnormality,178,No,0.8,2,0,Yes
-57,,Typical Angina,120,354,FALSE,Some abnormality,163,Yes,0.6,2,0,Yes
-57,,Typical Angina,140,192,FALSE,Some abnormality,148,No,0.4,1,0,Yes
+57,female,Typical Angina,120,354,FALSE,Some abnormality,163,Yes,0.6,2,0,Yes
+57,male,Typical Angina,140,192,FALSE,Some abnormality,148,No,0.4,1,0,Yes
 56,female,Atypical Angina,140,294,FALSE,Normal,153,No,1.3,1,0,Yes
 44,male,Atypical Angina,120,263,FALSE,Some abnormality,173,No,0,2,0,Yes
-52,male,,172,199,TRUE,Some abnormality,162,No,0.5,2,0,Yes
-57,,Non-Anginal,150,168,FALSE,Some abnormality,174,No,1.6,2,0,Yes
+52,male,Non-Anginal,172,199,TRUE,Some abnormality,162,No,0.5,2,0,Yes
+57,male,Non-Anginal,150,168,FALSE,Some abnormality,174,No,1.6,2,0,Yes
 54,male,Typical Angina,140,239,FALSE,Some abnormality,160,No,1.2,2,0,Yes
 48,female,Non-Anginal,130,275,FALSE,Some abnormality,139,No,0.2,2,0,Yes
 49,male,Atypical Angina,130,266,FALSE,Some abnormality,171,No,0.6,2,0,Yes

--- a/public/datasets/thanksgiving.csv
+++ b/public/datasets/thanksgiving.csv
@@ -338,7 +338,7 @@ Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,Yes,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,Yes,No,West South Central
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Turkey,Fried,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Other,Fried,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,No,Yes,No,No,Yes,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
@@ -561,7 +561,7 @@ Turkey,Baked,None,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turducken,Roasted,None,None,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Fried,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,No,No,No,No,Yes,No,No,No,No,Yes,No,No,Yes,No,Yes,No,No,No,No,Yes,No,No,Yes,Yes,South Atlantic
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Ham/Pork,Baked,Rice-based,None,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Tofurkey,Baked,Bread-based,None,Yes,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,Middle Atlantic
 Ham/Pork,I don't know,Bread-based,Canned,No,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
@@ -740,7 +740,7 @@ Chicken,Fried,Rice-based,Canned,Yes,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,No,No,No,Yes,No,No,Yes,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No,No,East South Central
 Turkey,Other,Bread-based,Canned,Yes,Yes,No,No,No,Yes,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Chicken,Baked,Other,None,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,East North Central
 Turkey,Roasted,Other,Homemade,Yes,No,No,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,East South Central
@@ -831,7 +831,7 @@ I don't know,I don't know,None,Homemade,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,South Atlantic
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Tofurkey,Fried,Rice-based,Homemade,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,Mountain
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,Yes,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,No,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,Middle Atlantic
@@ -849,12 +849,12 @@ Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,N
 Turkey,Roasted,Bread-based,Other,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Fried,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,Yes,South Atlantic
 Turkey,Baked,None,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Other,Fried,Bread-based,Canned,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,Yes,Yes,Middle Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,Yes,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
-,,,,,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
+Roast beef,Roasted,Riced-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,

--- a/public/datasets/thanksgiving.csv
+++ b/public/datasets/thanksgiving.csv
@@ -1,4 +1,4 @@
-Main dish,Main dish cooking method,Stuffing base,Cranberry Sauce,Gravy?,Brussel sprouts?,Carrots?,Cauliflower?,Corn?,Cornbread?,Fruit salad?,Green beans/green bean casserole?,Mac and cheese?,Mashed potatoes?,Rolls/biscuits?,Squash?,Vegetable salad?,Yams/sweet potato casserole?,Apple pie?,Buttermilk pie?,Cherry pie?,Chocolate pie?,Coconut cream pie?,Key lime pie?,Peach pie?,Pecan pie?,Pumpkin pie?,Sweet potato pie?,Apple cobbler?,Blondies?,Brownies?,Carrot cake?,Cheesecake?,Cookies?,Fudge?,Ice cream?,Peach cobbler?,US region
+Main dish,Main dish cooking method,Stuffing base,Cranberry sauce,Gravy,Brussel sprouts,Carrots,Cauliflower,Corn,Cornbread,Fruit salad,Green beans/green bean casserole,Mac and cheese,Mashed potatoes,Rolls/biscuits,Squash,Vegetable salad,Yams/sweet potato casserole,Apple pie,Buttermilk pie,Cherry pie,Chocolate pie,Coconut cream pie,Key lime pie,Peach pie,Pecan pie,Pumpkin pie,Sweet potato pie,Apple cobbler,Blondies,Brownies,Carrot cake,Cheesecake,Cookies,Fudge,Ice cream,Peach cobbler,US region
 Turkey,Baked,Bread-based,None,Yes,No,Yes,No,No,No,No,Yes,Yes,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,Yes,No,Middle Atlantic
 Turkey,Baked,Bread-based,Other,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,East South Central
 Turkey,Roasted,Rice-based,Homemade,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,Yes,Yes,No,Yes,No,Yes,No,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes,Yes,No,Mountain
@@ -95,7 +95,6 @@ Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,
 Other,Other,None,None,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,Yes,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,Pacific
-Turkey,Roasted,None,Homemade,Yes,Yes,No,No,No,Yes,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,Middle Atlantic
 Turkey,Fried,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,Middle Atlantic
@@ -113,7 +112,6 @@ Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,N
 Turkey,Roasted,Bread-based,None,Yes,Yes,Yes,No,Yes,Yes,No,Yes,No,Yes,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,Yes,No,No,No,East North Central
 Ham/Pork,Baked,Bread-based,None,Yes,No,No,Yes,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,Mountain
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,West North Central
 Turkey,Baked,None,None,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,No,West North Central
@@ -166,7 +164,6 @@ Turkey,Fried,None,Canned,No,Yes,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,Yes,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,Yes,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
-Turkey,Baked,Bread-based,Canned,Yes,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,No,Yes,No,No,No,No,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,No,
 Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,West North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,Yes,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,East North Central
@@ -190,7 +187,6 @@ Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Y
 Turkey,Baked,Bread-based,Canned,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,East North Central
 Turducken,Roasted,Bread-based,Homemade,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East South Central
-Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,No,No,No,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,Yes,No,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,Yes,Yes,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
@@ -259,7 +255,6 @@ Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,No
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,Yes,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,No,Yes,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,New England
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,Yes,No,South Atlantic
 Turkey,Fried,Bread-based,Canned,Yes,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,Yes,Yes,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,West North Central
@@ -273,7 +268,6 @@ Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,No,Yes,Yes,Yes,Yes,No,No,Yes,Y
 Turkey,Roasted,Other,Homemade,Yes,No,Yes,No,No,Yes,No,No,No,Yes,No,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,New England
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,Yes,No,Middle Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,Middle Atlantic
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,Yes,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,Yes,No,Yes,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,East South Central
 Turkey,Baked,Bread-based,Homemade,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Mountain
@@ -283,11 +277,9 @@ Turkey,Roasted,Rice-based,Homemade,Yes,Yes,No,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,Yes,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,Yes,No,No,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Ham/Pork,Baked,Bread-based,Canned,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Middle Atlantic
-Ham/Pork,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Fried,Other,Homemade,Yes,Yes,Yes,No,Yes,No,No,Yes,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes,No,Yes,No,No,Yes,No,No,Yes,Middle Atlantic
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
@@ -301,14 +293,11 @@ Turkey,Baked,None,None,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,Middle Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,No,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,New England
 Turkey,Other,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
-Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,No,No,Yes,Yes,No,Yes,Yes,No,No,No,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,East North Central
 Turkey,Other,Bread-based,None,Yes,Yes,No,No,No,No,No,Yes,Yes,Yes,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,South Atlantic
-Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Rice-based,Homemade,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,South Atlantic
-Turkey,Fried,Rice-based,Homemade,No,No,Yes,No,No,No,Yes,Yes,No,No,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,No,No,Yes,No,No,No,No,Yes,Yes,No,Yes,No,
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,Yes,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,West North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,New England
@@ -338,7 +327,6 @@ Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,Yes,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,Yes,No,West South Central
-Turkey,Fried,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Other,Fried,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,No,Yes,No,No,Yes,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
@@ -373,7 +361,6 @@ Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,N
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Chicken,Other,Bread-based,Canned,Yes,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Tofurkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
-Turkey,Baked,Other,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Rice-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Baked,Rice-based,Homemade,Yes,No,Yes,No,Yes,No,Yes,No,No,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,Yes,No,Yes,No,New England
@@ -388,7 +375,6 @@ Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,No,No,No,Yes,No,Yes,Yes,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
 Turkey,Roasted,Bread-based,Homemade,Yes,Yes,Yes,No,Yes,No,No,Yes,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,No,No,Yes,No,No,No,East North Central
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,Yes,No,Yes,No,Yes,Yes,No,No,No,South Atlantic
-Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,Yes,Yes,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,No,Yes,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,Yes,No,Yes,No,Yes,No,No,No,No,No,No,Yes,Yes,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,Yes,No,East North Central
@@ -418,7 +404,6 @@ Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,Yes,N
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Homemade,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Other,Yes,No,No,No,Yes,No,No,Yes,Yes,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,South Atlantic
-Chicken,Roasted,Rice-based,Homemade,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Ham/Pork,Baked,None,Canned,Yes,No,Yes,Yes,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,Yes,No,No,South Atlantic
 Turkey,Roasted,None,Other,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,East North Central
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,New England
@@ -441,14 +426,12 @@ Turkey,Other,Bread-based,None,Yes,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,No,Yes,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,Yes,No,East North Central
-Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,East South Central
 Ham/Pork,Baked,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,West North Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,Yes,Yes,No,Yes,No,No,No,New England
 Turkey,Baked,Rice-based,Canned,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,Yes,No,East South Central
-Chicken,Roasted,Bread-based,Homemade,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,No,Yes,No,Yes,No,
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Other,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Other,Baked,None,None,No,Yes,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,East South Central
@@ -464,7 +447,6 @@ Turkey,Fried,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes
 Turkey,Roasted,Bread-based,Homemade,Yes,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Baked,Bread-based,None,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,Middle Atlantic
 Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,No,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
-Turkey,Roasted,Bread-based,Homemade,Yes,Yes,Yes,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,
 Turkey,Fried,Rice-based,Homemade,Yes,No,No,Yes,No,No,Yes,Yes,Yes,No,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,South Atlantic
 Other,Other,Bread-based,None,No,No,Yes,No,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,East South Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
@@ -552,7 +534,6 @@ Ham/Pork,Baked,Bread-based,None,No,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,No,No,N
 Other,Other,None,Canned,No,No,No,No,Yes,No,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,New England
 Turkey,Baked,Rice-based,Canned,Yes,No,Yes,No,Yes,Yes,No,Yes,No,Yes,No,No,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,Yes,No,Yes,Yes,No,Yes,No,No,No,South Atlantic
-Turkey,Baked,Bread-based,None,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,No,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,Yes,No,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,West South Central
@@ -561,14 +542,12 @@ Turkey,Baked,None,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turducken,Roasted,None,None,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Fried,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,No,No,No,No,Yes,No,No,No,No,Yes,No,No,Yes,No,Yes,No,No,No,No,Yes,No,No,Yes,Yes,South Atlantic
-Ham/Pork,Baked,Rice-based,None,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Tofurkey,Baked,Bread-based,None,Yes,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,Middle Atlantic
 Ham/Pork,I don't know,Bread-based,Canned,No,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,South Atlantic
-Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,Yes,No,No,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,New England
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,No,No,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,South Atlantic
@@ -581,7 +560,6 @@ Turkey,Baked,Bread-based,None,Yes,No,No,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,No,Ye
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Other,Other,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,South Atlantic
-Ham/Pork,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,Yes,No,Yes,No,Yes,Yes,No,Yes,No,West North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,East South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,Yes,No,No,No,No,Yes,No,No,No,No,New England
@@ -613,7 +591,6 @@ Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,No,Yes,No,No,No,Yes
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,Yes,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,New England
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
-I don't know,I don't know,None,None,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,
 Turkey,Roasted,Bread-based,Homemade,Yes,No,Yes,Yes,No,Yes,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,West South Central
 Chicken,Other,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,Yes,No,No,No,South Atlantic
@@ -675,7 +652,6 @@ Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Y
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Baked,Rice-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,Yes,South Atlantic
 Other,Baked,Bread-based,None,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
-Turkey,Roasted,None,None,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,Yes,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,No,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,No,Yes,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,No,No,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,Yes,No,Yes,No,New England
@@ -694,14 +670,12 @@ Turkey,Roasted,Bread-based,Canned,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Y
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,West South Central
-Turkey,Other,Other,Homemade,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,None,Yes,No,No,No,Yes,Yes,No,No,No,Yes,Yes,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,New England
 Other,Baked,Bread-based,Homemade,Yes,Yes,No,No,No,No,No,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Fried,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,Yes,South Atlantic
 Other,Other,None,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Ham/Pork,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,East North Central
-Turkey,I don't know,Bread-based,None,No,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Other,Yes,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Ham/Pork,Baked,Bread-based,Other,Yes,No,Yes,No,Yes,No,No,Yes,Yes,Yes,Yes,Yes,No,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,Yes,No,Yes,Yes,No,No,No,South Atlantic
@@ -713,7 +687,6 @@ Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,N
 Turkey,Baked,Bread-based,Canned,No,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,Yes,No,Yes,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,South Atlantic
-Turkey,Fried,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Middle Atlantic
 Turkey,Baked,Bread-based,Canned,No,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,Yes,Yes,No,No,No,Yes,Yes,Yes,Yes,No,Yes,No,West North Central
 Turkey,Roasted,None,Homemade,Yes,No,No,No,No,No,Yes,Yes,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,South Atlantic
@@ -740,7 +713,6 @@ Chicken,Fried,Rice-based,Canned,Yes,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,No,No,No,Yes,No,No,Yes,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No,No,East South Central
 Turkey,Other,Bread-based,Canned,Yes,Yes,No,No,No,Yes,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
-Chicken,Baked,Other,None,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,East North Central
 Turkey,Roasted,Other,Homemade,Yes,No,No,No,Yes,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,East South Central
@@ -761,18 +733,14 @@ Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,Yes,N
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,No,No,Yes,Yes,Yes,No,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,Yes,No,Yes,No,No,No,Yes,No,Yes,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,Middle Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
-Roast beef,Roasted,Rice-based,Canned,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,Yes,No,No,No,Yes,No,No,Yes,No,Yes,No,No,No,No,No,No,Yes,Yes,South Atlantic
 Other,Baked,Bread-based,Homemade,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,No,West North Central
-Roast beef,Roasted,Rice-based,Homemade,Yes,No,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,No,
 Tofurkey,Baked,Bread-based,Homemade,No,Yes,Yes,No,No,No,No,Yes,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,Yes,No,Pacific
-Turkey,Baked,Bread-based,Homemade,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,None,None,Yes,No,No,No,Yes,Yes,No,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,Yes,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,Yes,No,Yes,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
-Roast beef,Fried,Rice-based,Canned,No,No,No,Yes,Yes,No,Yes,No,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Chicken,Roasted,Bread-based,None,Yes,No,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,Yes,No,No,Yes,Yes,No,Yes,No,Yes,No,Yes,Yes,No,Yes,No,No,No,West South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,West South Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,Yes,Yes,Pacific
@@ -791,7 +759,6 @@ Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes
 I don't know,Roasted,Other,None,No,No,Yes,Yes,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Other,Other,None,Canned,No,No,No,No,No,No,No,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
 Roast beef,Roasted,None,Homemade,No,Yes,No,Yes,No,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Rice-based,Canned,Yes,No,No,No,Yes,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,Yes,No,West South Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,No,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,Pacific
 Other,Baked,Bread-based,Homemade,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,West South Central
@@ -800,7 +767,6 @@ Turkey,Baked,Bread-based,Canned,Yes,No,Yes,No,Yes,Yes,No,Yes,No,Yes,Yes,No,No,Ye
 Other,Roasted,None,None,No,No,No,No,No,No,No,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,Yes,No,No,Yes,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,No,No,Yes,Yes,Yes,No,No,Yes,Mountain
-Roast beef,Baked,Rice-based,Homemade,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Roasted,Bread-based,Homemade,Yes,Yes,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Other,Homemade,Yes,No,No,No,No,No,Yes,No,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Mountain
 Tofurkey,Baked,Rice-based,Other,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
@@ -826,12 +792,10 @@ Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Y
 Chicken,Baked,Bread-based,Canned,Yes,No,No,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,South Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,None,Yes,No,Yes,No,Yes,Yes,No,No,No,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
-Chicken,Fried,Rice-based,Homemade,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,No,No,No,
 I don't know,I don't know,None,Homemade,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,West North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,East North Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,South Atlantic
-Tofurkey,Fried,Rice-based,Homemade,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,Mountain
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,Yes,Yes,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,Yes,No,Yes,No,Yes,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,Middle Atlantic
@@ -848,16 +812,11 @@ Turkey,Other,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Other,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Fried,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,Yes,South Atlantic
-Turkey,Baked,None,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
-Other,Fried,Bread-based,Canned,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,No,No,Yes,Yes,Middle Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
-Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,Yes,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
-Roast beef,Roasted,Riced-based,Homemade,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,No,Yes,Yes,Yes,Yes,Yes,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Pacific
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,No,No,Yes,No,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,New England
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,West South Central
@@ -874,7 +833,6 @@ Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,No,Y
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,West South Central
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Mountain
-I don't know,Fried,Bread-based,Canned,No,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,Yes,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,Yes,No,Yes,Yes,Yes,No,Yes,Middle Atlantic
 Turkey,Baked,Bread-based,Homemade,Yes,Yes,Yes,No,Yes,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,South Atlantic
@@ -902,7 +860,6 @@ Turkey,Roasted,None,None,No,Yes,No,Yes,No,No,Yes,No,No,No,No,Yes,Yes,No,No,No,No
 Turkey,Baked,Other,Canned,Yes,No,No,No,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,East South Central
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Mountain
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Middle Atlantic
-Turkey,I don't know,None,None,Yes,No,No,No,No,No,No,No,No,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,
 Ham/Pork,Roasted,None,None,Yes,No,No,No,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,Yes,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,West South Central
 Turkey,Roasted,Bread-based,Homemade,Yes,No,Yes,No,Yes,Yes,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,Pacific
@@ -933,14 +890,12 @@ Turkey,Roasted,Bread-based,Other,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,No,Y
 Turkey,Roasted,Rice-based,Canned,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Bread-based,Canned,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,Yes,Yes,No,No,Yes,No,Yes,No,No,No,Yes,No,Yes,No,Yes,Yes,Yes,Pacific
-Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,No,Yes,No,No,No,No,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,
 Turkey,Other,Bread-based,Other,Yes,No,No,No,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,Middle Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,No,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Mountain
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,Yes,Yes,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,West South Central
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,Yes,No,Yes,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,Yes,No,East South Central
 Ham/Pork,Baked,Bread-based,Canned,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Pacific
-Turkey,Other,Bread-based,Homemade,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,
 Other,Other,Bread-based,None,No,No,No,No,No,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Baked,Bread-based,Homemade,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,Yes,Yes,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,Pacific
 Turkey,Baked,Bread-based,Homemade,Yes,No,No,No,No,Yes,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,No,No,Pacific
@@ -948,7 +903,6 @@ Turkey,Other,Rice-based,None,Yes,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,No,Yes,N
 Turkey,Baked,Other,Canned,Yes,No,No,No,No,No,Yes,No,Yes,No,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,Yes,Yes,No,No,No,No,South Atlantic
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,No,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,Yes,No,Yes,No,Pacific
 Roast beef,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,Yes,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No,Pacific
-I don't know,I don't know,Bread-based,Canned,No,No,No,No,No,No,Yes,No,Yes,Yes,No,Yes,No,No,No,No,No,Yes,No,No,No,No,Yes,Yes,No,No,Yes,No,No,Yes,No,Yes,No,
 Turkey,Baked,Bread-based,Canned,No,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,Yes,No,No,Yes,No,No,No,No,No,No,Yes,Yes,West South Central
 Turkey,Roasted,Bread-based,Homemade,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Canned,Yes,No,Yes,No,Yes,No,No,No,No,Yes,Yes,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,East North Central
@@ -971,11 +925,8 @@ Turkey,I don't know,Bread-based,Canned,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,No,N
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,No,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,Yes,No,No,No,No,Yes,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,Yes,Yes,No,Yes,No,No,Yes,No,Yes,Yes,No,Yes,Yes,Yes,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Baked,Bread-based,Homemade,No,No,No,No,Yes,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,West North Central
-Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,Yes,No,Yes,Yes,Yes,Yes,No,No,No,Yes,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,Yes,Yes,
 Turkey,Roasted,Bread-based,None,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,South Atlantic
 Turkey,Roasted,Bread-based,Canned,Yes,No,No,No,Yes,No,Yes,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,Pacific
 Turkey,Roasted,Bread-based,Homemade,Yes,No,No,No,No,No,No,Yes,No,Yes,Yes,Yes,No,Yes,No,No,No,No,No,No,No,Yes,Yes,Yes,No,No,No,No,Yes,No,No,No,No,Mountain
 Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,Yes,No,Yes,Yes,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,Yes,No,No,Yes,No,No,No,Pacific
 Other,Baked,Rice-based,None,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,Yes,No,No,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,Pacific
-Turkey,Baked,None,Homemade,Yes,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,No,No,Yes,No,No,No,
-Turkey,Baked,Bread-based,Canned,Yes,No,No,No,Yes,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,No,No,Yes,No,No,No,No,No,No,

--- a/public/datasets/thanksgiving.json
+++ b/public/datasets/thanksgiving.json
@@ -28,172 +28,172 @@
     },
     {
       "type": "categorical",
-      "id": "Cranberry Sauce",
+      "id": "Cranberry sauce",
       "description": "The kind of cranberry sauce served."
     },
     {
       "type": "categorical",
-      "id": "Gravy?",
+      "id": "Gravy",
       "description": "Whether or not gravy was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Brussel sprouts?",
+      "id": "Brussel sprouts",
       "description": "Whether or not brussel sprouts were served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Carrots?",
+      "id": "Carrots",
       "description": "Whether or not carrots were served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Cauliflower?",
+      "id": "Cauliflower",
       "description": "Whether or not cauliflower was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Corn?",
+      "id": "Corn",
       "description": "Whether or not corn was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Cornbread?",
+      "id": "Cornbread",
       "description": "Whether or not cornbread was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Fruit salad?",
+      "id": "Fruit salad",
       "description": "Whether or not fruit salad was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Green beans/green bean casserole?",
+      "id": "Green beans/green bean casserole",
       "description": "Whether or not a dish with green beans was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Mac and cheese?",
+      "id": "Mac and cheese",
       "description": "Whether or not mac and cheese was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Mashed potatoes?",
+      "id": "Mashed potatoes",
       "description": "Whether or not mashed potatoes were served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Rolls/biscuits?",
+      "id": "Rolls/biscuits",
       "description": "Whether or not rolls or biscuits were served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Squash?",
+      "id": "Squash",
       "description": "Whether or not squash was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Vegetable salad?",
+      "id": "Vegetable salad",
       "description": "Whether or not vegetable salad was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Yams/sweet potato casserole?",
+      "id": "Yams/sweet potato casserole",
       "description": "Whether or not yam casserole or sweet potato casserole was served with the meal."
     },
     {
       "type": "categorical",
-      "id": "Apple pie?",
+      "id": "Apple pie",
       "description": "Whether or not apple pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Buttermilk pie?",
+      "id": "Buttermilk pie",
       "description": "Whether or not buttermilk pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Cherry pie?",
+      "id": "Cherry pie",
       "description": "Whether or not cherry pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Chocolate pie?",
+      "id": "Chocolate pie",
       "description": "Whether or not chocolate pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Coconut cream pie?",
+      "id": "Coconut cream pie",
       "description": "Whether or not coconut cream pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Key lime pie?",
+      "id": "Key lime pie",
       "description": "Whether or not key lime pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Peach pie?",
+      "id": "Peach pie",
       "description": "Whether or not peach pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Pecan pie?",
+      "id": "Pecan pie",
       "description": "Whether or not pecan pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Pumpkin pie?",
+      "id": "Pumpkin pie",
       "description": "Whether or not pumpkin pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Sweet potato pie?",
+      "id": "Sweet potato pie",
       "description": "Whether or not sweet potato pie was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Apple cobbler?",
+      "id": "Apple cobbler",
       "description": "Whether or not apple cobbler was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Blondies?",
+      "id": "Blondies",
       "description": "Whether or not blondies were served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Brownies?",
+      "id": "Brownies",
       "description": "Whether or not brownies were served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Carrot cake?",
+      "id": "Carrot cake",
       "description": "Whether or not carrot cake was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Cheesecake?",
+      "id": "Cheesecake",
       "description": "Whether or not cheese cake was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Cookies?",
+      "id": "Cookies",
       "description": "Whether or not cookies were served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Fudge?",
+      "id": "Fudge",
       "description": "Whether or not fudge was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Ice cream?",
+      "id": "Ice cream",
       "description": "Whether or not ice cream was served as a dessert."
     },
     {
       "type": "categorical",
-      "id": "Peach cobbler?",
+      "id": "Peach cobbler",
       "description": "Whether or not peach cobbler was served as a dessert."
     },
     {


### PR DESCRIPTION
This PR addresses the following:
* When using the Thanksgiving dataset, certain label/feature combinations made the animation on the Training screen freeze. The current workaround is to remove rows with empty cells. See my [notes](https://docs.google.com/document/d/1bGKrH5DNfjotzfgvCO3Z4af-mVLLbiBL-SY7gUOu7GU/edit?usp=sharing) for more details. 
* The question marks are removed from both the Thanksgiving and NCAA datasets (per https://github.com/code-dot-org/ml-playground/pull/191). Thank you for your help, @moneppo!

Before: 

https://user-images.githubusercontent.com/40412372/119754358-396eea80-be55-11eb-8975-c5d974b062c4.mov

After: 

https://user-images.githubusercontent.com/40412372/119754421-54d9f580-be55-11eb-9505-46f604943d44.mov


