### PR TITLE
Clean up: remove modelSize state, setter and references

### DIFF
--- a/src/UIComponents/GenerateResults.jsx
+++ b/src/UIComponents/GenerateResults.jsx
@@ -17,7 +17,6 @@ class GenerateResults extends Component {
   static propTypes = {
     data: PropTypes.array,
     readyToTrain: PropTypes.bool,
-    modelSize: PropTypes.number,
     labelColumn: PropTypes.string,
     selectedFeatures: PropTypes.array,
     instructionsOverlayActive: PropTypes.bool
@@ -189,7 +188,6 @@ class GenerateResults extends Component {
 
 export default connect(state => ({
   readyToTrain: readyToTrain(state),
-  modelSize: state.modelSize,
   labelColumn: state.labelColumn,
   selectedFeatures: state.selectedFeatures,
   instructionsOverlayActive: state.instructionsOverlayActive

--- a/src/UIComponents/TrainModel.jsx
+++ b/src/UIComponents/TrainModel.jsx
@@ -18,7 +18,6 @@ class TrainModel extends Component {
   static propTypes = {
     data: PropTypes.array,
     readyToTrain: PropTypes.bool,
-    modelSize: PropTypes.number,
     labelColumn: PropTypes.string,
     selectedFeatures: PropTypes.array,
     instructionsOverlayActive: PropTypes.bool
@@ -163,7 +162,6 @@ class TrainModel extends Component {
 
 export default connect(state => ({
   readyToTrain: readyToTrain(state),
-  modelSize: state.modelSize,
   labelColumn: state.labelColumn,
   selectedFeatures: state.selectedFeatures,
   instructionsOverlayActive: state.instructionsOverlayActive

--- a/src/helpers/navigationValidation.js
+++ b/src/helpers/navigationValidation.js
@@ -177,12 +177,12 @@ export function prevNextButtons(state) {
       ? { panel: "trainModel", text: "Train" }
       : null;
   } else if (state.currentPanel === "trainModel") {
-    if (state.modelSize) {
+    if (state.trainedModel) {
       prev = null;
       next = { panel: "generateResults", text: "Continue" };
     }
   } else if (state.currentPanel === "generateResults") {
-    if (state.modelSize) {
+    if (state.trainedModel) {
       prev = null;
       next = { panel: "results", text: "Continue" };
     }

--- a/src/redux.js
+++ b/src/redux.js
@@ -55,7 +55,6 @@ const SET_TRAINING_EXAMPLES = "SET_TRAINING_EXAMPLES";
 const SET_TRAINING_LABELS = "SET_TRAINING_LABELS";
 const SET_TEST_DATA = "SET_TEST_DATA";
 const SET_PREDICTION = "SET_PREDICTION";
-const SET_MODEL_SIZE = "SET_MODEL_SIZE";
 const SET_TRAINED_MODEL = "SET_TRAINED_MODEL";
 const SET_TRAINED_MODEL_DETAIL = "SET_TRAINED_MODEL_DETAIL";
 const SET_CURRENT_PANEL = "SET_CURRENT_PANEL";
@@ -175,10 +174,6 @@ export function resetState() {
   return { type: RESET_STATE };
 }
 
-export function setModelSize(modelSize) {
-  return { type: SET_MODEL_SIZE, modelSize };
-}
-
 export function setTrainedModel(trainedModel) {
   return { type: SET_TRAINED_MODEL, trainedModel };
 }
@@ -263,7 +258,6 @@ const initialState = {
   accuracyCheckPredictedLabels: [],
   testData: {},
   prediction: undefined,
-  modelSize: undefined,
   trainedModel: undefined,
   trainedModelDetails: {},
   instructionCallback: undefined,
@@ -437,12 +431,6 @@ export default function rootReducer(state = initialState, action) {
       mode: state.mode,
       reserveLocation: state.reserveLocation,
       firehoseMetricsLogger: state.firehoseMetricsLogger
-    };
-  }
-  if (action.type === SET_MODEL_SIZE) {
-    return {
-      ...state,
-      modelSize: action.modelSize
     };
   }
   if (action.type === SET_TRAINED_MODEL) {

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -4,7 +4,6 @@ https://github.com/mljs/knn */
 import {
   isRegression,
   setKValue,
-  setModelSize,
   setTrainedModel,
   setPrediction,
   setAccuracyCheckPredictedLabels,
@@ -96,9 +95,6 @@ export default class KNNTrainer {
     store.dispatch(setKValue(bestK));
     store.dispatch(setAccuracyCheckPredictedLabels(bestPredictedLabels));
     store.dispatch(setTrainedModel(bestModel));
-    const size = Buffer.byteLength(JSON.stringify(bestModel));
-    const kiloBytes = size / 1024;
-    store.dispatch(setModelSize(kiloBytes));
 
     const state2 = store.getState();
 


### PR DESCRIPTION
We added `modelSize` in #35 to get a sense of how big trained models would be to determine if it would be problematic to save them.  Size has not been an issue nor is it relevant to the user; we don't display model size anywhere. Furthermore we weren't really using `modelSize` except as a proxy for whether a model had been trained or not. Instead of `modelSize` we now just check if `trainedModel` is set, which allows us to completely delete `modelSize`, the setter for it and all references to it. 
