### PR TITLE
Fix Windows Chrome CrossTab text

### DIFF
--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -75,14 +75,15 @@ class CrossTab extends Component {
                   </thead>
                   <tbody>
                     <tr>
-                      <td
-                        style={{
-                          ...styles.bold,
-                          ...styles.crossTabLeftColumn
-                        }}
-                        rowSpan={crossTabData.results.length + 1}
-                      >
-                        {crossTabData.featureNames[0]}
+                      <td rowSpan={crossTabData.results.length + 1}>
+                        <div
+                          style={{
+                            ...styles.bold,
+                            ...styles.crossTabLeftColumn
+                          }}
+                        >
+                          {crossTabData.featureNames[0]}
+                        </div>
                       </td>
                       <td />
                       {crossTabData.uniqueLabelValues.map(


### PR DESCRIPTION
For some reason, the Windows version of Chrome doesn't support `writing-mode: vertical-rl;` on a `<td>`, while it works fine on macOS Chrome.  This is an [easy fix](https://stackoverflow.com/a/59854643).

### before

![Screen Shot 2021-06-04 at 5 49 24 PM](https://user-images.githubusercontent.com/2205926/120766750-62cfec00-c4cf-11eb-99d4-b947af1cb65d.png)

### after

![Screen Shot 2021-06-04 at 5 51 08 PM](https://user-images.githubusercontent.com/2205926/120766759-6499af80-c4cf-11eb-8d2b-4c56ed7ac281.png)
