### PR TITLE
Strip leading and trailing spaces in categorical values

### DIFF
--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -28,8 +28,17 @@ const isRowValid = (row) => {
   return cells.every(isCellValid)
 }
 
+const trimWhiteSpaces = (row) => {
+  var trimmedRows = {};
+  for (var cellName in row) {
+    trimmedRows[cellName] = row[cellName].trim();
+  }
+  return trimmedRows;
+}
+
 const cleanData = (data) => {
-  var cleanedData = data.filter(row => isRowValid(row));
+  var filterValidData = data.filter(row => isRowValid(row));
+  var cleanedData = filterValidData.map(row => trimWhiteSpaces(row));
   return cleanedData;
 }
 

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -31,7 +31,11 @@ const isRowValid = (row) => {
 const trimWhiteSpaces = (row) => {
   var trimmedRows = {};
   for (var cellName in row) {
-    trimmedRows[cellName] = row[cellName].trim();
+    if (typeof row[cellName] === 'string') {
+      trimmedRows[cellName] = row[cellName].trim();
+    } else {
+      trimmedRows[cellName] = row[cellName]
+    }
   }
   return trimmedRows;
 }

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -23,7 +23,7 @@ const cleanData = (data) => {
   var cleanedData = []
 
   for (var row of data) {
-    var cleanedRow = tryGetCleanedRow(row);
+    var cleanedRow = getCleanedRow(row);
     if (cleanedRow !== null) {
       cleanedData.push(cleanedRow);
     }
@@ -32,14 +32,16 @@ const cleanData = (data) => {
   return cleanedData;
 }
 
-const tryGetCleanedRow = (row) => {
-  for (var cellName in row) {
-    if (!isCellValid(row[cellName])) {
+const getCleanedRow = (row) => {
+  for (var column in row) {
+    var cellValue = row[column];
+
+    if (!isCellValid(cellValue)) {
       return null;
     }
 
-    if (typeof row[cellName] === 'string') {
-      row[cellName] = row[cellName].trim();
+    if (typeof cellValue === 'string') {
+      row[column] = cellValue.trim();
     }
   }
 

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -40,9 +40,7 @@ const getCleanedRow = (row) => {
       return null;
     }
 
-    if (typeof cellValue === 'string') {
-      row[column] = cellValue.trim();
-    }
+    row[column] = cellValue.trim();
   }
 
   return row;

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -19,36 +19,35 @@ export const parseCSV = (csvfile, download, useDefaultColumnDataType) => {
   });
 };
 
-const isCellValid = (cell) => {
-  return cell !== undefined && cell !== "";
-}
+const cleanData = (data) => {
+  var cleanedData = []
 
-const isRowValid = (row) => {
-  var cells = Object.values(row);
-  return cells.every(isCellValid)
-}
-
-const trimWhiteSpaces = (row) => {
-  var trimmedRows = {};
-  for (var cellName in row) {
-    if (typeof row[cellName] === 'string') {
-      trimmedRows[cellName] = row[cellName].trim();
-    } else {
-      trimmedRows[cellName] = row[cellName]
+  for (var row of data) {
+    var cleanedRow = tryGetCleanedRow(row);
+    if (cleanedRow !== null) {
+      cleanedData.push(cleanedRow);
     }
   }
-  return trimmedRows;
-}
 
-const cleanData = (data) => {
-  var filterValidData = data.filter(row => isRowValid(row));
-  var cleanedData = filterValidData.map(row => trimWhiteSpaces(row));
   return cleanedData;
 }
 
-const countRemovedRows = (originalData, cleanedData) => {
-  var removedRowsCount = originalData.length - cleanedData.length;
-  store.dispatch(setRemovedRowsCount(removedRowsCount));
+const tryGetCleanedRow = (row) => {
+  for (var cellName in row) {
+    if (!isCellValid(row[cellName])) {
+      return null;
+    }
+
+    if (typeof row[cellName] === 'string') {
+      row[cellName] = row[cellName].trim();
+    }
+  }
+
+  return row;
+}
+
+const isCellValid = (cell) => {
+  return cell !== undefined && cell !== "";
 }
 
 const updateData = (result, useDefaultColumnDataType, userUploadedData) => {
@@ -59,6 +58,11 @@ const updateData = (result, useDefaultColumnDataType, userUploadedData) => {
   if (useDefaultColumnDataType) {
     setDefaultColumnDataType(cleanedData);
   }
+}
+
+const countRemovedRows = (originalData, cleanedData) => {
+  var removedRowsCount = originalData.length - cleanedData.length;
+  store.dispatch(setRemovedRowsCount(removedRowsCount));
 }
 
 const setDefaultColumnDataType = data => {


### PR DESCRIPTION
In user-uploaded CSVs, categorical values with leading or trailing spaces were considered unique values along with its counterpart without the extra spaces, resulting in seemingly duplicated values. This change removes leading or trailing spaces from categorical values to prevent duplication. 

Example CSV:
![Screen Shot 2021-06-16 at 3 42 36 PM](https://user-images.githubusercontent.com/40412372/122305532-e9b39a00-cebb-11eb-9e96-12cbc4b81d59.png)

Before: 
![Screen Shot 2021-06-16 at 3 59 51 PM](https://user-images.githubusercontent.com/40412372/122305545-ee784e00-cebb-11eb-9be0-261eee1d3af5.png)

After: 
![Screen Shot 2021-06-16 at 3 42 25 PM](https://user-images.githubusercontent.com/40412372/122305570-fc2dd380-cebb-11eb-9a10-776f12daf7a5.png)
