### PR TITLE
Fixed Heart dataset bug

### DIFF
--- a/public/datasets/heart.csv
+++ b/public/datasets/heart.csv
@@ -1,4 +1,4 @@
-﻿age,sex,Chest Pain Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
+﻿Age,Sex,Chest Pain Type,Resting Blood Pressure,Cholesterol,Fasting Blood Sugar > 120mg/dl,Resting ECG Results,Maximum Heart Rate Achieved,Exercise Induced Angina,ST Depression Induced By Exercise Relative To Rest,Slope of Peak Exercise ST Segment,Number of Major Vessels Colored by Flourosopy,Diagnosis of Heart Disease
 63,male,None,145,233,TRUE,Normal,150,No,2.3,0,0,Yes
 37,male,Non-Anginal,130,250,FALSE,Some abnormality,187,No,3.5,0,0,Yes
 41,female,Atypical Angina,130,204,FALSE,Normal,172,No,1.4,2,0,Yes

--- a/public/datasets/heart.json
+++ b/public/datasets/heart.json
@@ -11,8 +11,8 @@
     }
   },
   "fields": [
-    { "type": "numerical", "id": "age", "description": "" },
-    { "type": "categorical", "id": "sex", "description": "" },
+    { "type": "numerical", "id": "Age", "description": "" },
+    { "type": "categorical", "id": "Sex", "description": "" },
     { "type": "categorical", "id": "Chest Pain Type", "description": "" },
     {
       "type": "numerical",

--- a/public/datasets/heart.json
+++ b/public/datasets/heart.json
@@ -11,7 +11,7 @@
     }
   },
   "fields": [
-    { "type": "numerical", "id": "\ufeffage", "description": "" },
+    { "type": "numerical", "id": "age", "description": "" },
     { "type": "categorical", "id": "sex", "description": "" },
     { "type": "categorical", "id": "Chest Pain Type", "description": "" },
     {


### PR DESCRIPTION
This PR addresses a bug in the Heart dataset. When clicking on the Age column in the Heart dataset, the `ColumnInspector` component doesn't render because of an error:
`Uncaught TypeError: Cannot read property 'type' of undefined`

Screenshot:
<img width="536" alt="Screen Shot 2021-06-01 at 11 53 07 PM" src="https://user-images.githubusercontent.com/40412372/120440670-a3e1c800-c338-11eb-9b8b-b22dd07fe063.png">

 
Before:

https://user-images.githubusercontent.com/40412372/120441601-96790d80-c339-11eb-8c99-0d51ecf62bb8.mov


After:

https://user-images.githubusercontent.com/40412372/120441669-a7298380-c339-11eb-92ae-999990be37f5.mov



