### PR TITLE
Prevent non-CSV uploads

### DIFF
--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -13,7 +13,7 @@ import {
 import { parseCSV } from "../csvReaderWrapper";
 import { parseJSON } from "../jsonReaderWrapper";
 import { allDatasets, getAvailableDatasets } from "../datasetManifest";
-import { styles, fileTypeErrorMessage } from "../constants";
+import { styles } from "../constants";
 import ScrollableContent from "./ScrollableContent";
 
 class SelectDataset extends Component {
@@ -34,8 +34,7 @@ class SelectDataset extends Component {
     super(props);
 
     this.state = {
-      download: false,
-      showFileTypeErrorMessage: false
+      download: false
     };
   }
 
@@ -54,8 +53,7 @@ class SelectDataset extends Component {
       this.props.setSelectedCSV(csvPath);
       this.props.setSelectedJSON(jsonPath);
       this.setState({
-        download: true,
-        showFileTypeErrorMessage: false
+        download: true
       });
 
       parseCSV(csvPath, true, false);
@@ -66,19 +64,11 @@ class SelectDataset extends Component {
 
   handleUploadSelect = event => {
     this.props.resetState();
-    const selectedCSV = event.target.files[0]
-    this.props.setSelectedCSV(selectedCSV);
+    this.props.setSelectedCSV(event.target.files[0]);
     this.setState({
       download: false
     });
-    if (selectedCSV.name.includes(".csv") ||
-    selectedCSV.type === "text/csv") {
-        parseCSV(event.target.files[0], false, true);
-    } else {
-      this.setState({
-        showFileTypeErrorMessage: true
-      });
-    }
+    parseCSV(event.target.files[0], false, true);
   };
 
   render() {
@@ -132,7 +122,7 @@ class SelectDataset extends Component {
               <input
                 className="csv-input"
                 type="file"
-                accept=".csv"
+                accept=".csv,text/csv,application/vnd.ms-excel"
                 name="file"
                 placeholder={null}
                 onChange={this.handleUploadSelect}
@@ -140,11 +130,6 @@ class SelectDataset extends Component {
                 value=""
               />
             </label>
-            {this.state.showFileTypeErrorMessage && (
-              <span style={styles.fileTypeErrorMessageConainer}>
-                {fileTypeErrorMessage}
-              </span>
-            )}
           </div>
         )}
       </div>

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -122,7 +122,7 @@ class SelectDataset extends Component {
               <input
                 className="csv-input"
                 type="file"
-                accept=".csv,.xls,.xlsx"
+                accept=".csv"
                 name="file"
                 placeholder={null}
                 onChange={this.handleUploadSelect}

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -132,7 +132,7 @@ class SelectDataset extends Component {
               <input
                 className="csv-input"
                 type="file"
-                accept=".csv,.xls,.xlsx"
+                accept=".csv"
                 name="file"
                 placeholder={null}
                 onChange={this.handleUploadSelect}

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -71,16 +71,13 @@ class SelectDataset extends Component {
     this.setState({
       download: false
     });
-    if (selectedCSV.name.includes(".xls") ||
-    selectedCSV.type === "application/vnd.ms-excel") {
+    if (selectedCSV.name.includes(".csv") ||
+    selectedCSV.type === "text/csv") {
+        parseCSV(event.target.files[0], false, true);
+    } else {
       this.setState({
         showFileTypeErrorMessage: true
       });
-    } else {
-      this.setState({
-        showFileTypeErrorMessage: false
-      });
-      parseCSV(event.target.files[0], false, true);
     }
   };
 

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -27,7 +27,7 @@ class SelectDataset extends Component {
     resetState: PropTypes.func.isRequired,
     specifiedDatasets: PropTypes.arrayOf(PropTypes.string),
     name: PropTypes.string,
-    highlightDataset: PropTypes.string,
+    highlightDataset: PropTypes.string
   };
 
   constructor(props) {
@@ -35,7 +35,7 @@ class SelectDataset extends Component {
 
     this.state = {
       download: false,
-      showFileTypeError: false
+      showFileTypeErrorMessage: false
     };
   }
 
@@ -55,7 +55,7 @@ class SelectDataset extends Component {
       this.props.setSelectedJSON(jsonPath);
       this.setState({
         download: true,
-        showFileTypeError: false
+        showFileTypeErrorMessage: false
       });
 
       parseCSV(csvPath, true, false);
@@ -74,11 +74,11 @@ class SelectDataset extends Component {
     if (selectedCSV.name.includes(".xls") ||
     selectedCSV.type === "application/vnd.ms-excel") {
       this.setState({
-        showFileTypeError: true
+        showFileTypeErrorMessage: true
       });
     } else {
       this.setState({
-        showFileTypeError: false
+        showFileTypeErrorMessage: false
       });
       parseCSV(event.target.files[0], false, true);
     }
@@ -143,7 +143,7 @@ class SelectDataset extends Component {
                 value=""
               />
             </label>
-            {this.state.showFileTypeError && (
+            {this.state.showFileTypeErrorMessage && (
               <span style={styles.fileTypeErrorMessageConainer}>
                 {fileTypeErrorMessage}
               </span>

--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -13,7 +13,7 @@ import {
 import { parseCSV } from "../csvReaderWrapper";
 import { parseJSON } from "../jsonReaderWrapper";
 import { allDatasets, getAvailableDatasets } from "../datasetManifest";
-import { styles } from "../constants";
+import { styles, fileTypeErrorMessage } from "../constants";
 import ScrollableContent from "./ScrollableContent";
 
 class SelectDataset extends Component {
@@ -27,14 +27,15 @@ class SelectDataset extends Component {
     resetState: PropTypes.func.isRequired,
     specifiedDatasets: PropTypes.arrayOf(PropTypes.string),
     name: PropTypes.string,
-    highlightDataset: PropTypes.string
+    highlightDataset: PropTypes.string,
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      download: false
+      download: false,
+      showFileTypeError: false
     };
   }
 
@@ -53,7 +54,8 @@ class SelectDataset extends Component {
       this.props.setSelectedCSV(csvPath);
       this.props.setSelectedJSON(jsonPath);
       this.setState({
-        download: true
+        download: true,
+        showFileTypeError: false
       });
 
       parseCSV(csvPath, true, false);
@@ -64,11 +66,22 @@ class SelectDataset extends Component {
 
   handleUploadSelect = event => {
     this.props.resetState();
-    this.props.setSelectedCSV(event.target.files[0]);
+    const selectedCSV = event.target.files[0]
+    this.props.setSelectedCSV(selectedCSV);
     this.setState({
       download: false
     });
-    parseCSV(event.target.files[0], false, true);
+    if (selectedCSV.name.includes(".xls") ||
+    selectedCSV.type === "application/vnd.ms-excel") {
+      this.setState({
+        showFileTypeError: true
+      });
+    } else {
+      this.setState({
+        showFileTypeError: false
+      });
+      parseCSV(event.target.files[0], false, true);
+    }
   };
 
   render() {
@@ -122,7 +135,7 @@ class SelectDataset extends Component {
               <input
                 className="csv-input"
                 type="file"
-                accept=".csv"
+                accept=".csv,.xls,.xlsx"
                 name="file"
                 placeholder={null}
                 onChange={this.handleUploadSelect}
@@ -130,6 +143,11 @@ class SelectDataset extends Component {
                 value=""
               />
             </label>
+            {this.state.showFileTypeError && (
+              <span style={styles.fileTypeErrorMessageConainer}>
+                {fileTypeErrorMessage}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,8 +36,6 @@ export const saveMessages = {
   piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number)."
 };
 
-export const fileTypeErrorMessage = "There was an error. Please upload a CSV."
-
 export function getFadeOpacity(animationProgress) {
   return animationProgress > 0.95
     ? 1 - (animationProgress - 0.95) / 0.05
@@ -958,9 +956,5 @@ export const styles = {
 
   navigationButtonsContainer: {
     position: "relative"
-  },
-
-  fileTypeErrorMessageConainer: {
-    margin: 10
   }
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,6 +36,8 @@ export const saveMessages = {
   piiProfanity: "Your model could not be saved because it contains profanity or personally identifying information (e.g. email, address, phone number)."
 };
 
+export const fileTypeErrorMessage = "There was an error. Please upload a CSV."
+
 export function getFadeOpacity(animationProgress) {
   return animationProgress > 0.95
     ? 1 - (animationProgress - 0.95) / 0.05
@@ -956,5 +958,9 @@ export const styles = {
 
   navigationButtonsContainer: {
     position: "relative"
+  },
+
+  fileTypeErrorMessageConainer: {
+    margin: 10
   }
 };

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -34,13 +34,15 @@ const cleanData = (data) => {
 
 const getCleanedRow = (row) => {
   for (var column in row) {
-    var cellValue = row[column];
+    if (column !== "__parsed_extra") {
+      var cellValue = row[column];
 
-    if (!isCellValid(cellValue)) {
-      return null;
+      if (!isCellValid(cellValue)) {
+        return null;
+      }
+
+      row[column] = cellValue.trim();
     }
-
-    row[column] = cellValue.trim();
   }
 
   return row;

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -47,7 +47,7 @@ const getCleanedRow = (row) => {
 }
 
 const isCellValid = (cell) => {
-  return cell !== undefined && cell !== "";
+  return cell !== undefined && cell !== "" && typeof cell === "string";
 }
 
 const updateData = (result, useDefaultColumnDataType, userUploadedData) => {


### PR DESCRIPTION
Previously, we allowed uploads of `.xls` and `.xlsx` files which aren't supported. This PR specifies that we only accept .csv files.

For example, an `.xlsx` file like this:
![Screen Shot 2021-06-23 at 1 15 32 PM](https://user-images.githubusercontent.com/40412372/123162141-1b30e600-d425-11eb-9085-f0a68e3b3541.png)

Renders like this in the data table:
![Screen Shot 2021-06-23 at 1 12 58 PM](https://user-images.githubusercontent.com/40412372/123162038-fccaea80-d424-11eb-9f08-96cdc50c3988.png)

We currently use two ways to check for CSV files. One of the ways is built into `react-papaparse v3.8.0`, which is what we use to parse CSVs. The [documentation](https://react-papaparse.js.org/docs#local-files) mentions the default MIME type is for CSV: `'text/csv, .csv, application/vnd.ms-excel'`.  

Another way is through the file `<input>` element in `SelectDataset`. The `accept` attribute specifies the file type, which is changed to only `.csv` in this PR. According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept): 

> The accept attribute doesn't validate the types of the selected files; it provides hints for browsers to guide users towards selecting the correct file types. It is still possible (in most cases) for users to toggle an option in the file chooser that makes it possible to override this and select any file they wish, and then choose incorrect file types.
> 
> Because of this, you should make sure that expected requirement is validated server-side.

Since we don't send the CSV file itself to the server, we can add a validation in the `handleUploadSelect` function in `SelectDataset`. I'm wondering if this would be redundant since we already have two checks for the CSV file. 

If we wanted to add this validation, we'd also need to display a message somewhere (e.g., `DataCard` component). Let me know what you all think!