### PR TITLE
Move max and min to placeholder

### DIFF
--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -52,12 +52,13 @@ class Predict extends Component {
                 return (
                   <div style={styles.cardRow} key={index}>
                     <label>
-                      {feature} {`(min: ${+min}, max: ${+max})`}
+                      {feature}
                       : &nbsp;
                       <input
                         type="number"
                         onChange={event => this.handleChange(event, feature)}
                         value={this.props.testData[feature] || ""}
+                        placeholder={`min: ${+min}, max: ${+max}`}
                       />
                     </label>
                   </div>


### PR DESCRIPTION
Updating how we show max and min for numerical feature inputs in the testing panel to be consistent with https://github.com/code-dot-org/code-dot-org/pull/40853. 

BEFORE 
![Screen Shot 2021-05-28 at 3 17 09 PM](https://user-images.githubusercontent.com/12300669/120032189-d05bb400-bfc7-11eb-9851-13381d62f42c.png)

AFTER 
![Screen Shot 2021-05-28 at 3 13 13 PM](https://user-images.githubusercontent.com/12300669/120031887-6ba05980-bfc7-11eb-9994-ac6e2b5befb4.png)
