### PR TITLE
Small dynamic instructions fix for column deselection

### DIFF
--- a/src/redux.js
+++ b/src/redux.js
@@ -557,7 +557,9 @@ export default function rootReducer(state = initialState, action) {
       return state;
     } else if (state.currentColumn === action.currentColumn) {
       // If column is selected, then deselect.
-      state.instructionsKeyCallback("dataDisplayFeatures", null);
+      if (state.currentPanel === "dataDisplayFeatures") {
+        state.instructionsKeyCallback("dataDisplayFeatures", null);
+      }
       return {
         ...state,
         currentColumn: undefined


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/ml-playground/pull/229.  When a column was deselected on the label selection screen, the dynamic instruction was being reset to `"dataDisplayFeatures"` when nothing should have happened.  That's now fixed.