### PR TITLE
Remove rows with empty cells 

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -179,7 +179,7 @@ class ColumnInspector extends Component {
                           <div style={styles.bold}>Column information:</div>
                           {!currentColumnData.isColumnDataValid && (
                             <p style={styles.error}>
-                              Numerical columns should contain only numbers.
+                              Numerical columns cannot contain strings or empty cells.
                             </p>
                           )}
                           {currentColumnData.isColumnDataValid && (

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -179,7 +179,7 @@ class ColumnInspector extends Component {
                           <div style={styles.bold}>Column information:</div>
                           {!currentColumnData.isColumnDataValid && (
                             <p style={styles.error}>
-                              Numerical columns cannot contain strings or empty cells.
+                              Numerical columns cannot contain strings.
                             </p>
                           )}
                           {currentColumnData.isColumnDataValid && (

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -25,7 +25,7 @@ class DataDisplay extends Component {
           <DataTable />
         </div>
         <div style={styles.footerText}>
-          There are {this.props.data.length} rows of data.
+          There are {this.props.data.length} rows of data. If rows contained empty cells, they were removed.
           {this.props.data.length > 100 &&
             <span>
               &nbsp;

--- a/src/UIComponents/DataDisplay.jsx
+++ b/src/UIComponents/DataDisplay.jsx
@@ -8,11 +8,16 @@ import { styles } from "../constants";
 
 class DataDisplay extends Component {
   static propTypes = {
-    data: PropTypes.array
+    data: PropTypes.array,
+    removedRowsCount: PropTypes.number
   };
 
   render() {
-    const { data } = this.props;
+    const { data, removedRowsCount } = this.props;
+    const removedRowsMsg =
+      removedRowsCount === 1
+      ? `${this.props.removedRowsCount} row was removed because it contained an empty cell.`
+      : `${this.props.removedRowsCount} rows were removed because they contained an empty cell.`;
 
     if (data.length === 0) {
       return null;
@@ -25,7 +30,13 @@ class DataDisplay extends Component {
           <DataTable />
         </div>
         <div style={styles.footerText}>
-          There are {this.props.data.length} rows of data. If rows contained empty cells, they were removed.
+          There are {this.props.data.length} rows of data.
+          {removedRowsCount > 0 &&
+            <span>
+              &nbsp;
+              {removedRowsMsg}
+            </span>
+          }
           {this.props.data.length > 100 &&
             <span>
               &nbsp;
@@ -40,6 +51,7 @@ class DataDisplay extends Component {
 
 export default connect(
   state => ({
-    data: state.data
+    data: state.data,
+    removedRowsCount: state.removedRowsCount
   })
 )(DataDisplay);

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -1,6 +1,10 @@
 import Papa from "papaparse";
 import { store } from "./index.js";
-import { setImportedData, setColumnsByDataType } from "./redux";
+import {
+  setImportedData,
+  setRemovedRowsCount,
+  setColumnsByDataType
+} from "./redux";
 import { ColumnTypes } from "./constants.js";
 
 export const parseCSV = (csvfile, download, setColumnsToOther) => {
@@ -33,12 +37,18 @@ const cleanData = (data) => {
   return cleanedData;
 }
 
-const updateData = (result, setColumnsToOther) => {
-  var data = cleanData(result.data);
+const countRemovedRows = (originalData, cleanedData) => {
+  var removedRowsCount = originalData.length - cleanedData.length;
+  store.dispatch(setRemovedRowsCount(removedRowsCount));
+}
 
-  store.dispatch(setImportedData(data));
+const updateData = (result, setColumnsToOther) => {
+  var data = result.data;
+  var cleanedData = cleanData(data);
+  countRemovedRows(data, cleanedData);
+  store.dispatch(setImportedData(cleanedData));
   if (setColumnsToOther) {
-    setDefaultColumnDataType(data);
+    setDefaultColumnDataType(cleanedData);
   }
 };
 

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -24,12 +24,7 @@ const isCellValid = (cell) => {
 
 const isRowValid = (row) => {
   var cells = Object.values(row);
-  for (var i = 0; i < cells.length; i++) {
-    if (!isCellValid(cells[i])) {
-      return false;
-    }
-  }
-  return true;
+  return cells.every(isCellValid)
 }
 
 const cleanData = (data) => {

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -14,8 +14,27 @@ export const parseCSV = (csvfile, download, setColumnsToOther) => {
   });
 };
 
+const isCellValid = (cell) => {
+  return cell !== undefined && cell !== "";
+}
+
+const isRowValid = (row) => {
+  var cells = Object.values(row);
+  for (var i = 0; i < cells.length; i++) {
+    if (!isCellValid(cells[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const cleanData = (data) => {
+  var cleanedData = data.filter(row => isRowValid(row));
+  return cleanedData;
+}
+
 const updateData = (result, setColumnsToOther) => {
-  var data = result.data;
+  var data = cleanData(result.data);
 
   store.dispatch(setImportedData(data));
   if (setColumnsToOther) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -30,6 +30,7 @@ const SET_SELECTED_CSV = "SET_SELECTED_CSV";
 const SET_SELECTED_JSON = "SET_SELECTED_JSON";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_IMPORTED_METADATA = "SET_IMPORTED_METADATA";
+const SET_REMOVED_ROWS_COUNT = "SET_REMOVED_ROWS_COUNT";
 const SET_COLUMNS_BY_DATA_TYPE = "SET_COLUMNS_BY_DATA_TYPE";
 const ADD_SELECTED_FEATURE = "ADD_SELECTED_FEATURE";
 const REMOVE_SELECTED_FEATURE = "REMOVE_SELECTED_FEATURE";
@@ -84,6 +85,10 @@ export function setImportedData(data) {
 
 export function setImportedMetadata(metadata) {
   return { type: SET_IMPORTED_METADATA, metadata };
+}
+
+export function setRemovedRowsCount(removedRowsCount) {
+  return { type: SET_REMOVED_ROWS_COUNT, removedRowsCount };
 }
 
 export const setColumnsByDataType = (column, dataType) => ({
@@ -229,6 +234,7 @@ const initialState = {
   jsonfile: undefined,
   data: [],
   metadata: {},
+  removedRowsCount: 0,
   highlightDataset: undefined,
   highlightColumn: undefined,
   columnsByDataType: {},
@@ -317,6 +323,12 @@ export default function rootReducer(state = initialState, action) {
         ...state.columnsByDataType,
         [action.column]: action.dataType
       }
+    };
+  }
+  if (action.type === SET_REMOVED_ROWS_COUNT) {
+    return {
+      ...state,
+      removedRowsCount: action.removedRowsCount
     };
   }
   if (action.type === ADD_SELECTED_FEATURE) {

--- a/src/train.js
+++ b/src/train.js
@@ -103,9 +103,7 @@ const extractExamples = (state, row) => {
   state.selectedFeatures.forEach(feature =>
     exampleValues.push(convertValue(state, feature, row))
   );
-  return exampleValues.filter(
-    label => label !== undefined && label !== "" && !isNaN(label)
-  );
+  return exampleValues;
 };
 
 const extractLabel = (state, row) => {
@@ -119,11 +117,9 @@ const getRandomInt = max => {
 const prepareTrainingData = () => {
   const updatedState = store.getState();
   const trainingExamples = updatedState.data
-    .map(row => extractExamples(updatedState, row))
-    .filter(example => example.length > 0 && example !== undefined);
+    .map(row => extractExamples(updatedState, row));
   const trainingLabels = updatedState.data
-    .map(row => extractLabel(updatedState, row))
-    .filter(label => label !== undefined && label !== "" && !isNaN(label));
+    .map(row => extractLabel(updatedState, row));
   /*
   Select X% of examples and corresponding labels from the training set to use for a post-training accuracy calculation.
   */


### PR DESCRIPTION
Previously we were filtering out training data that was empty or undefined. This was problematic because we didn't remove the whole row if there was a "dirty" cell, we just removed that cell.  Which could result in mismatched lengths of `trainingExamples` and `trainingLabels` which could not be processed by the KNN algorithm, causing an error: 
```
index.js?9dc3:33 Uncaught TypeError: Cannot read property 'push' of undefined
    at new KNN (index.js?9dc3:33)
```
The intermediate fix was to remove empty cells from the csvs for our internally curated datasets (e.g. https://github.com/code-dot-org/ml-playground/pull/195). This change alleviates this problem programmatically and for student uploaded datasets by eliminating any full row containing any undefined or empty cells prior to attempting to derive training examples and labels. 

I added a small note indicating that we remove rows with empty cells to clarify for the observant student who finds themselves with a smaller dataset in the tool than they intended. 

No rows removed - no empty cell message:
![Screen Shot 2021-06-01 at 10 07 20 AM](https://user-images.githubusercontent.com/12300669/120338583-5d518680-c2c2-11eb-9c92-7971a145ad19.png)

1 row removed:
![Screen Shot 2021-06-01 at 10 04 22 AM](https://user-images.githubusercontent.com/12300669/120338525-4f036a80-c2c2-11eb-898c-d0c15aff40b4.png)

More than 1 row removed: 
![Screen Shot 2021-06-01 at 10 06 11 AM](https://user-images.githubusercontent.com/12300669/120338557-56c30f00-c2c2-11eb-963a-05266d838b07.png)

