### PR TITLE
ColumnInspector refactor

### DIFF
--- a/src/UIComponents/AddFeatureButton.jsx
+++ b/src/UIComponents/AddFeatureButton.jsx
@@ -12,9 +12,9 @@ class AddFeatureButton extends Component {
     addSelectedFeature: PropTypes.func.isRequired
   };
 
-  addFeature = e => {
-    this.props.addSelectedFeature(this.props.column);
-    e.preventDefault();
+  addFeature = (event, column) => {
+    this.props.addSelectedFeature(column);
+    event.preventDefault();
   };
 
   render() {
@@ -23,7 +23,7 @@ class AddFeatureButton extends Component {
     return (
       <button
         type="button"
-        onClick={e => this.addFeature(e, column)}
+        onClick={event => this.addFeature(event, column)}
         style={styles.selectFeaturesButton}
       >
         Add feature

--- a/src/UIComponents/AddFeatureButton.jsx
+++ b/src/UIComponents/AddFeatureButton.jsx
@@ -1,0 +1,43 @@
+/* React component to handle selecting columns as features. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { styles } from "../constants";
+import { addSelectedFeature } from "../redux";
+
+
+class AddFeatureButton extends Component {
+  static propTypes = {
+    column: PropTypes.string,
+    addSelectedFeature: PropTypes.func.isRequired
+  };
+
+  addFeature = e => {
+    this.props.addSelectedFeature(this.props.column);
+    e.preventDefault();
+  };
+
+  render() {
+    const { column } = this.props;
+
+    return (
+      <button
+        type="button"
+        onClick={e => this.addFeature(e, column)}
+        style={styles.selectFeaturesButton}
+      >
+        Add feature
+      </button>
+    )
+  }
+
+}
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    addSelectedFeature(column) {
+      dispatch(addSelectedFeature(column));
+    }
+  })
+)(AddFeatureButton);

--- a/src/UIComponents/ColumnDataTypeDropdown.jsx
+++ b/src/UIComponents/ColumnDataTypeDropdown.jsx
@@ -1,0 +1,50 @@
+/* React component to handle setting datatype for selected columns. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { setColumnsByDataType } from "../redux";
+import { ColumnTypes } from "../constants.js";
+
+class ColumnDataTypeDropdown extends Component {
+  static propTypes = {
+    columnId: PropTypes.string,
+    currentDataType: PropTypes.oneOf(ColumnTypes)
+  };
+
+  handleChangeDataType = (event, feature) => {
+    event.preventDefault();
+    this.props.setColumnsByDataType(feature, event.target.value);
+  };
+
+  render() {
+    const { columnId, currentDataType } = this.props;
+
+    return (
+      <div>
+        <select
+          onChange={event =>
+            this.handleChangeDataType(event, columnId)
+          }
+          value={currentDataType}
+        >
+          {Object.values(ColumnTypes).map((option, index) => {
+            return (
+              <option key={index} value={option}>
+                {option}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    setColumnsByDataType(column, dataType) {
+      dispatch(setColumnsByDataType(column, dataType));
+    }
+  })
+)(ColumnDataTypeDropdown);

--- a/src/UIComponents/ColumnDetailsCategorical.jsx
+++ b/src/UIComponents/ColumnDetailsCategorical.jsx
@@ -1,0 +1,78 @@
+/* React component to handle showing details of categorical columns. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { colors, styles } from "../constants";
+import { Bar } from "react-chartjs-2";
+
+const barData = {
+  labels: [],
+  datasets: [
+    {
+      label: "",
+      backgroundColor: colors.tealTransparent,
+      borderColor: colors.teal,
+      borderWidth: 1,
+      hoverBackgroundColor: "#59cad3",
+      hoverBorderColor: "white",
+      data: []
+    }
+  ]
+};
+
+const chartOptions = {
+  scales: {
+    yAxes: [
+      {
+        ticks: {
+          beginAtZero: true
+        }
+      }
+    ]
+  },
+  legend: { display: false },
+  maintainAspectRatio: false
+};
+
+export default class ColumnDetailsCategorical extends Component {
+  static propTypes = {
+    id: PropTypes.string,
+    uniqueOptions: PropTypes.object,
+    optionFrequencies: PropTypes.object
+  };
+
+  render() {
+    const { uniqueOptions, optionFrequencies, id } = this.props;
+
+    barData.labels = Object.values(uniqueOptions);
+    barData.datasets[0].data = barData.labels.map(option => {
+      return optionFrequencies[option];
+    });
+    barData.datasets[0].label = id;
+
+    const maxLabelsInHistogram = 5;
+
+    return (
+      <div>
+        <div style={styles.bold}>Column information:</div>
+
+        <div style={styles.barChart}>
+          {barData.labels.length <= maxLabelsInHistogram && (
+            <Bar
+              data={barData}
+              width={100}
+              height={150}
+              options={chartOptions}
+            />
+          )}
+          {barData.labels.length > maxLabelsInHistogram && (
+            <div>
+              {barData.labels.length} values were found in this
+              column. A graph is only shown when there are{" "}
+              {maxLabelsInHistogram} or fewer.
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+};

--- a/src/UIComponents/ColumnDetailsNumerical.jsx
+++ b/src/UIComponents/ColumnDetailsNumerical.jsx
@@ -1,0 +1,35 @@
+/* React component to handle showing details of numerical columns. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { styles } from "../constants";
+
+export default class ColumnDetailsNumerical extends Component {
+  static propTypes = {
+    isColumnDataValid: PropTypes.bool,
+    extrema: PropTypes.object
+  };
+
+  render() {
+    const { isColumnDataValid, extrema } = this.props;
+
+    return (
+      <div>
+        <div style={styles.bold}>Column information:</div>
+        {!isColumnDataValid && (
+          <p style={styles.error}>
+            Numerical columns cannot contain strings.
+          </p>
+        )}
+        {isColumnDataValid && (
+          <div style={styles.contents}>
+            min: {extrema.min}
+            <br />
+            max: {extrema.max}
+            <br />
+            range: {extrema.range}
+          </div>
+        )}
+      </div>
+    );
+  }
+};

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -5,11 +5,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import {
-  setLabelColumn,
-  getCurrentColumnData,
-  addSelectedFeature
-} from "../redux";
+import { getCurrentColumnData } from "../redux";
 import { styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
@@ -17,27 +13,19 @@ import ScrollableContent from "./ScrollableContent";
 import ColumnDetailsNumerical from "./ColumnDetailsNumerical";
 import ColumnDetailsCategorical from "./ColumnDetailsCategorical";
 import ColumnDataTypeDropdown from "./ColumnDataTypeDropdown";
+import AddFeatureButton from "./AddFeatureButton";
 
 class ColumnInspector extends Component {
   static propTypes = {
     currentColumnData: PropTypes.object,
-    setLabelColumn: PropTypes.func.isRequired,
-    addSelectedFeature: PropTypes.func.isRequired,
     currentPanel: PropTypes.string
-  };
-
-  setPredictColumn = e => {
-    this.props.setLabelColumn(this.props.currentColumnData.id);
-    e.preventDefault();
-  };
-
-  addFeature = e => {
-    this.props.addSelectedFeature(this.props.currentColumnData.id);
-    e.preventDefault();
   };
 
   render() {
     const { currentColumnData, currentPanel } = this.props;
+
+    const selectingFeatures = currentPanel === "dataDisplayFeatures";
+    const selectingLabel = currentPanel === "dataDisplayLabel";
 
     return (
       currentColumnData && (
@@ -68,7 +56,7 @@ class ColumnInspector extends Component {
                 <br />
               </div>
             )}
-            {currentPanel === "dataDisplayFeatures" && (
+            {selectingFeatures && (
               <div>
                 <ScatterPlot />
                 <CrossTab />
@@ -89,27 +77,13 @@ class ColumnInspector extends Component {
             )}
           </ScrollableContent>
 
-          {currentPanel === "dataDisplayLabel" &&
-            currentColumnData.isSelectable && (
-              <button
-                type="button"
-                onClick={e => this.setPredictColumn(e, currentColumnData.id)}
-                style={styles.selectLabelButton}
-              >
-                Select label
-              </button>
-            )}
+          {selectingLabel && currentColumnData.isSelectable && (
+            <SelectLabelButton column={currentColumnData.id} />
+          )}
 
-          {currentPanel === "dataDisplayFeatures" &&
-            currentColumnData.isSelectable && (
-              <button
-                type="button"
-                onClick={e => this.addFeature(e, currentColumnData.id)}
-                style={styles.selectFeaturesButton}
-              >
-                Add feature
-              </button>
-            )}
+          {selectingFeatures && currentColumnData.isSelectable && (
+            <AddFeatureButton column={currentColumnData.id} />
+          )}
 
           {currentColumnData.hasTooManyUniqueOptions && (
             <div>
@@ -130,13 +104,5 @@ export default connect(
   state => ({
     currentColumnData: getCurrentColumnData(state),
     currentPanel: state.currentPanel
-  }),
-  dispatch => ({
-    setLabelColumn(labelColumn) {
-      dispatch(setLabelColumn(labelColumn));
-    },
-    addSelectedFeature(labelColumn) {
-      dispatch(addSelectedFeature(labelColumn));
-    }
   })
 )(ColumnInspector);

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -10,12 +10,7 @@ import {
   getCurrentColumnData,
   addSelectedFeature
 } from "../redux";
-import {
-  ColumnTypes,
-  styles,
-  colors,
-  UNIQUE_OPTIONS_MAX
-} from "../constants.js";
+import { styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
 import ScrollableContent from "./ScrollableContent";

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -14,6 +14,7 @@ import ColumnDetailsNumerical from "./ColumnDetailsNumerical";
 import ColumnDetailsCategorical from "./ColumnDetailsCategorical";
 import ColumnDataTypeDropdown from "./ColumnDataTypeDropdown";
 import AddFeatureButton from "./AddFeatureButton";
+import SelectLabelButton from "./SelectLabelButton";
 
 class ColumnInspector extends Component {
   static propTypes = {

--- a/src/UIComponents/SelectLabelButton.jsx
+++ b/src/UIComponents/SelectLabelButton.jsx
@@ -12,9 +12,9 @@ class SelectLabelButton extends Component {
     setLabelColumn: PropTypes.func.isRequired
   };
 
-  setPredictColumn = (e, column) => {
+  setPredictColumn = (event, column) => {
     this.props.setLabelColumn(column);
-    e.preventDefault();
+    event.preventDefault();
   };
 
 
@@ -24,7 +24,7 @@ class SelectLabelButton extends Component {
     return (
       <button
         type="button"
-        onClick={e => this.setPredictColumn(e, column)}
+        onClick={event => this.setPredictColumn(event, column)}
         style={styles.selectLabelButton}
       >
         Select label
@@ -40,4 +40,4 @@ export default connect(
       dispatch(setLabelColumn(column));
     }
   })
-)(AddFeatureButton);
+)(SelectLabelButton);

--- a/src/UIComponents/SelectLabelButton.jsx
+++ b/src/UIComponents/SelectLabelButton.jsx
@@ -1,0 +1,43 @@
+/* React component to handle selecting columns as features. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { styles } from "../constants";
+import { setLabelColumn } from "../redux";
+
+
+class SelectLabelButton extends Component {
+  static propTypes = {
+    column: PropTypes.string,
+    setLabelColumn: PropTypes.func.isRequired
+  };
+
+  setPredictColumn = (e, column) => {
+    this.props.setLabelColumn(column);
+    e.preventDefault();
+  };
+
+
+  render() {
+    const { column } = this.props;
+
+    return (
+      <button
+        type="button"
+        onClick={e => this.setPredictColumn(e, column)}
+        style={styles.selectLabelButton}
+      >
+        Select label
+      </button>
+    )
+  }
+}
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    setLabelColumn(column) {
+      dispatch(setLabelColumn(column));
+    }
+  })
+)(AddFeatureButton);

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -15,13 +15,8 @@ export function isColumnNumerical(state, column) {
   accurate models, and we don't want to overflow the metadata column for saved
   models.
 */
-export function hasTooManyUniqueOptions(state, column) {
-  if (isColumnCategorical(state, column)) {
-    const uniqueOptionsCount =
-      getUniqueOptions(state.data, state.currentColumn).length;
-    return uniqueOptionsCount > UNIQUE_OPTIONS_MAX;
-  }
-  return false;
+export function hasTooManyUniqueOptions(uniqueOptionsCount) {
+  return uniqueOptionsCount > UNIQUE_OPTIONS_MAX;
 }
 
 export function getUniqueOptions(data, column) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -727,21 +727,29 @@ export function getCurrentColumnData(state) {
     return null;
   }
 
-  return {
+  const columnData = {
     id: state.currentColumn,
     readOnly: isColumnReadOnly(state, state.currentColumn),
     dataType: state.columnsByDataType[state.currentColumn],
-    uniqueOptions: getUniqueOptionsCurrentColumn(state),
-    extrema: getExtremaCurrentColumn(state),
-    frequencies: getOptionFrequenciesCurrentColumn(state),
     description: getColumnDescription(state, state.currentColumn),
-    hasTooManyUniqueOptions: hasTooManyUniqueOptions(
-      state,
-      state.currentColumn
-    ),
     isColumnDataValid: isColumnDataValid(state, state.currentColumn),
     isSelectable: isSelectable(state, state.currentColumn)
   };
+
+  const isCategorical = columnData.dataType === ColumnTypes.CATEGORICAL;
+  const isNumerical = columnData.dataType === ColumnTypes.NUMERICAL;
+
+  if (isCategorical) {
+    const uniqueOptions = getUniqueOptionsCurrentColumn(state);
+    columnData.uniqueOptions = uniqueOptions;
+    columnData.hasTooManyUniqueOptions = hasTooManyUniqueOptions(
+      uniqueOptions.length
+    );
+    columnData.frequencies = getOptionFrequenciesCurrentColumn(state)
+  } else if (isNumerical) {
+    columnData.extrema = getExtremaCurrentColumn(state);
+  }
+  return columnData;
 }
 
 /* Functions for processing column data for visualizations. */


### PR DESCRIPTION
We had a fairly large, complex component `ColumnInspector` that was handling many aspects of displaying the details of a selected column. I extracted 5 smaller child components that each handle a specific part of the functionality: `ColumnDetailsCategorical`, `ColumnDetailsNumerical`, `AddFeatureButton`, `SelectLabelButton` and `ColumnDataTypeDropdown`. Now each component only receives the state they need and the code is more modular. This change has the additional benefit of hoisting logic out of the UI components and updating `getCurrentColumnData` to be more efficient; for example, we were previously calling `getUniqueOptions` for numerical columns which is excessive and unnecessary. 