### PR TITLE
Fix ResultsTable when running standalone

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -341,7 +341,11 @@ export const styles = {
     textAlign: "right",
     position: "sticky",
     top: 0,
-    fontSize: 12
+    fontSize: 12,
+    padding: 5,
+    borderStyle: "solid",
+    borderWidth: 1,
+    borderColor: "white"
   },
 
   dataDisplayHeader: {
@@ -567,12 +571,14 @@ export const styles = {
     backgroundColor: "white",
     color: "rgb(30, 30, 30)",
     verticalAlign: "top",
-    fontSize: 24
+    fontSize: 24,
+    height: 31
   },
 
   resultsTableSecondHeader: {
     top: "42px",
-    color: "white"
+    color: "white",
+    height: 15
   },
 
   resultsCellHighlight: {


### PR DESCRIPTION
The first row is no longer hidden under the header when running standalone.  This is done by borrowing some styling that the version running at studio.code.org would inherit from the dashboard set of styling.


### before, standalone

with first row of results hidden

![Screen Shot 2021-06-17 at 8 42 55 PM](https://user-images.githubusercontent.com/2205926/122381870-362fc180-cf1e-11eb-8596-bc011557e525.png)

### after, standalone

with first row of results visible

![Screen Shot 2021-06-17 at 8 41 14 PM](https://user-images.githubusercontent.com/2205926/122381862-3465fe00-cf1e-11eb-9fd5-d26d132757a5.png)

