### PR TITLE
Additional dynamic instructions based on user actions

### DIFF
--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -11,7 +11,7 @@ import { ColumnTypes } from "./constants.js";
 export const parseCSV = (csvfile, download, useDefaultColumnDataType) => {
   Papa.parse(csvfile, {
     complete: result => {
-      updateData(result, useDefaultColumnDataType);
+      updateData(result, useDefaultColumnDataType, !download);
     },
     header: true,
     download: download,
@@ -38,11 +38,11 @@ const countRemovedRows = (originalData, cleanedData) => {
   store.dispatch(setRemovedRowsCount(removedRowsCount));
 }
 
-const updateData = (result, useDefaultColumnDataType) => {
+const updateData = (result, useDefaultColumnDataType, userUploadedData) => {
   var data = result.data;
   var cleanedData = cleanData(data);
   countRemovedRows(data, cleanedData);
-  store.dispatch(setImportedData(cleanedData));
+  store.dispatch(setImportedData(cleanedData, userUploadedData));
   if (useDefaultColumnDataType) {
     setDefaultColumnDataType(cleanedData);
   }

--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -66,10 +66,7 @@ function onContinueStub() {
 
 function saveTrainedModelStub(data, response) {
   console.log("This would save a trained model.", data);
-  setTimeout(
-    () => response({ id: 303, status: "success" }),
-    2000
-  );
+  setTimeout(() => response({ id: 303, status: "success" }), 2000);
 }
 
 function logMetricStub(eventName, details) {
@@ -80,10 +77,13 @@ function setInstructionsKeyStub(instructionsKey, options) {
   const element = document.getElementById("instructions");
 
   element.innerText =
-    instructionsKey + (options.showOverlay ? " (click to dismiss overlay)" : " (no overlay)");
+    instructionsKey +
+    (options && options.showOverlay
+      ? " (click to dismiss overlay)"
+      : " (no overlay)");
 
   element.onclick = () => {
-    if (options.showOverlay) {
+    if (options && options.showOverlay) {
       element.innerText = instructionsKey + " (overlay dismissed)";
     }
     instructionsDismissed();


### PR DESCRIPTION
This change adds a few more dynamic instructions that show for specific user actions:

`uploadedDataset` - when the user uploads a CSV.
`selectedDataset` - when the user selects an existing dataset.

`selectedFeatureNumerical` - when the user clicks on a numerical feature column.
`selectedFeatureCategorical` - when the user clicks on a categorical feature column.
(The dynamic instruction is set to `dataDisplayFeatures`, again, if the column is deselected by clicking it again.)

`resultsDetails` - when the user views the details of the most recent results in the popup.
(The dynamic instruction is set to `results`, again, if the popup is dismissed.)