### PR TITLE
Fix dynamic instructions with specific dataset

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -305,10 +305,12 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_IMPORTED_DATA) {
-    state.instructionsKeyCallback(
-      action.userUploadedData ? "uploadedDataset" : "selectedDataset",
-      null
-    );
+    if (state.currentPanel === "selectDataset") {
+      state.instructionsKeyCallback(
+        action.userUploadedData ? "uploadedDataset" : "selectedDataset",
+        null
+      );
+    }
 
     return {
       ...state,


### PR DESCRIPTION
When the mode contains a specific dataset, the app jumps to the `"dataDisplayFeatures"` panel and shows the corresponding dynamic instruction.  However, the load of the dataset is asynchronous and completes shortly after the panel is displayed.

We were then setting the dynamic instruction to `"selectedDataset"` which was handy when on the `"selectDataset"` panel but not so handy when not.  Now, we only set that dynamic instruction when we're on the `"selectDataset"` panel.