### PR TITLE
Value conversion tests

### DIFF
--- a/src/helpers/valueConversion.js
+++ b/src/helpers/valueConversion.js
@@ -7,31 +7,19 @@ import { isEmpty, getKeyByValue } from "./utils.js";
 import { getSelectedCategoricalColumns } from "../redux.js";
 
 // Take a ML-friendly integer and convert to human-readable string.
-export function getConvertedValueForDisplay(state, rawValue, column) {
+export function convertValueForDisplay(state, value, column) {
   const convertedValue =
     getSelectedCategoricalColumns(state).includes(column) &&
     !isEmpty(state.featureNumberKey)
-      ? getKeyByValue(state.featureNumberKey[column], rawValue)
-      : rawValue;
+      ? getKeyByValue(state.featureNumberKey[column], value)
+      : value;
   return convertedValue;
 }
 
-/* For feature columns that store categorical data, looks up the value
-  associated with a row's specific option for a given feature; otherwise
-  returns the option converted to an integer for feature columns that store
-  numerical data.
-  @param {object} row, entry from the dataset
-  {
-    labelColumn: option,
-    featureColumn1: option,
-    featureColumn2: option
-    ...
-  }
-  @param {string} - feature name
-  @return {integer}
-  */
-export function convertValueForTraining(state, feature, row) {
-  return getSelectedCategoricalColumns(state).includes(feature)
-    ? state.featureNumberKey[feature][row[feature]]
-    : parseFloat(row[feature]);
+// Take a human-readable string and convert to a ML-friendly integer.
+export function convertValueForTraining(state, value, column) {
+  const convertedValue = getSelectedCategoricalColumns(state).includes(column)
+    ? state.featureNumberKey[column][value]
+    : parseFloat(value);
+  return convertedValue;
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -21,7 +21,7 @@ import {
   getUniqueOptions,
   isColumnDataValid
 } from "./helpers/columnDetails.js";
-import { getConvertedValueForDisplay } from "./helpers/valueConversion.js";
+import { convertValueForDisplay } from "./helpers/valueConversion.js";
 import { areArraysEqual } from "./helpers/utils.js";
 import {
   ColumnTypes,
@@ -928,7 +928,7 @@ export function getConvertedAccuracyCheckExamples(state) {
     let convertedAccuracyCheckExample = [];
     for (var i = 0; i < state.selectedFeatures.length; i++) {
       convertedAccuracyCheckExample.push(
-        getConvertedValueForDisplay(
+        convertValueForDisplay(
           state,
           example[i],
           state.selectedFeatures[i]
@@ -941,7 +941,7 @@ export function getConvertedAccuracyCheckExamples(state) {
 }
 
 export function getConvertedPredictedLabel(state) {
-  return getConvertedValueForDisplay(
+  return convertValueForDisplay(
     state,
     state.prediction,
     state.labelColumn
@@ -950,7 +950,7 @@ export function getConvertedPredictedLabel(state) {
 
 export function getConvertedLabels(state, rawLabels = []) {
   return rawLabels.map(label =>
-    getConvertedValueForDisplay(state, label, state.labelColumn)
+    convertValueForDisplay(state, label, state.labelColumn)
   );
 }
 

--- a/src/train.js
+++ b/src/train.js
@@ -63,13 +63,14 @@ const buildOptionNumberKeysByFeature = store => {
 const extractTrainingExamples = (state, row) => {
   let exampleValues = [];
   state.selectedFeatures.forEach(feature =>
-    exampleValues.push(convertValueForTraining(state, feature, row))
+    exampleValues.push(convertValueForTraining(state, row[feature], feature))
   );
   return exampleValues;
 };
 
 const extractTrainingLabel = (state, row) => {
-  return convertValueForTraining(state, state.labelColumn, row);
+  const value = row[state.labelColumn];
+  return convertValueForTraining(state, value, state.labelColumn);
 };
 
 const prepareTrainingData = store => {
@@ -115,7 +116,7 @@ const prepareTestData = store => {
   let testValues = [];
   updatedState.selectedFeatures.forEach(feature =>
     testValues.push(
-      convertValueForTraining(updatedState, feature, updatedState.testData)
+      convertValueForTraining(updatedState, updatedState.testData[feature], feature)
     )
   );
   return testValues;

--- a/test/unit/accuracy.test.js
+++ b/test/unit/accuracy.test.js
@@ -4,53 +4,8 @@ import {
   getAccuracyGrades,
   getResultsByGrade
 } from '../../src/helpers/accuracy.js';
+import { classificationState, regressionState } from './testData';
 import { ResultsGrades, ColumnTypes } from '../../src/constants.js';
-
-const columnsByDataType = {};
-columnsByDataType['height'] = ColumnTypes.NUMERICAL;
-columnsByDataType['sun'] = ColumnTypes.CATEGORICAL;
-
-const regressionState = {
-  data: [
-    {
-      sun: 'high',
-      height: 3.8
-    },
-    {
-      sun: 'high',
-      height: 3.9
-    },
-    {
-      sun: 'medium',
-      height: 2.6
-    },
-    {
-      sun: 'medium',
-      height: 2.5
-    },
-    {
-      sun: 'low',
-      height: 0.9
-    },
-    {
-      sun: 'low',
-      height: 1.6
-    }
-  ],
-  labelColumn: 'height',
-  accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
-  accuracyCheckLabels: [5.9, 3.8, 2.6, 2.5, 1.6, 0.7],
-  accuracyCheckExamples: [[2], [2], [1], [1], [0], [0]],
-  selectedFeatures: ['sun'],
-  columnsByDataType: columnsByDataType,
-  featureNumberKey: {
-    'sun': {
-      'low' : 0,
-      'medium' : 1,
-      'high' : 2,
-    }
-  }
-};
 
 const regressionGrades = [
   ResultsGrades.INCORRECT,
@@ -61,68 +16,6 @@ const regressionGrades = [
   ResultsGrades.INCORRECT
 ];
 
-const classificationState = {
-  data: [
-    {
-      weather: 'sunny',
-      temp: 'hot',
-      play: 'no'
-    },
-    {
-      weather: 'overcast',
-      temp: 'hot',
-      play: 'yes'
-    },
-    {
-      weather: 'overcast',
-      temp: 'mild',
-      play: 'yes'
-    },
-    {
-      weather: 'overcast',
-      temp: 'cool',
-      play: 'yes'
-    },
-    {
-      weather: 'rainy',
-      temp: 'mild',
-      play: 'yes'
-    },
-    {
-      weather: 'rainy',
-      temp: 'cool',
-      play: 'no'
-    }
-  ],
-  labelColumn: 'play',
-  selectedFeatures: ['temp', 'weather'],
-  columnsByDataType: {
-    weather: 'categorical',
-    temp: 'categorical',
-    play: 'categorical'
-  },
-  accuracyCheckLabels: [1, 0, 0, 0, 0, 1],
-  accuracyCheckExamples: [[0,2], [1,2], [1,1], [1,0], [2,1], [2,0]],
-  featureNumberKey: {
-    'temp': {
-      'cool' : 0,
-      'mild' : 1,
-      'hot' : 2,
-    },
-    'play': {
-      'yes' : 0,
-      'no' : 1
-    },
-    'weather': {
-      'sunny' : 0,
-      'overcast' : 1,
-      'rainy': 2
-    }
-  }
-};
-
-const mixedClassificationResults = [0, 0, 0, 1, 1, 0];
-
 const classificationGrades = [
   ResultsGrades.INCORRECT,
   ResultsGrades.CORRECT,
@@ -132,21 +25,42 @@ const classificationGrades = [
   ResultsGrades.INCORRECT
 ];
 
+const allCorrectGrades = [
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT
+];
+
+const allIncorrectGrades = [
+  ResultsGrades.INCORRECT,
+  ResultsGrades.INCORRECT,
+  ResultsGrades.INCORRECT,
+  ResultsGrades.INCORRECT,
+  ResultsGrades.INCORRECT,
+  ResultsGrades.INCORRECT
+];
+
+const mostlyCorrectGrades = [
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.CORRECT,
+  ResultsGrades.INCORRECT
+];
+
+const mixedResults = [0, 0, 0, 1, 1, 0];
+
 describe('redux functions', () => {
   test('getAccuracyClassification - all accurate', async () => {
     const accurateResults  = [1, 0, 0, 0, 0, 1];
-    classificationState['accuracyCheckPredictedLabels'] =
-      accurateResults;
+    classificationState['accuracyCheckPredictedLabels'] = accurateResults;
 
     const accuracy = getAccuracyClassification(classificationState);
-    expect(accuracy.grades).toEqual([
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT
-    ]);
+    expect(accuracy.grades).toEqual(allCorrectGrades);
     expect(accuracy.percentCorrect).toBe('100.00');
   });
 
@@ -156,21 +70,12 @@ describe('redux functions', () => {
       mostlyAccurateResults;
 
     const accuracy = getAccuracyClassification(classificationState);
-    expect(accuracy.grades).toEqual([
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.CORRECT,
-      ResultsGrades.INCORRECT
-    ]);
+    expect(accuracy.grades).toEqual(mostlyCorrectGrades);
     expect(accuracy.percentCorrect).toBe('83.33');
   });
 
   test('getAccuracyClassification - not very accurate', async () => {
-    const mixedResults = [0, 0, 0, 1, 1, 0];
-    classificationState['accuracyCheckPredictedLabels'] =
-      mixedClassificationResults;
+    classificationState['accuracyCheckPredictedLabels'] = mixedResults;
     const accuracy = getAccuracyClassification(classificationState);
     expect(accuracy.grades).toEqual(classificationGrades);
     expect(accuracy.percentCorrect).toBe('33.33');
@@ -182,14 +87,7 @@ describe('redux functions', () => {
       inaccurateResults;
 
     const accuracy = getAccuracyClassification(classificationState);
-    expect(accuracy.grades).toEqual([
-      ResultsGrades.INCORRECT,
-      ResultsGrades.INCORRECT,
-      ResultsGrades.INCORRECT,
-      ResultsGrades.INCORRECT,
-      ResultsGrades.INCORRECT,
-      ResultsGrades.INCORRECT
-    ]);
+    expect(accuracy.grades).toEqual(allIncorrectGrades);
     expect(accuracy.percentCorrect).toBe('0.00');
   });
 
@@ -207,7 +105,7 @@ describe('redux functions', () => {
 
   test("getAccuracyGrades - classification", async () => {
     classificationState['accuracyCheckPredictedLabels'] =
-      mixedClassificationResults;
+      mixedResults;
     const grades = getAccuracyGrades(classificationState);
     expect(grades).toEqual(classificationGrades);
   })
@@ -231,8 +129,7 @@ describe('redux functions', () => {
   });
 
   test("getResultsByGrade - correct, classification", async () => {
-    classificationState['accuracyCheckPredictedLabels'] =
-      mixedClassificationResults;
+    classificationState['accuracyCheckPredictedLabels'] = mixedResults;
     const results = getResultsByGrade(classificationState, ResultsGrades.CORRECT);
     const resultsCount = results.examples.length;
     const expectedCount = classificationGrades.filter(
@@ -242,8 +139,7 @@ describe('redux functions', () => {
   });
 
   test("getResultsByGrade - incorrect, classification", async () => {
-    classificationState['accuracyCheckPredictedLabels'] =
-      mixedClassificationResults;
+    classificationState['accuracyCheckPredictedLabels'] = mixedResults;
     const results = getResultsByGrade(classificationState, ResultsGrades.INCORRECT);
     const resultsCount = results.examples.length;
     const expectedCount = classificationGrades.filter(

--- a/test/unit/testData.js
+++ b/test/unit/testData.js
@@ -1,0 +1,106 @@
+/* Mock state to be used across the testing suite. */
+
+export const regressionState = {
+  data: [
+    {
+      sun: 'high',
+      height: 3.8
+    },
+    {
+      sun: 'high',
+      height: 3.9
+    },
+    {
+      sun: 'medium',
+      height: 2.6
+    },
+    {
+      sun: 'medium',
+      height: 2.5
+    },
+    {
+      sun: 'low',
+      height: 0.9
+    },
+    {
+      sun: 'low',
+      height: 1.6
+    }
+  ],
+  labelColumn: 'height',
+  accuracyCheckPredictedLabels: [4.0, 3.75, 2.63, 2.46, 1.6, 1.0],
+  accuracyCheckLabels: [5.9, 3.8, 2.6, 2.5, 1.6, 0.7],
+  accuracyCheckExamples: [[2], [2], [1], [1], [0], [0]],
+  selectedFeatures: ['sun'],
+  columnsByDataType: {
+    height: 'numerical',
+    sun: 'categorical'
+  },
+  featureNumberKey: {
+    'sun': {
+      'low' : 0,
+      'medium' : 1,
+      'high' : 2,
+    }
+  }
+};
+
+export const classificationState = {
+  data: [
+    {
+      weather: 'sunny',
+      temp: 'hot',
+      play: 'no'
+    },
+    {
+      weather: 'overcast',
+      temp: 'hot',
+      play: 'yes'
+    },
+    {
+      weather: 'overcast',
+      temp: 'mild',
+      play: 'yes'
+    },
+    {
+      weather: 'overcast',
+      temp: 'cool',
+      play: 'yes'
+    },
+    {
+      weather: 'rainy',
+      temp: 'mild',
+      play: 'yes'
+    },
+    {
+      weather: 'rainy',
+      temp: 'cool',
+      play: 'no'
+    }
+  ],
+  labelColumn: 'play',
+  selectedFeatures: ['temp', 'weather'],
+  columnsByDataType: {
+    weather: 'categorical',
+    temp: 'categorical',
+    play: 'categorical'
+  },
+  accuracyCheckLabels: [1, 0, 0, 0, 0, 1],
+  accuracyCheckExamples: [[0,2], [1,2], [1,1], [1,0], [2,1], [2,0]],
+  featureNumberKey: {
+    'temp': {
+      'cool' : 0,
+      'mild' : 1,
+      'hot' : 2,
+    },
+    'play': {
+      'yes' : 0,
+      'no' : 1
+    },
+    'weather': {
+      'sunny' : 0,
+      'overcast' : 1,
+      'rainy': 2
+    }
+  }
+};

--- a/test/unit/valueConversion.test.js
+++ b/test/unit/valueConversion.test.js
@@ -1,5 +1,36 @@
-describe("example test", () => {
-  test("first", async () => {
-    expect(true).toBe(true);
-  });
+import { convertValueForDisplay, convertValueForTraining } from '../../src/helpers/valueConversion';
+import { classificationState, regressionState } from './testData';
+
+describe("converting categorical values", () => {
+
+  const categoryOptionStrings = Object.keys(
+    classificationState.featureNumberKey[classificationState.labelColumn]
+  );
+
+  const numbersForMLTraining = Object.values(
+    classificationState.featureNumberKey[classificationState.labelColumn]
+  );
+
+  test("convert value for display", async () => {
+    numbersForMLTraining.forEach((number, i) => {
+      const stringCategory = categoryOptionStrings[i];
+      const convertedValue = convertValueForDisplay(
+        classificationState,
+        number,
+        classificationState.labelColumn);
+      expect(stringCategory).toBe(convertedValue);
+    });
+  })
+
+  test("convert value for training", async () => {
+    categoryOptionStrings.forEach((string, i) => {
+      const machineLearningNumber = numbersForMLTraining[i]
+      const convertedValue = convertValueForTraining(
+        classificationState,
+        string,
+        classificationState.labelColumn
+      );
+      expect(machineLearningNumber).toBe(convertedValue);
+    });
+  })
 });

--- a/test/unit/valueConversion.test.js
+++ b/test/unit/valueConversion.test.js
@@ -1,5 +1,5 @@
 import { convertValueForDisplay, convertValueForTraining } from '../../src/helpers/valueConversion';
-import { classificationState, regressionState } from './testData';
+import { classificationState } from './testData';
 
 describe("converting categorical values", () => {
 


### PR DESCRIPTION
Tests for helper functions that convert categorical strings into numbers to pass to the machine learning algorithm and back to strings again for displaying in the UI. 

I made a few corollary updates along the way: 

- Extracted testing set-up inputs into `testData.js` file to facilitate re-usability across tests

- Declared and re-used some expected outcomes variables in accuracy tests 

- Aligned the naming and parameters of the conversion functions -  e.g.`convertValueForDisplay` rather than `getConvertedValueForDisplay` and each function now takes in `state`, `value` and `column`.