### PR TITLE
Log panel navigation as a Google Analytics page view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,23 +36,11 @@ class PanelButtons extends Component {
     shouldDisplaySaveStatus: PropTypes.func
   };
 
-  reportPanelView = panel => {
-    if (!window.ga || !panel) {
-      return;
-    }
-    // Record each panel as a different page view in Google Analytics.
-    const syntheticPagePath = window.location.pathname + '/' + panel;
-    window.ga('set', 'page', syntheticPagePath);
-    window.ga('send', 'pageview');
-  };
-
   onClickPrev = () => {
-    this.reportPanelView(this.props.currentPanel);
     this.props.setCurrentPanel(this.props.panelButtons.prev.panel);
   };
 
   onClickNext = () => {
-    this.reportPanelView(this.props.currentPanel);
     if (["continue", "finish"].includes(this.props.panelButtons.next.panel)) {
       this.props.onContinue();
     } else if (this.props.currentPanel === "saveModel") {

--- a/src/App.js
+++ b/src/App.js
@@ -36,11 +36,23 @@ class PanelButtons extends Component {
     shouldDisplaySaveStatus: PropTypes.func
   };
 
+  reportPanelView = panel => {
+    if (!window.ga || !panel) {
+      return;
+    }
+    // Record each panel as a different page view in Google Analytics.
+    const syntheticPagePath = window.location.pathname + '/' + panel;
+    window.ga('set', 'page', syntheticPagePath);
+    window.ga('send', 'pageview');
+  };
+
   onClickPrev = () => {
+    this.reportPanelView(this.props.currentPanel);
     this.props.setCurrentPanel(this.props.panelButtons.prev.panel);
   };
 
   onClickNext = () => {
+    this.reportPanelView(this.props.currentPanel);
     if (["continue", "finish"].includes(this.props.panelButtons.next.panel)) {
       this.props.onContinue();
     } else if (this.props.currentPanel === "saveModel") {

--- a/src/redux.js
+++ b/src/redux.js
@@ -176,7 +176,6 @@ export function setInstructionsKeyCallback(instructionsKeyCallback) {
 }
 
 export function setCurrentPanel(currentPanel) {
-  reportPanelView(currentPanel);
   return { type: SET_CURRENT_PANEL, currentPanel };
 }
 
@@ -453,6 +452,7 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_CURRENT_PANEL) {
+    reportPanelView(action.currentPanel);
     let showedOverlay = false;
     if (state.instructionsKeyCallback) {
       const options = {};

--- a/src/redux.js
+++ b/src/redux.js
@@ -176,6 +176,7 @@ export function setInstructionsKeyCallback(instructionsKeyCallback) {
 }
 
 export function setCurrentPanel(currentPanel) {
+  reportPanelView(currentPanel);
   return { type: SET_CURRENT_PANEL, currentPanel };
 }
 
@@ -599,6 +600,16 @@ export default function rootReducer(state = initialState, action) {
   }
   return state;
 }
+
+function reportPanelView(panel) {
+  if (!window.ga || !panel) {
+    return;
+  }
+  // Record each panel as a different page view in Google Analytics.
+  const syntheticPagePath = window.location.pathname + '/' + panel;
+  window.ga('set', 'page', syntheticPagePath);
+  window.ga('send', 'pageview');
+};
 
 export function getFeatures(state) {
   return state.data.length > 0 ? Object.keys(state.data[0]) : [];

--- a/src/redux.js
+++ b/src/redux.js
@@ -609,7 +609,7 @@ function reportPanelView(panel) {
   const syntheticPagePath = window.location.pathname + '/' + panel;
   window.ga('set', 'page', syntheticPagePath);
   window.ga('send', 'pageview');
-};
+}
 
 export function getFeatures(state) {
   return state.data.length > 0 ? Object.keys(state.data[0]) : [];


### PR DESCRIPTION
To track how users move through the flow of AI Lab, I added Google Analytics logging that will send a metrics for each panel view as a page view by appending the current panel to the level url. For example: 

![Screen Shot 2021-06-01 at 3 40 25 PM](https://user-images.githubusercontent.com/12300669/120381087-ffd42e80-c2ef-11eb-8b49-27957f24114d.png)

The current panel is logged in coordination with setting `state.currentPanel`.

The typical panel flow is `selectDataset`, `dataDisplayLabel`, `dataDisplayFeatures`, `trainModel`, `generateResults`, `results`, `saveModel`,  then `modelSummary`. 

![Screen Shot 2021-06-02 at 1 05 30 PM](https://user-images.githubusercontent.com/12300669/120522982-61a1a080-c3a3-11eb-82a9-5f29fc3e7ad7.png)
