### PR TITLE
Autodetect column datatype for uploaded csvs, clean up variable name

### DIFF
--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -19,6 +19,10 @@ export const parseCSV = (csvfile, download, useDefaultColumnDataType) => {
   });
 };
 
+const isCellValid = (cell) => {
+  return cell !== undefined && cell !== "";
+}
+
 const isRowValid = (row) => {
   var cells = Object.values(row);
   return cells.every(isCellValid)
@@ -40,7 +44,7 @@ const updateData = (result, useDefaultColumnDataType) => {
   countRemovedRows(data, cleanedData);
   store.dispatch(setImportedData(cleanedData));
   if (useDefaultColumnDataType) {
-    setDefaultColumnDataType(data);
+    setDefaultColumnDataType(cleanedData);
   }
 }
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -645,6 +645,15 @@ function isColumnNumerical(state, column) {
   return (state.columnsByDataType[column] === ColumnTypes.NUMERICAL);
 }
 
+export function columnContainsOnlyNumbers(data, column) {
+  for (let row of data) {
+    if (isNaN((row[column]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isValidNumericalData(state, column) {
   return !isNaN(getMaximumValue(state, column));
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -646,12 +646,7 @@ function isColumnNumerical(state, column) {
 }
 
 export function columnContainsOnlyNumbers(data, column) {
-  for (let row of data) {
-    if (isNaN((row[column]))) {
-      return false;
-    }
-  }
-  return true;
+  return data.every(row => !isNaN(row[column]));
 }
 
 function isValidNumericalData(state, column) {


### PR DESCRIPTION
`setColumnsToOther` is a relic of a time when we had three datatypes (numerical, categorical, other). Now, we have two: numerical and categorical so the variable name is confusing.  Instead, the intent of the `setColumnsToOther` boolean parameter is really something more like "should we infer the column datatype in the column from the data in the column because this is a user uploaded dataset that doesn't have column datatype set in JSON metadata?". I've updated to `useDefaultColumnDataType`. In addition to renaming the variable, we are now being more clever about setting the column's datatype. Previously, we would always default to categorical; now, if we detect that the column contains only numbers, we will set the column's datatype to numerical. 


https://user-images.githubusercontent.com/12300669/120349489-284a3180-c2cc-11eb-8b9d-aa79ee0e7b61.mov

