### PR TITLE
Remove unused props, splice instead of slice

### DIFF
--- a/src/UIComponents/ResultsDetails.jsx
+++ b/src/UIComponents/ResultsDetails.jsx
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import {
-  getConvertedAccuracyCheckExamples,
-  getConvertedLabels,
   getSummaryStat,
   setShowResultsDetails,
   getCorrectResults,
@@ -22,9 +20,6 @@ class ResultsDetails extends Component {
     selectedFeatures: PropTypes.array,
     labelColumn: PropTypes.string,
     summaryStat: PropTypes.object,
-    accuracyCheckExamples: PropTypes.array,
-    accuracyCheckLabels: PropTypes.array,
-    accuracyCheckPredictedLabels: PropTypes.array,
     setShowResultsDetails: PropTypes.func,
     correctResults: PropTypes.object,
     incorrectResults: PropTypes.object,
@@ -60,12 +55,6 @@ export default connect(
     selectedFeatures: state.selectedFeatures,
     labelColumn: state.labelColumn,
     summaryStat: getSummaryStat(state),
-    accuracyCheckExamples: getConvertedAccuracyCheckExamples(state),
-    accuracyCheckLabels: getConvertedLabels(state, state.accuracyCheckLabels),
-    accuracyCheckPredictedLabels: getConvertedLabels(
-      state,
-      state.accuracyCheckPredictedLabels
-    ),
     correctResults: getCorrectResults(state),
     incorrectResults: getIncorrectResults(state)
   }),

--- a/src/train.js
+++ b/src/train.js
@@ -130,8 +130,8 @@ const prepareTrainingData = () => {
   let accuracyCheckLabels = [];
   if (updatedState.reserveLocation === TestDataLocations.END) {
     const index = -1 * numToReserve;
-    accuracyCheckExamples = trainingExamples.slice(index);
-    accuracyCheckLabels = trainingLabels.slice(index);
+    accuracyCheckExamples = trainingExamples.splice(index);
+    accuracyCheckLabels = trainingLabels.splice(index);
   }
   if (updatedState.reserveLocation === TestDataLocations.RANDOM) {
     let numReserved = 0;


### PR DESCRIPTION
Here's fun Monday bug: we were still training on the full dataset when selecting test data from the end. [Slice doesn't mutate the original array](https://wsvincent.com/javascript-array-slice-vs-splice/). I updated to use `splice` so now the training and test data are actually split properly and we only train on the first 90% of the data. 

The Curriculum team reported befuddling outcomes. With a [small dataset](https://docs.google.com/spreadsheets/d/1c3bids7-BH1rwEiCEgVkNvojANvmDKGt7BY3ZfHGJl8/edit#gid=0) (10 rows) where "yes" predicted A 9 times, and B one time in the last row, models were confusingly accurately predicting B when they shouldn't have. 