### PR TITLE
Save status for pii and profanity 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,7 +52,6 @@ class PanelButtons extends Component {
 
   render() {
     const { panelButtons, saveStatus } = this.props;
-
     let loadSaveStatus= this.props.isSaveComplete(saveStatus)
       ? (saveMessages[saveStatus])
       : ( <FontAwesomeIcon icon={faSpinner} />);

--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,7 @@ class PanelButtons extends Component {
 
   render() {
     const { panelButtons, saveStatus } = this.props;
+
     let loadSaveStatus= this.props.isSaveComplete(saveStatus)
       ? (saveMessages[saveStatus])
       : ( <FontAwesomeIcon icon={faSpinner} />);

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -18,7 +18,6 @@ class SaveModel extends Component {
     trainedModelDetails: PropTypes.object,
     labelColumn: PropTypes.string,
     columnDescriptions: PropTypes.array,
-    saveStatus: PropTypes.string,
     dataDescription: PropTypes.string,
     isUserUploadedDataset: PropTypes.bool
   };
@@ -229,7 +228,6 @@ export default connect(
     trainedModelDetails: state.trainedModelDetails,
     labelColumn: state.labelColumn,
     columnDescriptions: getSelectedColumnDescriptions(state),
-    saveStatus: state.saveStatus,
     dataDescription: getDataDescription(state),
     isUserUploadedDataset: isUserUploadedDataset(state)
   }),

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ export const UNIQUE_OPTIONS_MAX = 50;
 export const saveMessages = {
   success: "Your model was saved!",
   failure: "There was an error. Your model did not save. Please try again.",
-  piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number, etc). "
+  piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number, etc)."
 };
 
 export function getFadeOpacity(animationProgress) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,8 @@ export const UNIQUE_OPTIONS_MAX = 50;
 
 export const saveMessages = {
   success: "Your model was saved!",
-  failure: "There was an error. Your model did not save. Please try again."
+  failure: "There was an error. Your model did not save. Please try again.",
+  piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number, etc). "
 };
 
 export function getFadeOpacity(animationProgress) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ export const UNIQUE_OPTIONS_MAX = 50;
 export const saveMessages = {
   success: "Your model was saved!",
   failure: "There was an error. Your model did not save. Please try again.",
-  piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number, etc)."
+  piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number)."
 };
 
 export function getFadeOpacity(animationProgress) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -255,7 +255,7 @@ const initialState = {
   currentPanel: "selectDataset",
   currentColumn: undefined,
   resultsPhase: undefined,
-  // Possible values for saveStatus: notStarted, started, success, and failure.
+  // Possible values for saveStatus: notStarted, started, success, piiProfanity, and failure.
   saveStatus: "notStarted",
   columnRefs: {},
   historicResults: [],
@@ -1511,9 +1511,9 @@ function getResultsByGrade(state, grade) {
 }
 
 export function isSaveComplete(saveStatus) {
-  return ["success", "failure"].includes(saveStatus);
+  return ["success", "failure", "piiProfanity"].includes(saveStatus);
 }
 
 export function shouldDisplaySaveStatus(saveStatus) {
-  return ["success", "failure", "started"].includes(saveStatus);
+  return ["success", "failure", "started", "piiProfanity"].includes(saveStatus);
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -255,7 +255,8 @@ const initialState = {
   currentPanel: "selectDataset",
   currentColumn: undefined,
   resultsPhase: undefined,
-  // Possible values for saveStatus: notStarted, started, success, piiProfanity, and failure.
+  // Possible values for saveStatus: "notStarted", "started", "success",
+  // "piiProfanity", and "failure".
   saveStatus: "notStarted",
   columnRefs: {},
   historicResults: [],


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/40915

Prior to saving we are now passing trained model data through a profanity and personally identifying information filter. If something unsafe to share is caught, we block the save of the model and show this message in AI Lab: 

![Screen Shot 2021-06-07 at 12 17 20 PM](https://user-images.githubusercontent.com/12300669/121056308-1238e700-c78c-11eb-9b48-740f8ea7ee98.png)
