### PR TITLE
Remove form & label tags

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -111,94 +111,87 @@ class ColumnInspector extends Component {
           <div style={styles.largeText}>{currentColumnData.id}</div>
           <div style={styles.scrollableContents}>
             <div style={styles.scrollingContents}>
-              <form>
-                <div>
-                  <label>
-                    <span style={styles.bold}>Data Type:</span>
+              <div>
+                <span style={styles.bold}>Data Type:</span>
+                &nbsp;
+                {currentColumnData.readOnly && currentColumnData.dataType}
+                {!currentColumnData.readOnly && (
+                  <select
+                    onChange={event =>
+                      this.handleChangeDataType(event, currentColumnData.id)
+                    }
+                    value={currentColumnData.dataType}
+                  >
+                    {Object.values(ColumnTypes).map((option, index) => {
+                      return (
+                        <option key={index} value={option}>
+                          {option}
+                        </option>
+                      );
+                    })}
+                  </select>
+                )}
+                {currentColumnData.description && (
+                  <div>
+                    <br />
+                    <span style={styles.bold}>Description:</span>
                     &nbsp;
-                    {currentColumnData.readOnly && currentColumnData.dataType}
-                    {!currentColumnData.readOnly && (
-                      <select
-                        onChange={event =>
-                          this.handleChangeDataType(event, currentColumnData.id)
-                        }
-                        value={currentColumnData.dataType}
-                      >
-                        {Object.values(ColumnTypes).map((option, index) => {
-                          return (
-                            <option key={index} value={option}>
-                              {option}
-                            </option>
-                          );
-                        })}
-                      </select>
-                    )}
-                    {currentColumnData.description && (
-                      <div>
-                        <br />
-                        <span style={styles.bold}>Description:</span>
-                        &nbsp;
-                        <div>{currentColumnData.description}</div>
-                        <br />
-                      </div>
-                    )}
-                  </label>
-
-                  {currentPanel === "dataDisplayLabel" &&
-                    currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
-                      <div>
-                        <div style={styles.bold}>Column information:</div>
-
-                        {barData.labels.length <= maxLabelsInHistogram && (
-                          <Bar
-                            data={barData}
-                            width={100}
-                            height={150}
-                            options={chartOptions}
-                          />
-                        )}
-                        {barData.labels.length > maxLabelsInHistogram && (
-                          <div>
-                            {barData.labels.length} values were found in this
-                            column. A graph is only shown when there are{" "}
-                            {maxLabelsInHistogram} or fewer.
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                  {currentPanel === "dataDisplayFeatures" && (
+                    <div>{currentColumnData.description}</div>
+                    <br />
+                  </div>
+                )}
+                {currentPanel === "dataDisplayLabel" &&
+                  currentColumnData.dataType === ColumnTypes.CATEGORICAL && (
                     <div>
-                      <ScatterPlot />
-                      <CrossTab />
-                    </div>
-                  )}
+                      <div style={styles.bold}>Column information:</div>
 
-                  {currentColumnData.dataType === ColumnTypes.NUMERICAL && (
-                    <div>
-                      {currentColumnData.extrema && (
+                      {barData.labels.length <= maxLabelsInHistogram && (
+                        <Bar
+                          data={barData}
+                          width={100}
+                          height={150}
+                          options={chartOptions}
+                        />
+                      )}
+                      {barData.labels.length > maxLabelsInHistogram && (
                         <div>
-                          <div style={styles.bold}>Column information:</div>
-                          {isNaN(currentColumnData.extrema.min) && (
-                            <p style={styles.error}>
-                              Numerical columns should contain only numbers.
-                            </p>
-                          )}
-                          {!isNaN(currentColumnData.extrema.min) && (
-                            <div style={styles.contents}>
-                              min: {currentColumnData.extrema.min}
-                              <br />
-                              max: {currentColumnData.extrema.max}
-                              <br />
-                              range: {currentColumnData.extrema.range}
-                            </div>
-                          )}
+                          {barData.labels.length} values were found in this
+                          column. A graph is only shown when there are{" "}
+                          {maxLabelsInHistogram} or fewer.
                         </div>
                       )}
                     </div>
                   )}
-                </div>
-              </form>
+                {currentPanel === "dataDisplayFeatures" && (
+                  <div>
+                    <ScatterPlot />
+                    <CrossTab />
+                  </div>
+                )}
+                {currentColumnData.dataType === ColumnTypes.NUMERICAL && (
+                  <div>
+                    {currentColumnData.extrema && (
+                      <div>
+                        <div style={styles.bold}>Column information:</div>
+                        {isNaN(currentColumnData.extrema.min) && (
+                          <p style={styles.error}>
+                            Numerical columns should contain only numbers.
+                          </p>
+                        )}
+                        {!isNaN(currentColumnData.extrema.min) && (
+                          <div style={styles.contents}>
+                            min: {currentColumnData.extrema.min}
+                            <br />
+                            max: {currentColumnData.extrema.max}
+                            <br />
+                            range: {currentColumnData.extrema.range}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -44,27 +44,25 @@ class Predict extends Component {
         <div style={styles.largeText}>Try it out!</div>
         <div style={styles.scrollableContents}>
           <div style={styles.scrollingContents}>
-            <form>
+            <div>
               {this.props.selectedNumericalFeatures.map((feature, index) => {
                 let min = this.props.extremaByColumn[feature].min.toFixed(2);
                 let max = this.props.extremaByColumn[feature].max.toFixed(2);
 
                 return (
                   <div style={styles.cardRow} key={index}>
-                    <label>
-                      {feature} {`(min: ${+min}, max: ${+max})`}
-                      : &nbsp;
-                      <input
-                        type="number"
-                        onChange={event => this.handleChange(event, feature)}
-                        value={this.props.testData[feature] || ""}
-                      />
-                    </label>
+                    {feature} {`(min: ${+min}, max: ${+max})`}
+                    : &nbsp;
+                    <input
+                      type="number"
+                      onChange={event => this.handleChange(event, feature)}
+                      value={this.props.testData[feature] || ""}
+                    />
                   </div>
                 );
               })}
-            </form>
-            <form>
+            </div>
+            <div>
               {this.props.selectedCategoricalFeatures.map((feature, index) => {
                 return (
                   <div style={styles.cardRow} key={index}>
@@ -89,7 +87,7 @@ class Predict extends Component {
                   </div>
                 );
               })}
-            </form>
+            </div>
           </div>
         </div>
         <br />

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -122,7 +122,7 @@ class SaveModel extends Component {
               </div>
             </div>
             <div key={dataDescriptionField.id} style={styles.cardRow}>
-              <label style={styles.bold}>{dataDescriptionField.text}</label>
+              <div style={styles.bold}>{dataDescriptionField.text}</div>
               {this.props.isUserUploadedDataset && (
                 <div>
                   <textarea
@@ -187,7 +187,7 @@ class SaveModel extends Component {
               {this.getUsesFields().map(field => {
                 return (
                   <div key={field.id} style={styles.cardRow}>
-                    <label style={styles.bold}>{field.text}</label>
+                    <div style={styles.bold}>{field.text}</div>
                     <div>{field.description}</div>
                     <ul>
                       {field.descriptionDetails &&


### PR DESCRIPTION
Removing `form` tags should help alleviate the issue, seen in Predict panel, where pressing Enter in a field submits the form and navigates to a new page.