### PR TITLE
Reposition navigation buttons and save model message

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,7 @@ class PanelButtons extends Component {
       : ( <FontAwesomeIcon icon={faSpinner} />);
 
     return (
-      <div style={styles.navigationButtonContainer}>
+      <div style={styles.navigationButtonsContainer}>
         {panelButtons.prev && (
           <div style={styles.previousButton}>
             <button

--- a/src/App.js
+++ b/src/App.js
@@ -59,7 +59,7 @@ class PanelButtons extends Component {
       : ( <FontAwesomeIcon icon={faSpinner} />);
 
     return (
-      <div>
+      <div style={styles.navigationButtonContainer}>
         {panelButtons.prev && (
           <div style={styles.previousButton}>
             <button

--- a/src/constants.js
+++ b/src/constants.js
@@ -108,9 +108,8 @@ export const styles = {
   },
 
   bodyContainer: {
-    height: "100%",
-    boxSizing: "border-box",
-    paddingBottom: 50
+    height: "calc(100% - 50px)",
+    boxSizing: "border-box"
   },
 
   largeText: {
@@ -590,18 +589,16 @@ export const styles = {
   predictBotRight: { float: "right", width: "75%" },
 
   previousButton: {
-    position: "fixed",
-    left: 20,
-    bottom: 40,
+    position: "absolute",
+    left: 0,
     fontSize: 30,
     cursor: "pointer",
     zIndex: 1001
   },
 
   nextButton: {
-    position: "fixed",
-    right: 20,
-    bottom: 40,
+    position: "absolute",
+    right: 0,
     fontSize: 30,
     cursor: "pointer",
     zIndex: 1001
@@ -929,13 +926,15 @@ export const styles = {
   },
 
   modelSaveMessage: {
-    bottom: 40,
+    top: 10,
     zIndex: 1001,
     right: "calc(50% - 250px)",
     textAlign: "center",
-    position: "fixed",
-    width: 500,
-    height: 30,
-    lineHeight: "20px"
+    position: "absolute",
+    width: 500
+  },
+
+  navigationButtonContainer: {
+    position: "relative"
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -934,7 +934,7 @@ export const styles = {
     width: 500
   },
 
-  navigationButtonContainer: {
+  navigationButtonsContainer: {
     position: "relative"
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -591,6 +591,7 @@ export const styles = {
   previousButton: {
     position: "absolute",
     left: 0,
+    top: 7,
     fontSize: 30,
     cursor: "pointer",
     zIndex: 1001
@@ -599,6 +600,7 @@ export const styles = {
   nextButton: {
     position: "absolute",
     right: 0,
+    top: 7,
     fontSize: 30,
     cursor: "pointer",
     zIndex: 1001
@@ -611,7 +613,8 @@ export const styles = {
     fontSize: 24,
     border: "initial",
     padding: "10px 20px 10px 20px",
-    cursor: "pointer"
+    cursor: "pointer",
+    margin: 0
   },
 
   statement: {
@@ -926,7 +929,7 @@ export const styles = {
   },
 
   modelSaveMessage: {
-    top: 10,
+    top: 15,
     zIndex: 1001,
     right: "calc(50% - 250px)",
     textAlign: "center",


### PR DESCRIPTION
This issue was raised in https://github.com/code-dot-org/code-dot-org/pull/41062: the save model message was shown over the split between the grey background and scrollbar. This PR repositions the scrollbars outside the UI area so there's no overlap with the navigation buttons or save message.

**Standalone before:** 
 <img width="1093" alt="before-scrollbar-enabled-2" src="https://user-images.githubusercontent.com/40412372/122010745-40ac5880-cd70-11eb-83b5-34c6869e6d8c.png">

 **Standalone after:** 
<img width="1091" alt="after-scrollbar-enabled2" src="https://user-images.githubusercontent.com/40412372/122010798-4dc94780-cd70-11eb-89d7-44f3a122547d.png">

**Code Studio before with scrollbars:**
![studio-before-scrollbars-2](https://user-images.githubusercontent.com/40412372/122011193-b284a200-cd70-11eb-924e-2052d8fbef29.png)

**Code Studio after with scrollbars:**
![studio-after-scrollbars-2](https://user-images.githubusercontent.com/40412372/122011253-c0d2be00-cd70-11eb-84f7-831c25d8a7d2.png)

**Code Studio before without scrollbars:**
![studio-before-no-scrollbars-2](https://user-images.githubusercontent.com/40412372/122011299-cb8d5300-cd70-11eb-855f-5d1b1722be4a.png)

**Code Studio before without scrollbars:**
![studio-after-no-scrollbars-2](https://user-images.githubusercontent.com/40412372/122011376-dd6ef600-cd70-11eb-9082-b98c275e0ab6.png)




