### PR TITLE
Update graph styling

### DIFF
--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -9,7 +9,7 @@ import {
   addSelectedFeature,
   removeSelectedFeature
 } from "../redux";
-import { ColumnTypes, styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
+import { ColumnTypes, styles, colors, UNIQUE_OPTIONS_MAX } from "../constants.js";
 import { Bar } from "react-chartjs-2";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
@@ -19,11 +19,11 @@ const barData = {
   datasets: [
     {
       label: "",
-      backgroundColor: "rgba(255,99,132,0.2)",
-      borderColor: "rgba(255,99,132,1)",
+      backgroundColor: colors.tealTransparent,
+      borderColor: colors.teal,
       borderWidth: 1,
-      hoverBackgroundColor: "rgba(255,99,132,0.4)",
-      hoverBorderColor: "rgba(255,99,132,1)",
+      hoverBackgroundColor: "#59cad3",
+      hoverBorderColor: "white",
       data: []
     }
   ]

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -78,12 +78,7 @@ class CrossTab extends Component {
                       <td
                         style={{
                           ...styles.bold,
-                          ...styles.regularText,
-                          ...{
-                            writingMode: "vertical-rl",
-                            whiteSpace: "nowrap",
-                            transform: "scale(-1)"
-                          }
+                          ...styles.crossTabLeftColumn
                         }}
                         rowSpan={crossTabData.results.length + 1}
                       >

--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -16,7 +16,7 @@ class CrossTab extends Component {
   getCellStyle = percent => {
     return {
       ...styles["crossTabCell" + Math.round(percent / 20)],
-      ...styles.tableCell
+      ...styles.crossTabTableCell
     };
   };
 
@@ -40,35 +40,56 @@ class CrossTab extends Component {
 
     return (
       <div id="cross-tab">
-
         {crossTabData && !showTable && (
           <div>
-            <div style={styles.bold}>Table:</div>
+            <div style={styles.bold}>Relationship information:</div>
 
-            <div>The currently-selected data is too large to show in a table.</div>
+            <div>
+              The currently-selected data is too large to show in a table.
+            </div>
           </div>
         )}
 
         {showTable && (
           <div>
-            <div style={styles.bold}>Table:</div>
+            <div style={styles.bold}>Relationship information:</div>
             <div style={styles.scrollableContents}>
               <div style={styles.scrollingContents}>
                 <table>
                   <thead>
                     <tr>
-                      <th colSpan={crossTabData.featureNames.length}>&nbsp;</th>
-                      <th colSpan={crossTabData.uniqueLabelValues.length}>
+                      <th style={styles.crosssTabHeader} />
+                      <th
+                        style={styles.crosssTabHeader}
+                        colSpan={crossTabData.featureNames.length}
+                      >
+                        &nbsp;
+                      </th>
+                      <th
+                        colSpan={crossTabData.uniqueLabelValues.length}
+                        style={{ ...styles.crosssTabHeader, ...styles.bold }}
+                      >
                         {crossTabData.labelName}
                       </th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr>
-                      {crossTabData.featureNames.map((featureName, index) => {
-                        return <td key={index}>{featureName}</td>;
-                      })}
-
+                      <td
+                        style={{
+                          ...styles.bold,
+                          ...styles.regularText,
+                          ...{
+                            writingMode: "vertical-rl",
+                            whiteSpace: "nowrap",
+                            transform: "scale(-1)"
+                          }
+                        }}
+                        rowSpan={crossTabData.results.length + 1}
+                      >
+                        {crossTabData.featureNames[0]}
+                      </td>
+                      <td />
                       {crossTabData.uniqueLabelValues.map(
                         (uniqueLabelValue, index) => {
                           return (
@@ -84,7 +105,11 @@ class CrossTab extends Component {
                         <tr key={resultIndex}>
                           {result.featureValues.map(
                             (featureValue, featureIndex) => {
-                              return <td key={featureIndex}>{featureValue}</td>;
+                              return (
+                                <td key={featureIndex} style={styles.tableCell}>
+                                  {featureValue}
+                                </td>
+                              );
                             }
                           )}
                           {crossTabData.uniqueLabelValues.map(

--- a/src/UIComponents/ScatterPlot.jsx
+++ b/src/UIComponents/ScatterPlot.jsx
@@ -14,14 +14,11 @@ const scatterDataBase = {
       pointRadius: 4,
       pointHitRadius: 10,
       pointBorderWidth: 1,
-
-      //backgroundColor: "green",
-      pointBorderColor: "white", // "rgba(75,192,192,1)",
-      pointBackgroundColor: colors.teal, // "#fff",
-
+      pointBorderColor: "white",
+      pointBackgroundColor: colors.teal,
       pointHoverRadius: 6,
-      pointHoverBackgroundColor: "#59cad3", //"rgba(75,192,192,1)",
-      pointHoverBorderColor: "white", // "rgba(220,220,220,1)",
+      pointHoverBackgroundColor: "#59cad3",
+      pointHoverBorderColor: "white",
       pointHoverBorderWidth: 2,
       data: []
     }

--- a/src/UIComponents/ScatterPlot.jsx
+++ b/src/UIComponents/ScatterPlot.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getScatterPlotData } from "../redux";
-import { styles } from "../constants.js";
+import { styles, colors } from "../constants.js";
 import { Scatter } from "react-chartjs-2";
 
 const scatterDataBase = {
@@ -11,16 +11,18 @@ const scatterDataBase = {
     {
       label: "",
       fill: true,
-      backgroundColor: "rgba(75,192,192,0.4)",
-      pointBorderColor: "rgba(75,192,192,1)",
-      pointBackgroundColor: "#fff",
-      pointBorderWidth: 4,
-      pointHoverRadius: 6,
-      pointHoverBackgroundColor: "rgba(75,192,192,1)",
-      pointHoverBorderColor: "rgba(220,220,220,1)",
-      pointHoverBorderWidth: 2,
-      pointRadius: 1,
+      pointRadius: 4,
       pointHitRadius: 10,
+      pointBorderWidth: 1,
+
+      //backgroundColor: "green",
+      pointBorderColor: "white", // "rgba(75,192,192,1)",
+      pointBackgroundColor: colors.teal, // "#fff",
+
+      pointHoverRadius: 6,
+      pointHoverBackgroundColor: "#59cad3", //"rgba(75,192,192,1)",
+      pointHoverBorderColor: "white", // "rgba(220,220,220,1)",
+      pointHoverBorderWidth: 2,
       data: []
     }
   ]

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -99,7 +99,8 @@ class SelectDataset extends Component {
                   onMouseLeave={() => this.props.setHighlightDataset(undefined)}
                 >
                   <img
-                    src={assetPath + dataset.imagePath}
+                    className="hoverimg"
+                    src={assetPath + /*"datasets/tile.png" */ dataset.imagePath}
                     style={styles.selectDatasetImage}
                     draggable={false}
                   />

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -99,8 +99,7 @@ class SelectDataset extends Component {
                   onMouseLeave={() => this.props.setHighlightDataset(undefined)}
                 >
                   <img
-                    className="hoverimg"
-                    src={assetPath + /*"datasets/tile.png" */ dataset.imagePath}
+                    src={assetPath + dataset.imagePath}
                     style={styles.selectDatasetImage}
                     draggable={false}
                   />

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,9 +45,8 @@ export function getFadeOpacity(animationProgress) {
 const labelColor = "rgb(254, 96, 3)";
 const featureColor = "rgb(75, 155, 213)";
 const backgroundColor = "#f2f2f2";
-const tealColor =  "rgb(89, 202, 211)"; // "#61d2eb"; // "#00adbc"; // "#80d6de"; // "rgb(97, 210, 235)";
-const tealColorTransparent =  "rgba(89, 202, 211, 0.4)"; // "#61d2eb"; // "#00adbc"; // "#80d6de"; // "rgb(97, 210, 235)";
-
+const tealColor = "rgb(89, 202, 211)";
+const tealColorTransparent = "rgba(89, 202, 211, 0.4)";
 
 export const colors = {
   feature: featureColor,
@@ -416,6 +415,13 @@ export const styles = {
     border: "initial",
     fontSize: 14,
     padding: "initial"
+  },
+
+  crossTabLeftColumn: {
+    fontSize: 14,
+    writingMode: "vertical-rl",
+    whiteSpace: "nowrap",
+    transform: "scale(-1)"
   },
 
   crossTabTableCell: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -410,6 +410,23 @@ export const styles = {
   dataDisplayCellFeatureUnselected: {},
   dataDisplayCellUnselected: {},
 
+  crosssTabHeader: {
+    backgroundColor: "initial",
+    color: "initial",
+    border: "initial",
+    fontSize: 14,
+    padding: "initial"
+  },
+
+  crossTabTableCell: {
+    paddingLeft: 20,
+    textAlign: "right",
+    fontSize: 12,
+    borderStyle: "solid",
+    borderWidth: 1,
+    borderColor: "white"
+  },
+
   crossTabCell0: {
     backgroundColor: "rgba(89, 202, 211, 0)"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,11 +45,16 @@ export function getFadeOpacity(animationProgress) {
 const labelColor = "rgb(254, 96, 3)";
 const featureColor = "rgb(75, 155, 213)";
 const backgroundColor = "#f2f2f2";
+const tealColor =  "rgb(89, 202, 211)"; // "#61d2eb"; // "#00adbc"; // "#80d6de"; // "rgb(97, 210, 235)";
+const tealColorTransparent =  "rgba(89, 202, 211, 0.4)"; // "#61d2eb"; // "#00adbc"; // "#80d6de"; // "rgb(97, 210, 235)";
+
 
 export const colors = {
   feature: featureColor,
   label: labelColor,
-  background: backgroundColor
+  background: backgroundColor,
+  teal: tealColor,
+  tealTransparent: tealColorTransparent
 };
 
 export const styles = {
@@ -282,7 +287,7 @@ export const styles = {
     border: "none",
     cursor: "pointer",
     borderRadius: 5,
-    backgroundColor: "#61d2eb",
+    backgroundColor: colors.teal,
     color: "white",
     padding: "10px 20px",
     display: "inline-block"
@@ -406,22 +411,22 @@ export const styles = {
   dataDisplayCellUnselected: {},
 
   crossTabCell0: {
-    backgroundColor: "rgba(255,100,100, 0)"
+    backgroundColor: "rgba(89, 202, 211, 0)"
   },
   crossTabCell1: {
-    backgroundColor: "rgba(255,100,100, 0.2)"
+    backgroundColor: "rgba(89, 202, 211, 0.2)"
   },
   crossTabCell2: {
-    backgroundColor: "rgba(255,100,100, 0.4)"
+    backgroundColor: "rgba(89, 202, 211, 0.4)"
   },
   crossTabCell3: {
-    backgroundColor: "rgba(255,100,100, 0.6)"
+    backgroundColor: "rgba(89, 202, 211, 0.6)"
   },
   crossTabCell4: {
-    backgroundColor: "rgba(255,100,100, 0.8)"
+    backgroundColor: "rgba(89, 202, 211, 0.8)"
   },
   crossTabCell5: {
-    backgroundColor: "rgba(255,100,100, 1)"
+    backgroundColor: "rgba(89, 202, 211, 1)"
   },
 
   resultsPanelContainer: {
@@ -456,7 +461,7 @@ export const styles = {
     border: "none",
     cursor: "pointer",
     borderRadius: 5,
-    backgroundColor: "#61d2eb",
+    backgroundColor: colors.teal,
     color: "white",
     lineHeight: 1.3,
     position: "relative",
@@ -487,7 +492,7 @@ export const styles = {
     cursor: "pointer"
   },
   selectedPill: {
-    backgroundColor: "#61d2eb",
+    backgroundColor: colors.teal,
     color: "white",
     border: "none"
   },


### PR DESCRIPTION
This updates the styling for bar charts, scatter plots, and CrossTab tables.

I wanted a colour different to the red we use for labels and the blue we use for features, and have been using teal for that reason in some other parts of the UI.  (Specifically, for the data selection highlight border, the Upload CSV button, the Details button in results, and the Correct/Incorrect highlight in the results popup.)

Now, the charts & table in this PR get the teal treatment as well.

### Bar chart
![Screen Shot 2021-05-31 at 2 15 54 PM](https://user-images.githubusercontent.com/2205926/120139938-5e819700-c18e-11eb-92f9-29ceeb11ae49.png)

### Scatter plot
The white borders on individual points now make them easier to see.

![Screen Shot 2021-05-31 at 2 17 12 PM](https://user-images.githubusercontent.com/2205926/120139940-5f1a2d80-c18e-11eb-87cf-cf08266f1704.png)

### CrossTab
CrossTab also gets some revised styling with the vertical text on the left.

![Screen Shot 2021-05-31 at 2 15 30 PM](https://user-images.githubusercontent.com/2205926/120139934-5c1f3d00-c18e-11eb-8163-d5e251cec85a.png)
