### PR TITLE
Test ML 2.0 

### DIFF
--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -30,14 +30,27 @@ export default class KNNTrainer {
     this.store = store;
     const state = store.getState();
     const datasetSize = state.data.length;
-    const defaultRegressionK = datasetSize < 100 ? 1 : 5;
+    /*
+      We modify algorithm hyperparameters (k) based on dataset size and type of
+      machine learning in attempt to increase the liklihood of accurate
+      models that behave in ways consistent with the mental model presented in
+      the curriculum.
+    */
+    const smallDatasetSize = 10;
+    const mediumDatasetSize = 100;
+    const minimalK = 1;
+    const smallK = 5;
+    const defaultRegressionK = datasetSize < mediumDatasetSize
+      ? minimalK
+      : smallK;
     const defaultClassificationK = Math.round(datasetSize / 3);
+
     let bestModel = null;
     let bestPredictedLabels = [];
     let bestK = -1;
     let bestAccuracy = -1;
     if (state.accuracyCheckExamples.length > 0) {
-      if (datasetSize < 11 && !isRegression(state)) {
+      if (datasetSize <= smallDatasetSize && !isRegression(state)) {
         this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
           k: datasetSize
         });

--- a/test/unit/train.test.js
+++ b/test/unit/train.test.js
@@ -28,6 +28,9 @@ describe("train functions", () => {
     ];
 
     store.dispatch(setImportedData(data, false));
+    store.dispatch(setColumnsByDataType("cost", ColumnTypes.NUMERICAL));
+    store.dispatch(setColumnsByDataType("rain", ColumnTypes.NUMERICAL));
+    store.dispatch(setColumnsByDataType("temperature", ColumnTypes.NUMERICAL));
     store.dispatch(setLabelColumn("cost"));
     store.dispatch(addSelectedFeature("temperature"));
     store.dispatch(addSelectedFeature("rain"));
@@ -35,12 +38,13 @@ describe("train functions", () => {
     train.init(store);
     train.onClickTrain(store);
 
-    store.dispatch(setTestData({temperature: "150", rain: "1030"}));
+    store.dispatch(setTestData({temperature: "10", rain: "1010"}));
 
     train.onClickPredict(store);
 
     const predictedValue = getConvertedPredictedLabel(store.getState());
-    expect(predictedValue).toBe(30);
+
+    expect(predictedValue).toBe(20);
   });
 
   test("train and predict with categorical data", async () => {
@@ -74,6 +78,6 @@ describe("train functions", () => {
 
     const predictedLabel = getConvertedPredictedLabel(store.getState());
 
-    expect(predictedLabel).toBe("yellow");
+    expect(predictedLabel).toBe("green");
   });
 });


### PR DESCRIPTION
Riffing off of #228 I made some adjustments to K values for certain cases - small datasets and classification v regression - to have passing tests for expected values that are more aligned to what we'd actually expect. For classification, when the dataset is small we use a K value that is the entire training dataset size so as to avoid hard-to-reason-about tie breaker situations. For regression, when the dataset is small, just look at the single closest neighbor. 

This is continued iteration on K value optimization described in #166.