### PR TITLE
Revert "Layout datasets before images load"

### DIFF
--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -98,15 +98,13 @@ class SelectDataset extends Component {
                 }
                 onMouseLeave={() => this.props.setHighlightDataset(undefined)}
               >
-                <div style={styles.selectDatasetItemContainer}>
-                  <img
-                    src={assetPath + dataset.imagePath}
-                    style={styles.selectDatasetImage}
-                    draggable={false}
-                    className="ailab-image-hover"
-                  />
-                  <div style={styles.selectDatasetText}>{dataset.name}</div>
-                </div>
+                <img
+                  src={assetPath + dataset.imagePath}
+                  style={styles.selectDatasetImage}
+                  draggable={false}
+                  className="ailab-image-hover"
+                />
+                <div style={styles.selectDatasetText}>{dataset.name}</div>
               </div>
             );
           })}

--- a/src/constants.js
+++ b/src/constants.js
@@ -266,17 +266,8 @@ export const styles = {
     border: "solid 4px rgb(85, 217, 255)"
   },
 
-  selectDatasetItemContainer: {
-    width: "100%",
-    // This assumes that all dataset images have a 1.5 aspect ratio, e.g. 720x480.
-    paddingTop: "calc(100% / 1.5)"
-  },
-
   selectDatasetImage: {
-    display: "block",
-    width: "calc(100% - 20px)",
-    position: "absolute",
-    top: 10
+    width: "100%"
   },
 
   selectDatasetText: {


### PR DESCRIPTION
Reverts code-dot-org/ml-playground#216

Will merge into `main` instead.