### PR TITLE
Fix table border leak

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -313,9 +313,9 @@ export const styles = {
 
   displayTable: {
     whiteSpace: "nowrap",
-    borderSpacing: 0,
+    borderSpacing: 0.5,
     width: "100%",
-    borderCollapse: "collapse"
+    borderCollapse: "initial"
   },
 
   tableParent: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -313,7 +313,7 @@ export const styles = {
 
   displayTable: {
     whiteSpace: "nowrap",
-    borderSpacing: 0.5,
+    borderSpacing: 0,
     width: "100%",
     borderCollapse: "initial"
   },


### PR DESCRIPTION
The sticky header used in tables was not entirely covering the scrolling content.  After a lot of reading and experimenting, this is apparently the solution to keep the majority of the existing appearance while avoiding the "leak".

### before

![Screen Shot 2021-06-06 at 9 29 44 PM](https://user-images.githubusercontent.com/2205926/120922784-f811e280-c67f-11eb-91b2-fd9493497b6b.png)

### after

![Screen Shot 2021-06-06 at 9 30 04 PM](https://user-images.githubusercontent.com/2205926/120922790-fa743c80-c67f-11eb-842b-8d8612f70505.png)

### before

![Screen Shot 2021-06-06 at 9 32 13 PM](https://user-images.githubusercontent.com/2205926/120922870-72426700-c680-11eb-93df-844db6c68f54.png)

### after

![Screen Shot 2021-06-06 at 9 33 43 PM](https://user-images.githubusercontent.com/2205926/120922873-740c2a80-c680-11eb-9258-8b31c2e9d411.png)
