### PR TITLE
Clean up: Refactor KNNTrainer 

### DIFF
--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -27,10 +27,7 @@ export default class KNNTrainer {
 
     logFirehoseMetric("train-model", state2);
 
-    const accuracy = getPercentCorrect(state2);
-    store.dispatch(
-      setHistoricResult(state2.labelColumn, state2.selectedFeatures, accuracy)
-    );
+    this.storeHistoricResult(store, state2);
   }
 
   /*
@@ -100,6 +97,17 @@ export default class KNNTrainer {
     return kValues;
   }
 
+  calculatePotentialKValues(state) {
+    let datasetSize = state.data.length;
+    let trainingExamplesSize = state.trainingExamples.length;
+    let possibleKValues = [1, 3, 5, 7, 17, 31, 45, 61];
+    const heuristicK = Math.round(Math.sqrt(datasetSize));
+    possibleKValues.push(heuristicK);
+    const oneThird = Math.round(datasetSize / 3);
+    possibleKValues.push(oneThird);
+    return possibleKValues.filter(kValue => kValue <= trainingExamplesSize);
+  }
+
   getAccuracyPercent() {
     const state = this.store.getState();
     const percent = getPercentCorrect(state);
@@ -118,21 +126,18 @@ export default class KNNTrainer {
     this.store.dispatch(setPrediction(prediction));
   }
 
-  calculatePotentialKValues(state) {
-    let datasetSize = state.data.length;
-    let possibleKValues = [1, 3, 5, 7, 17, 31, 45, 61];
-    const heuristicK = Math.round(Math.sqrt(datasetSize));
-    possibleKValues.push(heuristicK);
-    const oneThird = Math.round(datasetSize / 3);
-    possibleKValues.push(oneThird);
-    return possibleKValues;
-  }
-
   storeTrainedModel(store, trainedModel) {
     store.dispatch(setKValue(trainedModel.kValue));
     store.dispatch(setAccuracyCheckPredictedLabels(
       trainedModel.predictedLabels
     ));
     store.dispatch(setTrainedModel(trainedModel.model));
+  }
+
+  storeHistoricResult(store, state) {
+    const accuracy = getPercentCorrect(state);
+    store.dispatch(
+      setHistoricResult(state.labelColumn, state.selectedFeatures, accuracy)
+    );
   }
 }

--- a/src/trainers/KNNTrainer.js
+++ b/src/trainers/KNNTrainer.js
@@ -14,87 +14,14 @@ import { logFirehoseMetric } from "../helpers/metrics";
 const KNN = require("ml-knn");
 
 export default class KNNTrainer {
-  calculatePossibleKValues() {
-    const state = this.store.getState();
-    let datasetSize = state.data.length;
-    let possibleKValues = [1, 3, 5, 7, 17, 31, 45, 61];
-    const heuristicK = Math.round(Math.sqrt(datasetSize));
-    possibleKValues.push(heuristicK);
-    const oneThird = Math.round(datasetSize / 3);
-    possibleKValues.push(oneThird);
-    return possibleKValues;
-  }
 
   startTraining(store) {
     this.store = store;
     const state = store.getState();
-    const datasetSize = state.data.length;
-    /*
-      We modify algorithm hyperparameters (k) based on dataset size and type of
-      machine learning in attempt to increase the liklihood of accurate
-      models that behave in ways consistent with the mental model presented in
-      the curriculum.
-    */
-    const smallDatasetSize = 10;
-    const mediumDatasetSize = 100;
-    const minimalK = 1;
-    const smallK = 5;
-    const defaultRegressionK = datasetSize < mediumDatasetSize
-      ? minimalK
-      : smallK;
-    const defaultClassificationK = Math.round(datasetSize / 3);
 
-    let bestModel = null;
-    let bestPredictedLabels = [];
-    let bestK = -1;
-    let bestAccuracy = -1;
-    if (state.accuracyCheckExamples.length > 0) {
-      if (datasetSize <= smallDatasetSize && !isRegression(state)) {
-        this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
-          k: datasetSize
-        });
-        bestModel = this.knn;
-        bestK = datasetSize;
-      } else if (isRegression(state)) {
-        this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
-          k: defaultRegressionK
-        });
-        bestModel = this.knn;
-        bestK = defaultRegressionK;
-      } else {
-        const kValues = this.calculatePossibleKValues();
-        kValues
-          .filter(kValue => kValue <= state.trainingExamples.length)
-          .forEach(kValue => {
-            this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
-              k: kValue
-            });
-            var model = this.knn;
-            const predictedLabels = this.batchPredict(
-              state.accuracyCheckExamples
-            );
-            const accuracy = this.getAccuracyPercent();
-            if (accuracy > bestAccuracy) {
-              bestAccuracy = accuracy;
-              bestK = kValue;
-              bestModel = model;
-              bestPredictedLabels = predictedLabels;
-            }
-          });
-        }
-      } else {
-      const defaultK = isRegression(state)
-        ? defaultRegressionK
-        : defaultClassificationK;
-      this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
-        k: defaultK
-      });
-      bestModel = this.knn;
-      bestK = defaultK;
-    }
-    store.dispatch(setKValue(bestK));
-    store.dispatch(setAccuracyCheckPredictedLabels(bestPredictedLabels));
-    store.dispatch(setTrainedModel(bestModel));
+    const trainedModel = this.getOptimalModelDetails(state);
+
+    this.storeTrainedModel(store, trainedModel);
 
     const state2 = store.getState();
 
@@ -104,6 +31,73 @@ export default class KNNTrainer {
     store.dispatch(
       setHistoricResult(state2.labelColumn, state2.selectedFeatures, accuracy)
     );
+  }
+
+  /*
+    We modify algorithm hyperparameters (k) based on dataset size and type of
+    machine learning in attempt to increase the liklihood of accurate
+    models that behave in ways consistent with the mental model presented in
+    the curriculum. For large classification datasets we try a variety of K
+    values and select the one that yields the most accurate model.
+  */
+  getOptimalModelDetails(state) {
+    let optimalValues = {};
+    let bestModel = null;
+    let bestPredictedLabels = [];
+    let bestK = -1;
+    let bestAccuracy = -1;
+    const kValues = this.possibleKValues(state);
+    kValues.forEach(kValue => {
+      this.knn = new KNN(state.trainingExamples, state.trainingLabels, {
+        k: kValue
+      });
+      var model = this.knn;
+      const predictedLabels = this.batchPredict(
+        state.accuracyCheckExamples
+      );
+      const accuracy = this.getAccuracyPercent();
+      if (accuracy > bestAccuracy) {
+        bestAccuracy = accuracy;
+        bestK = kValue;
+        bestModel = model;
+        bestPredictedLabels = predictedLabels;
+      }
+    });
+    optimalValues.model = bestModel;
+    optimalValues.predictedLabels = bestPredictedLabels;
+    optimalValues.kValue = bestK;
+    return optimalValues;
+  }
+
+  possibleKValues(state) {
+    let datasetSize = state.data.length;
+    const smallDatasetSize = 10;
+    const mediumDatasetSize = 100;
+
+    let kValues = [];
+    const minimalK = 1;
+    const smallK = 5;
+    const defaultRegressionK = datasetSize < mediumDatasetSize
+      ? minimalK
+      : smallK;
+    const defaultClassificationK = Math.round(datasetSize / 3);
+    const defaultK = isRegression(state)
+      ? defaultRegressionK
+      : defaultClassificationK;
+
+    if (state.accuracyCheckExamples.length > 0) {
+      if (datasetSize <= smallDatasetSize && !isRegression(state)) {
+        kValues.push(datasetSize)
+      } else if (isRegression(state)) {
+        kValues.push(defaultRegressionK)
+      } else {
+        kValues = this.calculatePotentialKValues(state)
+          .filter(kValue => kValue <= state.trainingExamples.length)
+      }
+    } else {
+      kValues.push(defaultK)
+    }
+    return kValues;
   }
 
   getAccuracyPercent() {
@@ -122,5 +116,23 @@ export default class KNNTrainer {
     const state = this.store.getState();
     const prediction = state.trainedModel.predict(testValues);
     this.store.dispatch(setPrediction(prediction));
+  }
+
+  calculatePotentialKValues(state) {
+    let datasetSize = state.data.length;
+    let possibleKValues = [1, 3, 5, 7, 17, 31, 45, 61];
+    const heuristicK = Math.round(Math.sqrt(datasetSize));
+    possibleKValues.push(heuristicK);
+    const oneThird = Math.round(datasetSize / 3);
+    possibleKValues.push(oneThird);
+    return possibleKValues;
+  }
+
+  storeTrainedModel(store, trainedModel) {
+    store.dispatch(setKValue(trainedModel.kValue));
+    store.dispatch(setAccuracyCheckPredictedLabels(
+      trainedModel.predictedLabels
+    ));
+    store.dispatch(setTrainedModel(trainedModel.model));
   }
 }


### PR DESCRIPTION
After the changes in #234 there were cases - small datasets -  where `predictedLabels` wasn't being set. In revisiting the code to fix that omission, I realized that the previous `startTraining` function was repetitive; each different case was tasked with doing the work of setting `this.knn`, `bestModel`, `bestK` and `bestPredictedLabels`. In this PR I extracted that shared work into a more modular and specifically named `getOptimalModelDetails`. 

Now the high level function `startTraining` handles calling helper functions to 1.) get the best model and its details 2.) store those model details in state, 3.) log a metric that a model was trained and 4.) store the historic results in state. 

`getOptimalModelDetails` determines which model is best by iterating through a set of possibleKValues, which in turn are determined by dataset size and type of machine learning (regression or classification). 