### PR TITLE
Layout datasets before images load

### DIFF
--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -98,13 +98,15 @@ class SelectDataset extends Component {
                 }
                 onMouseLeave={() => this.props.setHighlightDataset(undefined)}
               >
-                <img
-                  src={assetPath + dataset.imagePath}
-                  style={styles.selectDatasetImage}
-                  draggable={false}
-                  className="ailab-image-hover"
-                />
-                <div style={styles.selectDatasetText}>{dataset.name}</div>
+                <div style={styles.selectDatasetItemContainer}>
+                  <img
+                    src={assetPath + dataset.imagePath}
+                    style={styles.selectDatasetImage}
+                    draggable={false}
+                    className="ailab-image-hover"
+                  />
+                  <div style={styles.selectDatasetText}>{dataset.name}</div>
+                </div>
               </div>
             );
           })}

--- a/src/constants.js
+++ b/src/constants.js
@@ -272,8 +272,17 @@ export const styles = {
     border: "solid 4px rgb(85, 217, 255)"
   },
 
+  selectDatasetItemContainer: {
+    width: "100%",
+    // This assumes that all dataset images have a 1.5 aspect ratio, e.g. 720x480.
+    paddingTop: "calc(100% / 1.5)"
+  },
+
   selectDatasetImage: {
-    width: "100%"
+    display: "block",
+    width: "calc(100% - 20px)",
+    position: "absolute",
+    top: 10
   },
 
   selectDatasetText: {


### PR DESCRIPTION
This change uses the assumption that dataset images have a 1.5 aspect ratio (e.g. 720x480) to layout the SelectDataset scene with correct-sized tiles before the actual image files are loaded. Previously, it depended upon the images being loaded to get the correct layout, which made for a bit of a mess during the image loading.

(This is a fresh attempt after https://github.com/code-dot-org/ml-playground/pull/216 was merged prematurely into a working branch.)