### PR TITLE
Fix Movies dataset bug

### DIFF
--- a/public/datasets/movies.json
+++ b/public/datasets/movies.json
@@ -60,7 +60,15 @@
       "id": "Star",
       "description": "The lead actor or actress."
     },
-    { "type": "categorical", "id": "Writer", "description": "" },
+    {
+      "type": "numerical",
+      "id": "Votes",
+      "description": ""
+    },
+    {
+      "type": "categorical", 
+      "id": "Writer", 
+      "description": "" },
     {
       "type": "categorical",
       "id": "Year",

--- a/public/datasets/movies.json
+++ b/public/datasets/movies.json
@@ -42,9 +42,21 @@
       "id": "Country",
       "description": "The movie's country of origin."
     },
-    { "type": "categorical", "id": "Director", "description": "" },
-    { "type": "categorical", "id": "Genre", "description": "" },
-    { "type": "categorical", "id": "Name", "description": "" },
+    {
+      "type": "categorical", 
+      "id": "Director", 
+      "description": "" 
+    },
+    { 
+      "type": "categorical",
+      "id": "Genre", 
+      "description": "" 
+    },
+    { 
+      "type": "categorical",
+      "id": "Name", 
+      "description": ""
+    },
     {
       "type": "categorical",
       "id": "Rating",
@@ -66,9 +78,10 @@
       "description": ""
     },
     {
-      "type": "categorical", 
-      "id": "Writer", 
-      "description": "" },
+      "type": "categorical",
+      "id": "Writer",
+      "description": ""
+    },
     {
       "type": "categorical",
       "id": "Year",


### PR DESCRIPTION
There was a discrepancy between the JSON and CSV files for the Movies dataset. The `ColumnInspector` component wasn't rendering when clicking on the Votes column. 

Screenshot of the error in the browser debugger tool:
![Screen Shot 2021-06-02 at 4 58 06 PM](https://user-images.githubusercontent.com/40412372/120567006-8870ce80-c3c5-11eb-9084-69340e02d8bc.png)

Related PRs: https://github.com/code-dot-org/ml-playground/pull/191 and https://github.com/code-dot-org/ml-playground/pull/209