### PR TITLE
Current column selectors 

### DIFF
--- a/src/UIComponents/ColumnDataTypeDropdown.jsx
+++ b/src/UIComponents/ColumnDataTypeDropdown.jsx
@@ -8,7 +8,8 @@ import { ColumnTypes } from "../constants.js";
 class ColumnDataTypeDropdown extends Component {
   static propTypes = {
     columnId: PropTypes.string,
-    currentDataType: PropTypes.oneOf(ColumnTypes)
+    currentDataType: PropTypes.oneOf(ColumnTypes),
+    setColumnsByDataType: PropTypes.func.isRequired
   };
 
   handleChangeDataType = (event, feature) => {

--- a/src/UIComponents/ColumnDetailsCategorical.jsx
+++ b/src/UIComponents/ColumnDetailsCategorical.jsx
@@ -4,7 +4,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { colors, styles } from "../constants";
 import { Bar } from "react-chartjs-2";
-import { getCategoricalColumns } from "../selectors";
+import { getCategoricalColumnDetails } from "../selectors";
 
 const barData = {
   labels: [],
@@ -41,9 +41,9 @@ class ColumnDetailsCategorical extends Component {
   };
 
   render() {
-    const { uniqueOptions, frequencies } = this.props.columnDetails;
+    const { id, uniqueOptions, frequencies } = this.props.columnDetails;
 
-    barData.labels = Object.values(uniqueOptions);
+    barData.labels = uniqueOptions && Object.values(uniqueOptions);
     barData.datasets[0].data = barData.labels.map(option => {
       return frequencies[option];
     });
@@ -54,7 +54,6 @@ class ColumnDetailsCategorical extends Component {
     return (
       <div>
         <div style={styles.bold}>Column information:</div>
-
         <div style={styles.barChart}>
           {barData.labels.length <= maxLabelsInHistogram && (
             <Bar

--- a/src/UIComponents/ColumnDetailsCategorical.jsx
+++ b/src/UIComponents/ColumnDetailsCategorical.jsx
@@ -75,4 +75,4 @@ export default class ColumnDetailsCategorical extends Component {
       </div>
     );
   }
-};
+}

--- a/src/UIComponents/ColumnDetailsCategorical.jsx
+++ b/src/UIComponents/ColumnDetailsCategorical.jsx
@@ -4,7 +4,9 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { colors, styles } from "../constants";
 import { Bar } from "react-chartjs-2";
-import { getCategoricalColumnDetails } from "../selectors";
+import {
+  getCategoricalColumnDetails
+} from "../selectors/currentColumnSelectors";
 
 const barData = {
   labels: [],

--- a/src/UIComponents/ColumnDetailsCategorical.jsx
+++ b/src/UIComponents/ColumnDetailsCategorical.jsx
@@ -1,8 +1,10 @@
 /* React component to handle showing details of categorical columns. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+import { connect } from "react-redux";
 import { colors, styles } from "../constants";
 import { Bar } from "react-chartjs-2";
+import { getCategoricalColumns } from "../selectors";
 
 const barData = {
   labels: [],
@@ -33,19 +35,17 @@ const chartOptions = {
   maintainAspectRatio: false
 };
 
-export default class ColumnDetailsCategorical extends Component {
+class ColumnDetailsCategorical extends Component {
   static propTypes = {
-    id: PropTypes.string,
-    uniqueOptions: PropTypes.object,
-    optionFrequencies: PropTypes.object
+    columnDetails: PropTypes.object
   };
 
   render() {
-    const { uniqueOptions, optionFrequencies, id } = this.props;
+    const { uniqueOptions, frequencies } = this.props.columnDetails;
 
     barData.labels = Object.values(uniqueOptions);
     barData.datasets[0].data = barData.labels.map(option => {
-      return optionFrequencies[option];
+      return frequencies[option];
     });
     barData.datasets[0].label = id;
 
@@ -76,3 +76,9 @@ export default class ColumnDetailsCategorical extends Component {
     );
   }
 }
+
+export default connect(
+  state => ({
+    columnDetails: getCategoricalColumnDetails(state)
+  })
+)(ColumnDetailsCategorical);

--- a/src/UIComponents/ColumnDetailsNumerical.jsx
+++ b/src/UIComponents/ColumnDetailsNumerical.jsx
@@ -32,4 +32,4 @@ export default class ColumnDetailsNumerical extends Component {
       </div>
     );
   }
-};
+}

--- a/src/UIComponents/ColumnDetailsNumerical.jsx
+++ b/src/UIComponents/ColumnDetailsNumerical.jsx
@@ -1,26 +1,27 @@
 /* React component to handle showing details of numerical columns. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+import { connect } from "react-redux";
 import { styles } from "../constants";
+import { getNumericalColumnDetails } from "../selectors";
 
-export default class ColumnDetailsNumerical extends Component {
+class ColumnDetailsNumerical extends Component {
   static propTypes = {
-    isColumnDataValid: PropTypes.bool,
-    extrema: PropTypes.object
+    columnDetails: PropTypes.object
   };
 
   render() {
-    const { isColumnDataValid, extrema } = this.props;
+    const { extrema, containsOnlyNumbers } = this.props.columnDetails;
 
     return (
       <div>
         <div style={styles.bold}>Column information:</div>
-        {!isColumnDataValid && (
+        {!containsOnlyNumbers && (
           <p style={styles.error}>
             Numerical columns cannot contain strings.
           </p>
         )}
-        {isColumnDataValid && (
+        {containsOnlyNumbers && extrema && (
           <div style={styles.contents}>
             min: {extrema.min}
             <br />
@@ -33,3 +34,9 @@ export default class ColumnDetailsNumerical extends Component {
     );
   }
 }
+
+export default connect(
+  state => ({
+    columnDetails: getNumericalColumnDetails(state)
+  })
+)(ColumnDetailsNumerical);

--- a/src/UIComponents/ColumnDetailsNumerical.jsx
+++ b/src/UIComponents/ColumnDetailsNumerical.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { styles } from "../constants";
-import { getNumericalColumnDetails } from "../selectors";
+import { getNumericalColumnDetails } from "../selectors/currentColumnSelectors";
 
 class ColumnDetailsNumerical extends Component {
   static propTypes = {

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -5,8 +5,8 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getCurrentColumnDetails } from "../selectors";
-import { styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
+import { getCurrentColumnDetails } from "../selectors/currentColumnSelectors";
+import { styles, UNIQUE_OPTIONS_MAX, ColumnTypes } from "../constants.js";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
 import ScrollableContent from "./ScrollableContent";
@@ -28,8 +28,10 @@ class ColumnInspector extends Component {
     const selectingFeatures = currentPanel === "dataDisplayFeatures";
     const selectingLabel = currentPanel === "dataDisplayLabel";
 
-    const isCategorical = currentColumnDetails && currentColumnDetails.dataType === 'categorical'
-    const isNumerical = currentColumnDetails && currentColumnDetails.dataType === 'numerical'
+    const isCategorical = currentColumnDetails && currentColumnDetails.dataType
+      === ColumnTypes.CATEGORICAL;
+    const isNumerical = currentColumnDetails && currentColumnDetails.dataType
+      === ColumnTypes.NUMERICAL;
 
     if (!currentColumnDetails) {
       return null;

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getCurrentColumnDetails } from "../selectors/currentColumnSelectors";
-import { styles, UNIQUE_OPTIONS_MAX, ColumnTypes } from "../constants.js";
+import { styles, ColumnTypes } from "../constants.js";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
 import ScrollableContent from "./ScrollableContent";
@@ -15,6 +15,7 @@ import ColumnDetailsCategorical from "./ColumnDetailsCategorical";
 import ColumnDataTypeDropdown from "./ColumnDataTypeDropdown";
 import AddFeatureButton from "./AddFeatureButton";
 import SelectLabelButton from "./SelectLabelButton";
+import UniqueOptionsWarning from "./UniqueOptionsWarning";
 
 class ColumnInspector extends Component {
   static propTypes = {
@@ -75,24 +76,13 @@ class ColumnInspector extends Component {
             {isCategorical && <ColumnDetailsCategorical /> }
             {isNumerical && <ColumnDetailsNumerical /> }
           </ScrollableContent>
-
           {selectingLabel && currentColumnDetails.isSelectable && (
             <SelectLabelButton column={currentColumnDetails.id} />
           )}
-
           {selectingFeatures && currentColumnDetails.isSelectable && (
             <AddFeatureButton column={currentColumnDetails.id} />
           )}
-
-          {currentColumnDetails.hasTooManyUniqueOptions && (
-            <div>
-              <span style={styles.bold}>Note:</span>
-              &nbsp; Categorical columns with more than {
-                UNIQUE_OPTIONS_MAX
-              }{" "}
-              unique values can not be selected as the label or a feature.
-            </div>
-          )}
+          <UniqueOptionsWarning />
         </div>
       )
     );

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -27,6 +27,7 @@ class ColumnInspector extends Component {
 
     const selectingFeatures = currentPanel === "dataDisplayFeatures";
     const selectingLabel = currentPanel === "dataDisplayLabel";
+
     const isCategorical = currentColumnDetails && currentColumnDetails.dataType === 'categorical'
     const isNumerical = currentColumnDetails && currentColumnDetails.dataType === 'numerical'
 

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -5,7 +5,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { getCurrentColumnData } from "../redux";
+import { getCurrentColumnDetails } from "../selectors";
 import { styles, UNIQUE_OPTIONS_MAX } from "../constants.js";
 import ScatterPlot from "./ScatterPlot";
 import CrossTab from "./CrossTab";
@@ -18,18 +18,18 @@ import SelectLabelButton from "./SelectLabelButton";
 
 class ColumnInspector extends Component {
   static propTypes = {
-    currentColumnData: PropTypes.object,
+    currentColumnDetails: PropTypes.object,
     currentPanel: PropTypes.string
   };
 
   render() {
-    const { currentColumnData, currentPanel } = this.props;
+    const { currentColumnDetails, currentPanel } = this.props;
 
     const selectingFeatures = currentPanel === "dataDisplayFeatures";
     const selectingLabel = currentPanel === "dataDisplayLabel";
 
     return (
-      currentColumnData && (
+      currentColumnDetails && (
         <div
           id="column-inspector"
           style={{
@@ -37,23 +37,23 @@ class ColumnInspector extends Component {
             ...styles.rightPanel
           }}
         >
-          <div style={styles.largeText}>{currentColumnData.id}</div>
+          <div style={styles.largeText}>{currentColumnDetails.id}</div>
           <ScrollableContent>
             <span style={styles.bold}>Data Type:</span>
             &nbsp;
-            {currentColumnData.readOnly && currentColumnData.dataType}
-            {!currentColumnData.readOnly && (
+            {currentColumnDetails.readOnly && currentColumnDetails.dataType}
+            {!currentColumnDetails.readOnly && (
               <ColumnDataTypeDropdown
-                columnId={currentColumnData.id}
-                currentDataType={currentColumnData.dataType}
+                columnId={currentColumnDetails.id}
+                currentDataType={currentColumnDetails.dataType}
               />
             )}
-            {currentColumnData.description && (
+            {currentColumnDetails.description && (
               <div>
                 <br />
                 <span style={styles.bold}>Description:</span>
                 &nbsp;
-                <div>{currentColumnData.description}</div>
+                <div>{currentColumnDetails.description}</div>
                 <br />
               </div>
             )}
@@ -63,30 +63,30 @@ class ColumnInspector extends Component {
                 <CrossTab />
               </div>
             )}
-            {currentColumnData.uniqueOptions && (
+            {currentColumnDetails.uniqueOptions && (
               <ColumnDetailsCategorical
-                id={currentColumnData.id}
-                uniqueOptions={currentColumnData.uniqueOptions}
-                optionFrequencies={currentColumnData.frequencies}
+                id={currentColumnDetails.id}
+                uniqueOptions={currentColumnDetails.uniqueOptions}
+                optionFrequencies={currentColumnDetails.frequencies}
               />
             )}
-            {currentColumnData.extrema && (
+            {currentColumnDetails.extrema && (
               <ColumnDetailsNumerical
-                isColumnDataValid={currentColumnData.isColumnDataValid}
-                extrema={currentColumnData.extrema}
+                isColumnDataValid={currentColumnDetails.isColumnDataValid}
+                extrema={currentColumnDetails.extrema}
               />
             )}
           </ScrollableContent>
 
-          {selectingLabel && currentColumnData.isSelectable && (
-            <SelectLabelButton column={currentColumnData.id} />
+          {selectingLabel && currentColumnDetails.isSelectable && (
+            <SelectLabelButton column={currentColumnDetails.id} />
           )}
 
-          {selectingFeatures && currentColumnData.isSelectable && (
-            <AddFeatureButton column={currentColumnData.id} />
+          {selectingFeatures && currentColumnDetails.isSelectable && (
+            <AddFeatureButton column={currentColumnDetails.id} />
           )}
 
-          {currentColumnData.hasTooManyUniqueOptions && (
+          {currentColumnDetails.hasTooManyUniqueOptions && (
             <div>
               <span style={styles.bold}>Note:</span>
               &nbsp; Categorical columns with more than {
@@ -103,7 +103,7 @@ class ColumnInspector extends Component {
 
 export default connect(
   state => ({
-    currentColumnData: getCurrentColumnData(state),
+    currentColumnDetails: getCurrentColumnDetails(state),
     currentPanel: state.currentPanel
   })
 )(ColumnInspector);

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -27,6 +27,12 @@ class ColumnInspector extends Component {
 
     const selectingFeatures = currentPanel === "dataDisplayFeatures";
     const selectingLabel = currentPanel === "dataDisplayLabel";
+    const isCategorical = currentColumnDetails && currentColumnDetails.dataType === 'categorical'
+    const isNumerical = currentColumnDetails && currentColumnDetails.dataType === 'numerical'
+
+    if (!currentColumnDetails) {
+      return null;
+    }
 
     return (
       currentColumnDetails && (
@@ -63,19 +69,8 @@ class ColumnInspector extends Component {
                 <CrossTab />
               </div>
             )}
-            {currentColumnDetails.uniqueOptions && (
-              <ColumnDetailsCategorical
-                id={currentColumnDetails.id}
-                uniqueOptions={currentColumnDetails.uniqueOptions}
-                optionFrequencies={currentColumnDetails.frequencies}
-              />
-            )}
-            {currentColumnDetails.extrema && (
-              <ColumnDetailsNumerical
-                isColumnDataValid={currentColumnDetails.isColumnDataValid}
-                extrema={currentColumnDetails.extrema}
-              />
-            )}
+            {isCategorical && <ColumnDetailsCategorical /> }
+            {isNumerical && <ColumnDetailsNumerical /> }
           </ScrollableContent>
 
           {selectingLabel && currentColumnDetails.isSelectable && (

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -4,10 +4,10 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import {
   setTrainedModelDetail,
-  getSelectedColumnDescriptions,
   getDataDescription,
   isUserUploadedDataset
 } from "../redux";
+import { getSelectedColumnsDescriptions } from "../selectors";
 import { styles, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
 import ScrollableContent from "./ScrollableContent";
@@ -222,7 +222,7 @@ export default connect(
     trainedModel: state.trainedModel,
     trainedModelDetails: state.trainedModelDetails,
     labelColumn: state.labelColumn,
-    columnDescriptions: getSelectedColumnDescriptions(state),
+    columnDescriptions: getSelectedColumnsDescriptions(state),
     dataDescription: getDataDescription(state),
     isUserUploadedDataset: isUserUploadedDataset(state)
   }),

--- a/src/UIComponents/SelectLabelButton.jsx
+++ b/src/UIComponents/SelectLabelButton.jsx
@@ -1,4 +1,4 @@
-/* React component to handle selecting columns as features. */
+/* React component to handle selecting a column as the label. */
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";

--- a/src/UIComponents/UniqueOptionsWarning.jsx
+++ b/src/UIComponents/UniqueOptionsWarning.jsx
@@ -1,0 +1,38 @@
+/* React component to handle showing warning for excessive unique options. */
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { styles, UNIQUE_OPTIONS_MAX } from "../constants";
+import {
+  hasTooManyUniqueOptions
+} from "../selectors/currentColumnSelectors";
+
+class UniqueOptionsWarning extends Component {
+  static propTypes = {
+    showWarning: PropTypes.bool
+  };
+
+  render() {
+    const { showWarning } = this.props;
+
+    if (!showWarning) {
+      return null;
+    }
+    
+    return (
+      <div>
+        <span style={styles.bold}>Note:</span>
+        &nbsp; Categorical columns with more than {
+          UNIQUE_OPTIONS_MAX
+        }{" "}
+        unique values can not be selected as the label or a feature.
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    showWarning: hasTooManyUniqueOptions(state)
+  })
+)(UniqueOptionsWarning);

--- a/src/UIComponents/UniqueOptionsWarning.jsx
+++ b/src/UIComponents/UniqueOptionsWarning.jsx
@@ -18,7 +18,7 @@ class UniqueOptionsWarning extends Component {
     if (!showWarning) {
       return null;
     }
-    
+
     return (
       <div>
         <span style={styles.bold}>Note:</span>

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -5,7 +5,7 @@ import {
   setColumnsByDataType,
   setRemovedRowsCount
 } from "./redux";
-import { columnContainsOnlyNumbers } from "./helpers/columnDetails.js";
+import { containsOnlyNumbers } from "./helpers/columnDetails.js";
 import { ColumnTypes } from "./constants.js";
 
 export const parseCSV = (csvfile, download, useDefaultColumnDataType) => {
@@ -68,7 +68,7 @@ const countRemovedRows = (originalData, cleanedData) => {
 const setDefaultColumnDataType = data => {
   const columns = Object.keys(data[0]);
   for (let column of columns) {
-    if (columnContainsOnlyNumbers(data, column)) {
+    if (containsOnlyNumbers(data, column)) {
       store.dispatch(setColumnsByDataType(column, ColumnTypes.NUMERICAL))
     } else {
       store.dispatch(setColumnsByDataType(column, ColumnTypes.CATEGORICAL))

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -20,48 +20,15 @@ export function hasTooManyUniqueOptions(uniqueOptionsCount) {
 }
 
 export function getUniqueOptions(data, column) {
-  return Array.from(new Set(data.map(row => row[column]))).filter(
+  const columnData = getColumnData(data, column);
+  return Array.from(new Set(columnData)).filter(
     option => option !== undefined && option !== ""
   );
 }
 
-function isValidCategoricalData(state, column) {
-  return !hasTooManyUniqueOptions(state, column);
-}
-
-export function containsOnlyNumbers(currentColumnData) {
-  return currentColumnData.every(cell => !isNaN(cell));
-}
-
-function isValidNumericalData(state, column) {
-  return columnContainsOnlyNumbers(state.data, column);
-}
-
-export function isColumnDataValid(state, column) {
-  return (
-    isColumnCategorical(state, column) && isValidCategoricalData(state,column)
-  ) ||
-  (isColumnNumerical(state, column) && isValidNumericalData(state, column));
-}
-
-function isLabel(state, column) {
-  return column === state.labelColumn;
-}
-
-function isFeature(state, column) {
-  return state.selectedFeatures.includes(column);
-}
-
-function isSelected(state, column) {
-  return isLabel(state, column) || isFeature(state, column);
-}
-
-export function isSelectable(state, column) {
-  return isColumnDataValid(state, column) && !isSelected(state, column);
-}
-
 export function isColumnReadOnly(metadata, column) {
   const metadataColumnType =
+    column &&
     metadata &&
     metadata.fields &&
     metadata.fields.find(field => {
@@ -74,7 +41,8 @@ function getColumnData(data, column) {
   return data.map(row => row[column]);
 }
 
-export function getExtrema(columnData) {
+export function getExtrema(data, column) {
+  const columnData = getColumnData(data, column);
   let extrema = {};
   extrema.max = Math.max(...columnData);
   extrema.min = Math.min(...columnData);
@@ -83,9 +51,14 @@ export function getExtrema(columnData) {
   return extrema;
 }
 
+export function containsOnlyNumbers(data, column) {
+  const columnData = getColumnData(data, column);
+  return columnData.every(cell => !isNaN(cell));
+}
+
 export function getColumnDescription(column, metadata, trainedModelDetails) {
   // Use metadata if available.
-  if (metadata && metadata.fields) {
+  if (column && metadata && metadata.fields) {
     const field = metadata.fields.find(field => {
       return field.id === column;
     });

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -106,7 +106,7 @@ export function buildOptionNumberKey(state, feature) {
 export function getColumnDataToSave(state, column) {
   const columnData = {};
   columnData.id = column;
-  columnData.description = getColumnDescription(state, column);
+  columnData.description = getColumnDescription(column, state.metadata, state.trainedModelDetails);
   if (isColumnCategorical(state, column)) {
     columnData.values = getUniqueOptions(state.data, column);
   } else if (isColumnNumerical(state, column)) {

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -29,8 +29,8 @@ function isValidCategoricalData(state, column) {
   return !hasTooManyUniqueOptions(state, column);
 }
 
-export function columnContainsOnlyNumbers(data, column) {
-  return data.every(row => !isNaN(row[column]));
+export function containsOnlyNumbers(currentColumnData) {
+  return currentColumnData.every(cell => !isNaN(cell));
 }
 
 function isValidNumericalData(state, column) {
@@ -74,8 +74,7 @@ function getColumnData(data, column) {
   return data.map(row => row[column]);
 }
 
-export function getExtrema(data, column) {
-  const columnData = getColumnData(data, column);
+export function getExtrema(columnData) {
   let extrema = {};
   extrema.max = Math.max(...columnData);
   extrema.min = Math.min(...columnData);

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -60,11 +60,11 @@ export function isSelectable(state, column) {
   return isColumnDataValid(state, column) && !isSelected(state, column);
 }
 
-export function isColumnReadOnly(state, column) {
+export function isColumnReadOnly(metadata, column) {
   const metadataColumnType =
-    state.metadata &&
-    state.metadata.fields &&
-    state.metadata.fields.find(field => {
+    metadata &&
+    metadata.fields &&
+    metadata.fields.find(field => {
       return field.id === column;
     }).type;
   return !!metadataColumnType;

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -20,7 +20,7 @@ export function filterColumnsByType(columnsByDataType, columnType) {
   accurate models, and we don't want to overflow the metadata column for saved
   models.
 */
-export function hasTooManyUniqueOptions(uniqueOptionsCount) {
+export function tooManyUniqueOptions(uniqueOptionsCount) {
   return uniqueOptionsCount > UNIQUE_OPTIONS_MAX;
 }
 

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -10,6 +10,11 @@ export function isColumnNumerical(state, column) {
   return (state.columnsByDataType[column] === ColumnTypes.NUMERICAL);
 }
 
+export function filterColumnsByType(columnsByDataType, columnType) {
+  return Object.keys(columnsByDataType).filter(
+    column => columnsByDataType[column] === columnType
+  );
+}
 /*
   Categorical columns with too many unique values are unlikley to make
   accurate models, and we don't want to overflow the metadata column for saved

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -84,28 +84,23 @@ export function getExtrema(data, column) {
   return extrema;
 }
 
-export function getColumnDescription(state, columnId) {
-  if (!state || !columnId) {
-    return null;
-  }
-
+export function getColumnDescription(column, metadata, trainedModelDetails) {
   // Use metadata if available.
-  if (state.metadata && state.metadata.fields) {
-    const field = state.metadata.fields.find(field => {
-      return field.id === columnId;
+  if (metadata && metadata.fields) {
+    const field = metadata.fields.find(field => {
+      return field.id === column;
     });
     return field.description;
   }
 
   // Try using a user-entered column description if available.
-  if (!state.columns) {
-    return;
-  }
-  const matchedColumn = state.columns.find(column => {
-    return column.id === columnId;
-  });
-  if (matchedColumn) {
-    return matchedColumn.description;
+  if (trainedModelDetails && trainedModelDetails.columns) {
+    const matchedColumn = trainedModelDetails.columns.find(column => {
+      return column.id === column;
+    });
+    if (matchedColumn) {
+      return matchedColumn.description;
+    }
   }
 
   // No column description available.

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -17,6 +17,10 @@ export function areArraysEqual(array1, array2) {
   );
 }
 
+export function arrayIntersection(array1, array2) {
+  return array1.filter(value => array2.includes(value));
+}
+
 export function getRandomInt(max) {
   return Math.floor(Math.random() * Math.floor(max));
 }

--- a/src/helpers/valueConversion.js
+++ b/src/helpers/valueConversion.js
@@ -4,7 +4,7 @@
   likewise convert the returned integers back into human-readable strings.
 */
 import { isEmpty, getKeyByValue } from "./utils.js";
-import { getSelectedCategoricalColumns } from "../redux.js";
+import { getSelectedCategoricalColumns } from "../selectors.js";
 
 // Take a ML-friendly integer and convert to human-readable string.
 export function convertValueForDisplay(state, value, column) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -11,8 +11,6 @@ import {
 import {
   isColumnNumerical,
   isColumnCategorical,
-  isColumnReadOnly,
-  getColumnDescription,
   getColumnDataToSave,
 } from "./helpers/columnDetails.js";
 import { getUniqueOptionsLabelColumn } from "./selectors";
@@ -673,45 +671,6 @@ export function getPanelButtons(state) {
 
 export function readyToTrain(state) {
   return uniqLabelFeaturesSelected(state);
-}
-
-/* Functions for filtering and selecting columns by type.  */
-
-export function filterColumnsByType(columnsByDataType, columnType) {
-  return Object.keys(columnsByDataType).filter(
-    column => columnsByDataType[column] === columnType
-  );
-}
-
-function getCategoricalColumns(state) {
-  return filterColumnsByType(state.columnsByDataType, ColumnTypes.CATEGORICAL);
-}
-
-export function getSelectedCategoricalColumns(state) {
-  let intersection = getCategoricalColumns(state).filter(
-    x => state.selectedFeatures.includes(x) || x === state.labelColumn
-  );
-  return intersection;
-}
-
-function getSelectedColumns(state) {
-  return state.selectedFeatures
-    .concat(state.labelColumn)
-    .filter(column => column !== undefined && column !== "")
-    .map(columnId => {
-      return { id: columnId, readOnly: isColumnReadOnly(state.metadata, columnId) };
-    });
-}
-
-/* Functions for getting specific details about a batch of columns.  */
-
-export function getSelectedColumnDescriptions(state) {
-  return getSelectedColumns(state).map(column => {
-    return {
-      id: column.id,
-      description: getColumnDescription(state, column.id)
-    };
-  });
 }
 
 /* Functions for processing column data for visualizations. */

--- a/src/redux.js
+++ b/src/redux.js
@@ -22,7 +22,8 @@ import {
   getUniqueOptionsCurrentColumn,
   getUniqueOptionsLabelColumn,
   getExtremaCurrentColumn,
-  getOptionFrequenciesCurrentColumn
+  getOptionFrequenciesCurrentColumn,
+  isCurrentColumnReadOnly
 } from "./selectors";
 import { convertValueForDisplay } from "./helpers/valueConversion.js";
 import { areArraysEqual } from "./helpers/utils.js";
@@ -707,7 +708,7 @@ function getSelectedColumns(state) {
     .concat(state.labelColumn)
     .filter(column => column !== undefined && column !== "")
     .map(columnId => {
-      return { id: columnId, readOnly: isColumnReadOnly(state, columnId) };
+      return { id: columnId, readOnly: isColumnReadOnly(state.metadata, columnId) };
     });
 }
 
@@ -731,7 +732,7 @@ export function getCurrentColumnData(state) {
 
   const columnData = {
     id: state.currentColumn,
-    readOnly: isColumnReadOnly(state, state.currentColumn),
+    readOnly: isCurrentColumnReadOnly(state),
     dataType: state.columnsByDataType[state.currentColumn],
     description: getColumnDescription(state, state.currentColumn),
     isColumnDataValid: isColumnDataValid(state, state.currentColumn),

--- a/src/redux.js
+++ b/src/redux.js
@@ -13,18 +13,9 @@ import {
   isColumnCategorical,
   isColumnReadOnly,
   getColumnDescription,
-  hasTooManyUniqueOptions,
   getColumnDataToSave,
-  isSelectable,
-  isColumnDataValid
 } from "./helpers/columnDetails.js";
-import {
-  getUniqueOptionsCurrentColumn,
-  getUniqueOptionsLabelColumn,
-  getExtremaCurrentColumn,
-  getOptionFrequenciesCurrentColumn,
-  isCurrentColumnReadOnly
-} from "./selectors";
+import { getUniqueOptionsLabelColumn } from "./selectors";
 import { convertValueForDisplay } from "./helpers/valueConversion.js";
 import { areArraysEqual } from "./helpers/utils.js";
 import {
@@ -721,40 +712,6 @@ export function getSelectedColumnDescriptions(state) {
       description: getColumnDescription(state, column.id)
     };
   });
-}
-
-/* Functions for retrieving aggregate details about a currently selected column. */
-
-export function getCurrentColumnData(state) {
-  if (!state.currentColumn) {
-    return null;
-  }
-
-  const columnData = {
-    id: state.currentColumn,
-    readOnly: isCurrentColumnReadOnly(state),
-    dataType: state.columnsByDataType[state.currentColumn],
-    description: getCurrentColumnDescription(state),
-    isSelectable: isSelectable(state, state.currentColumn)
-  };
-
-  const isCategorical = columnData.dataType === ColumnTypes.CATEGORICAL;
-  const isNumerical = columnData.dataType === ColumnTypes.NUMERICAL;
-
-  if (isCategorical) {
-    const uniqueOptions = getUniqueOptionsCurrentColumn(state);
-    const hasTooManyUniqueOptions = hasTooManyUniqueOptions(
-      uniqueOptions.length
-    );
-    columnData.uniqueOptions = uniqueOptions;
-    columnData.hasTooManyUniqueOptions = hasTooManyUniqueOptions,
-    columnData.isColumnDataValid = !hasTooManyUniqueOptions,
-    columnData.frequencies = getOptionFrequenciesCurrentColumn(state)
-  } else if (isNumerical) {
-    columnData.extrema = getExtremaCurrentColumn(state);
-    columnData.isColumnDataValid = columnContainsOnlyNumbers(stata.data, state.currentColumn)
-  }
-  return columnData;
 }
 
 /* Functions for processing column data for visualizations. */

--- a/src/redux.js
+++ b/src/redux.js
@@ -734,8 +734,7 @@ export function getCurrentColumnData(state) {
     id: state.currentColumn,
     readOnly: isCurrentColumnReadOnly(state),
     dataType: state.columnsByDataType[state.currentColumn],
-    description: getColumnDescription(state, state.currentColumn),
-    isColumnDataValid: isColumnDataValid(state, state.currentColumn),
+    description: getCurrentColumnDescription(state),
     isSelectable: isSelectable(state, state.currentColumn)
   };
 
@@ -744,13 +743,16 @@ export function getCurrentColumnData(state) {
 
   if (isCategorical) {
     const uniqueOptions = getUniqueOptionsCurrentColumn(state);
-    columnData.uniqueOptions = uniqueOptions;
-    columnData.hasTooManyUniqueOptions = hasTooManyUniqueOptions(
+    const hasTooManyUniqueOptions = hasTooManyUniqueOptions(
       uniqueOptions.length
     );
+    columnData.uniqueOptions = uniqueOptions;
+    columnData.hasTooManyUniqueOptions = hasTooManyUniqueOptions,
+    columnData.isColumnDataValid = !hasTooManyUniqueOptions,
     columnData.frequencies = getOptionFrequenciesCurrentColumn(state)
   } else if (isNumerical) {
     columnData.extrema = getExtremaCurrentColumn(state);
+    columnData.isColumnDataValid = columnContainsOnlyNumbers(stata.data, state.currentColumn)
   }
   return columnData;
 }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,23 +1,19 @@
 import { createSelector } from 'reselect';
 import { ColumnTypes } from "./constants.js";
 import {
+  filterColumnsByType,
   getUniqueOptions,
   getExtrema,
-  isColumnReadOnly,
-  getColumnDescription,
-  hasTooManyUniqueOptions,
-  containsOnlyNumbers,
-  filterColumnsByType
-} from './helpers/columnDetails';
+  getColumnDescription
+ } from './helpers/columnDetails';
 import { arrayIntersection } from './helpers/utils';
 
-const getData = state => state.data;
-const getColumnsByDataType = state => state.columnsByDataType;
+export const getData = state => state.data;
+export const getColumnsByDataType = state => state.columnsByDataType;
 const getSelectedFeatures = state => state.selectedFeatures;
 const getLabelColumn = state => state.labelColumn;
-const getCurrentColumn = state => state.currentColumn;
-const getMetadata = state => state.metadata;
-const getTrainedModelDetails = state => state.trainedModelDetails;
+export const getMetadata = state => state.metadata;
+export const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -87,28 +83,6 @@ export const getUniqueOptionsLabelColumn = createSelector(
   }
 )
 
-export const getUniqueOptionsCurrentColumn = createSelector(
-  [getCurrentColumn, getData],
-  (currentColumn, data) => {
-    return getUniqueOptions(data, currentColumn).sort()
-  }
-)
-
-export const getOptionFrequenciesCurrentColumn = createSelector(
-  [getCurrentColumn, getData],
-  (currentColumn, data) => {
-    let optionFrequencies = {};
-    for (let row of data) {
-      if (optionFrequencies[row[currentColumn]]) {
-        optionFrequencies[row[currentColumn]]++;
-      } else {
-        optionFrequencies[row[currentColumn]] = 1;
-      }
-    }
-    return optionFrequencies;
-  }
-)
-
 export const getExtremaByColumn = createSelector(
   [getSelectedNumericalColumns, getData],
   (getSelectedNumericalColumns, data) => {
@@ -117,34 +91,6 @@ export const getExtremaByColumn = createSelector(
       extremaByColumn[column] = getExtrema(data, column)
     ))
     return extremaByColumn;
-  }
-)
-
-export const getCurrentColumnData = createSelector(
-  [getCurrentColumn, getData],
-  (currentColumn, data) => {
-    return data.map(row => row[currentColumn]);
-  }
-)
-
-export const getExtremaCurrentColumn = createSelector(
-  [getCurrentColumn, getData],
-  (currentColumn, data) => {
-    return getExtrema(data, currentColumn);
-  }
-)
-
-export const isCurrentColumnReadOnly = createSelector(
-  [getCurrentColumn, getMetadata],
-  (currentColumn, metadata) => {
-    return isColumnReadOnly(metadata, currentColumn)
-  }
-)
-
-export const getCurrentColumnDescription = createSelector(
-  [getCurrentColumn, getMetadata, getTrainedModelDetails],
-  (currentColumn, metadata, trainedModelDetails) => {
-    return getColumnDescription(currentColumn, metadata, trainedModelDetails);
   }
 )
 
@@ -161,113 +107,5 @@ export const getSelectedColumnsDescriptions = createSelector(
         )
       };
     });
-  }
-)
-
-export const isCurrentColumnSelectable = createSelector(
-  [getSelectedColumns, getCurrentColumn],
-  (selectedColumns, currentColumn) => {
-    return !selectedColumns.includes(currentColumn);
-  }
-)
-
-export const currentColumnContainsOnlyNumbers = createSelector(
-  [getCurrentColumn, getData],
-  (currentColumn, data) => {
-    return containsOnlyNumbers(data, currentColumn);
-  }
-)
-
-export const currentColumnHasTooManyUniqueOptions = createSelector(
-  [getUniqueOptionsCurrentColumn],
-  (uniqueOptionsCurrentColumn) => {
-    return hasTooManyUniqueOptions(uniqueOptionsCurrentColumn.length);
-  }
-)
-
-export const currentColumnIsCategorical = createSelector(
-  [getCurrentColumn, getColumnsByDataType],
-  (currentColumn, columnsByDataType) => {
-    return columnsByDataType[currentColumn] === ColumnTypes.CATEGORICAL;
-  }
-)
-
-export const getCategoricalColumnDetails = createSelector(
-  [
-    getCurrentColumn,
-    currentColumnIsCategorical,
-    getUniqueOptionsCurrentColumn,
-    getOptionFrequenciesCurrentColumn
-  ],
-  (
-    currentColumn,
-    isCategorical,
-    uniqueOptions,
-    uniqueOptionFrequencies
-  ) => {
-    const categeoricalColumnDetails = {};
-    categeoricalColumnDetails.id = currentColumn;
-    if (isCategorical) {
-      categeoricalColumnDetails.uniqueOptions = uniqueOptions;
-      categeoricalColumnDetails.frequencies = uniqueOptionFrequencies;
-    }
-    return categeoricalColumnDetails;
-  }
-)
-
-export const currentColumnIsNumerical = createSelector(
-  [getCurrentColumn, getColumnsByDataType],
-  (currentColumn, columnsByDataType) => {
-    return columnsByDataType[currentColumn] === ColumnTypes.NUMERICAL;
-  }
-)
-
-export const getNumericalColumnDetails = createSelector(
-  [
-    getCurrentColumn,
-    currentColumnIsNumerical,
-    getExtremaCurrentColumn,
-    currentColumnContainsOnlyNumbers
-  ],
-  (
-    currentColumn,
-    isNumerical,
-    extrema,
-    containsOnlyNumbers
-  ) => {
-    const numericalColumnDetails = {};
-    numericalColumnDetails.id = currentColumn;
-    if (isNumerical) {
-      numericalColumnDetails.extrema = extrema;
-      numericalColumnDetails.containsOnlyNumbers = containsOnlyNumbers;
-    }
-    return numericalColumnDetails;
-  }
-)
-
-export const getCurrentColumnDetails = createSelector(
-  [
-    getCurrentColumn,
-    isCurrentColumnReadOnly,
-    getColumnsByDataType,
-    getCurrentColumnDescription,
-    isCurrentColumnSelectable
-  ],
-  (
-    currentColumn,
-    isReadOnly,
-    columnsByDataType,
-    description,
-    isSelectable
-  ) => {
-    if (currentColumn) {
-      return {
-        id: currentColumn,
-        readOnly: isReadOnly,
-        dataType: columnsByDataType[currentColumn],
-        description: description,
-        isSelectable: isSelectable
-      };
-    }
   }
 )

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -6,10 +6,10 @@ import {
   isColumnReadOnly,
   getColumnDescription,
   hasTooManyUniqueOptions,
-  containsOnlyNumbers
+  containsOnlyNumbers,
+  filterColumnsByType
 } from './helpers/columnDetails';
 import { arrayIntersection } from './helpers/utils';
-import { filterColumnsByType } from './redux';
 
 const getData = state => state.data;
 const getColumnsByDataType = state => state.columnsByDataType;

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,6 +1,11 @@
 import { createSelector } from 'reselect';
 import { ColumnTypes } from "./constants.js";
-import { getUniqueOptions, getExtrema } from './helpers/columnDetails';
+import {
+  getUniqueOptions,
+  getExtrema,
+  isColumnReadOnly
+} from './helpers/columnDetails';
+import { arrayIntersection } from './helpers/utils';
 import { filterColumnsByType } from './redux';
 
 const getData = state => state.data;
@@ -8,6 +13,7 @@ const getColumnsByDataType = state => state.columnsByDataType;
 const getSelectedFeatures = state => state.selectedFeatures;
 const getLabelColumn = state => state.labelColumn;
 const getCurrentColumn = state => state.currentColumn;
+const getMetadata = state => state.metadata;
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -16,21 +22,25 @@ export const getCategoricalColumns = createSelector(
   }
 )
 
+export const getSelectedColumns = createSelector(
+  [getSelectedFeatures, getLabelColumn],
+  (selectedFeatures, labelColumn) => {
+    selectedFeatures.push(labelColumn)
+    return selectedFeatures;
+  }
+)
+
 export const getSelectedCategoricalColumns = createSelector(
-  [getCategoricalColumns, getSelectedFeatures, getLabelColumn],
-  (categoricalColumns, selectedFeatures, labelColumn) => {
-    return categoricalColumns.filter(
-      column => (selectedFeatures.includes(column) || column === labelColumn)
-    );
+  [getCategoricalColumns, getSelectedColumns],
+  (categoricalColumns, selectedColumns) => {
+    return arrayIntersection(categoricalColumns, selectedColumns);
   }
 )
 
 export const getSelectedCategoricalFeatures = createSelector(
   [getCategoricalColumns, getSelectedFeatures],
   (categoricalColumns, selectedFeatures) => {
-    return categoricalColumns.filter(
-      column => selectedFeatures.includes(column)
-    );
+    return arrayIntersection(categoricalColumns, selectedFeatures);
   }
 )
 
@@ -42,20 +52,16 @@ export const getNumericalColumns = createSelector(
 )
 
 export const getSelectedNumericalColumns = createSelector(
-  [getNumericalColumns, getSelectedFeatures, getLabelColumn],
-  (numericalColumns, selectedFeatures, labelColumn) => {
-    return numericalColumns.filter(
-      column => (selectedFeatures.includes(column) || column === labelColumn)
-    )
+  [getNumericalColumns, getSelectedColumns],
+  (numericalColumns, selectedColumns) => {
+    return arrayIntersection(numericalColumns, selectedColumns);
   }
 )
 
 export const getSelectedNumericalFeatures = createSelector(
   [getNumericalColumns, getSelectedFeatures],
   (numericalColumns, selectedFeatures) => {
-    return numericalColumns.filter(
-      column => selectedFeatures.includes(column)
-    );
+    return arrayIntersection(numericalColumns, selectedFeatures);
   }
 )
 
@@ -116,3 +122,34 @@ export const getExtremaCurrentColumn = createSelector(
     return getExtrema(data, currentColumn);
   }
 )
+
+export const isCurrentColumnReadOnly = createSelector(
+  [getCurrentColumn, getMetadata],
+  (currentColumn, metadata) => {
+    return isColumnReadOnly(metadata, currentColumn)
+  }
+)
+
+// export const getCurrentColumnData = createSelector(
+//   [
+//     getCurrentColumn,
+//     isCurrentColumnReadOnly,
+//     getColumnsByDataType,
+//     getCurrentColumnDescription,
+//     isCurrentColumnValid,
+//     isCurrentColumnSelectable,
+//     getUniqueOptionsCurrentColumn,
+//     getOptionFrequenciesCurrentColumn,
+//     getExtremaCurrentColumn
+//   ],
+//   (
+//     currentColumn,
+//     isReadOnly,
+//     columnsByDataType,
+//     description,
+//     isValid,
+//     isSelectable,
+//     uniqueOptions,
+//     extrema
+//   )
+// )

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -3,7 +3,8 @@ import { ColumnTypes } from "./constants.js";
 import {
   getUniqueOptions,
   getExtrema,
-  isColumnReadOnly
+  isColumnReadOnly,
+  getColumnDescription
 } from './helpers/columnDetails';
 import { arrayIntersection } from './helpers/utils';
 import { filterColumnsByType } from './redux';
@@ -14,6 +15,7 @@ const getSelectedFeatures = state => state.selectedFeatures;
 const getLabelColumn = state => state.labelColumn;
 const getCurrentColumn = state => state.currentColumn;
 const getMetadata = state => state.metadata;
+const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -127,6 +129,29 @@ export const isCurrentColumnReadOnly = createSelector(
   [getCurrentColumn, getMetadata],
   (currentColumn, metadata) => {
     return isColumnReadOnly(metadata, currentColumn)
+  }
+)
+
+export const getCurrentColumnDescription = createSelector(
+  [getCurrentColumn, getMetadata, getTrainedModelDetails],
+  (currentColumn, metadata, trainedModelDetails) => {
+    return getColumnDescription(currentColumn, metadata, trainedModelDetails);
+  }
+)
+
+export const getSelectedColumnsDescriptions = createSelector(
+  [getSelectedColumns, getMetadata, getTrainedModelDetails],
+  (selectedColumns, metadata, trainedModelDetails) => {
+    return selectedColumns.map(column => {
+      return {
+        id: column,
+        description: getColumnDescription(
+          column,
+          metadata,
+          trainedModelDetails
+        )
+      };
+    });
   }
 )
 

--- a/src/selectors/currentColumnSelectors.js
+++ b/src/selectors/currentColumnSelectors.js
@@ -4,7 +4,7 @@ import {
   getExtrema,
   isColumnReadOnly,
   getColumnDescription,
-  hasTooManyUniqueOptions,
+  tooManyUniqueOptions,
   containsOnlyNumbers
 } from '../helpers/columnDetails';
 import {
@@ -189,9 +189,16 @@ export const currentColumnIsCategorical = createSelector(
   }
 )
 
+export const hasTooManyUniqueOptions = createSelector(
+  [getUniqueOptionsCurrentColumn, currentColumnIsCategorical],
+  (uniqueOptions, isCategorical) => {
+    return isCategorical && tooManyUniqueOptions(uniqueOptions.length);
+  }
+)
+
 export const isValidCategoricalData = createSelector(
-  [currentColumnIsCategorical, hasTooManyUniqueOptions],
-  (isCategorical, hasTooManyUniqueOptions) => {
-    return isCategorical && !hasTooManyUniqueOptions;
+  [currentColumnIsCategorical, getUniqueOptionsCurrentColumn],
+  (isCategorical, uniqueOptions) => {
+    return isCategorical && !tooManyUniqueOptions(uniqueOptions.length);
   }
 )

--- a/src/selectors/currentColumnSelectors.js
+++ b/src/selectors/currentColumnSelectors.js
@@ -1,0 +1,197 @@
+import { createSelector } from 'reselect';
+import {
+  getUniqueOptions,
+  getExtrema,
+  isColumnReadOnly,
+  getColumnDescription,
+  hasTooManyUniqueOptions,
+  containsOnlyNumbers
+} from '../helpers/columnDetails';
+import {
+  getSelectedColumns,
+  getData,
+  getColumnsByDataType,
+  getMetadata,
+  getTrainedModelDetails
+ } from '../selectors';
+import { ColumnTypes } from "../constants.js";
+
+const getCurrentColumn = state => state.currentColumn;
+
+export const getCurrentColumnDetails = createSelector(
+  [
+    getCurrentColumn,
+    (state, props) => isCurrentColumnReadOnly(state, props),
+    getColumnsByDataType,
+    (state, props) => getCurrentColumnDescription(state, props),
+    (state, props) => isCurrentColumnSelectable(state, props)
+  ],
+  (
+    currentColumn,
+    isReadOnly,
+    columnsByDataType,
+    description,
+    isSelectable
+  ) => {
+    if (currentColumn) {
+      return {
+        id: currentColumn,
+        readOnly: isReadOnly,
+        dataType: columnsByDataType[currentColumn],
+        description: description,
+        isSelectable: isSelectable
+      };
+    }
+  }
+)
+
+export const isCurrentColumnReadOnly = createSelector(
+  [getCurrentColumn, getMetadata],
+  (currentColumn, metadata) => {
+    return isColumnReadOnly(metadata, currentColumn)
+  }
+)
+
+export const getCurrentColumnDescription = createSelector(
+  [getCurrentColumn, getMetadata, getTrainedModelDetails],
+  (currentColumn, metadata, trainedModelDetails) => {
+    return getColumnDescription(currentColumn, metadata, trainedModelDetails);
+  }
+)
+
+export const isCurrentColumnSelectable = createSelector(
+  [
+    (state, props) => isCurrentColumnSelected(state, props),
+    (state, props) => isValidData(state, props)
+  ],
+  (selected, isValidData) => {
+    return !selected && isValidData;
+  }
+)
+
+export const isCurrentColumnSelected = createSelector(
+  [getSelectedColumns, getCurrentColumn],
+  (selectedColumns, currentColumn) => {
+    return selectedColumns.includes(currentColumn);
+  }
+)
+
+export const isValidData = createSelector(
+  [
+    (state, props) => isValidNumericalData(state, props),
+    (state, props) => isValidCategoricalData(state, props)
+  ],
+  (isValidNumericalData, isValidCategoricalData) => {
+    return isValidNumericalData || isValidCategoricalData;
+  }
+)
+
+export const getNumericalColumnDetails = createSelector(
+  [
+    getCurrentColumn,
+    (state, props) => currentColumnIsNumerical(state, props),
+    (state, props) => getExtremaCurrentColumn(state, props),
+    (state, props) => currentColumnContainsOnlyNumbers(state, props)
+  ],
+  (
+    currentColumn,
+    isNumerical,
+    extrema,
+    containsOnlyNumbers
+  ) => {
+    const numericalColumnDetails = {};
+    numericalColumnDetails.id = currentColumn;
+    if (isNumerical) {
+      numericalColumnDetails.extrema = extrema;
+      numericalColumnDetails.containsOnlyNumbers = containsOnlyNumbers;
+    }
+    return numericalColumnDetails;
+  }
+)
+
+export const currentColumnIsNumerical = createSelector(
+  [getCurrentColumn, getColumnsByDataType],
+  (currentColumn, columnsByDataType) => {
+    return columnsByDataType[currentColumn] === ColumnTypes.NUMERICAL;
+  }
+)
+
+export const getExtremaCurrentColumn = createSelector(
+  [getCurrentColumn, getData],
+  (currentColumn, data) => {
+    return getExtrema(data, currentColumn);
+  }
+)
+
+export const currentColumnContainsOnlyNumbers = createSelector(
+  [getCurrentColumn, getData],
+  (currentColumn, data) => {
+    return containsOnlyNumbers(data, currentColumn);
+  }
+)
+
+export const isValidNumericalData = createSelector(
+  [currentColumnIsNumerical, currentColumnContainsOnlyNumbers],
+  (isNumerical, containsOnlyNumbers) => {
+    return isNumerical && containsOnlyNumbers;
+  }
+)
+
+export const getCategoricalColumnDetails = createSelector(
+  [
+    getCurrentColumn,
+    (state, props) => currentColumnIsCategorical(state, props),
+    (state, props) => getUniqueOptionsCurrentColumn(state, props),
+    (state, props) => getOptionFrequenciesCurrentColumn(state, props)
+  ],
+  (
+    currentColumn,
+    isCategorical,
+    uniqueOptions,
+    uniqueOptionFrequencies
+  ) => {
+    const categeoricalColumnDetails = {};
+    categeoricalColumnDetails.id = currentColumn;
+    if (isCategorical) {
+      categeoricalColumnDetails.uniqueOptions = uniqueOptions;
+      categeoricalColumnDetails.frequencies = uniqueOptionFrequencies;
+    }
+    return categeoricalColumnDetails;
+  }
+)
+
+export const getUniqueOptionsCurrentColumn = createSelector(
+  [getCurrentColumn, getData],
+  (currentColumn, data) => {
+    return getUniqueOptions(data, currentColumn).sort()
+  }
+)
+
+export const getOptionFrequenciesCurrentColumn = createSelector(
+  [getCurrentColumn, getData],
+  (currentColumn, data) => {
+    let optionFrequencies = {};
+    for (let row of data) {
+      if (optionFrequencies[row[currentColumn]]) {
+        optionFrequencies[row[currentColumn]]++;
+      } else {
+        optionFrequencies[row[currentColumn]] = 1;
+      }
+    }
+    return optionFrequencies;
+  }
+)
+
+export const currentColumnIsCategorical = createSelector(
+  [getCurrentColumn, getColumnsByDataType],
+  (currentColumn, columnsByDataType) => {
+    return columnsByDataType[currentColumn] === ColumnTypes.CATEGORICAL;
+  }
+)
+
+export const isValidCategoricalData = createSelector(
+  [currentColumnIsCategorical, hasTooManyUniqueOptions],
+  (isCategorical, hasTooManyUniqueOptions) => {
+    return isCategorical && !hasTooManyUniqueOptions;
+  }
+)

--- a/src/train.js
+++ b/src/train.js
@@ -4,13 +4,13 @@ import KNNTrainer from "./trainers/KNNTrainer";
 
 import { buildOptionNumberKey } from "./helpers/columnDetails.js";
 import {
-  getSelectedCategoricalColumns,
   setFeatureNumberKey,
   setTrainingExamples,
   setTrainingLabels,
   setAccuracyCheckExamples,
   setAccuracyCheckLabels
 } from "./redux";
+import { getSelectedCategoricalColumns } from "./selectors";
 import {
   TestDataLocations,
   PERCENT_OF_DATASET_FOR_TESTING

--- a/test/unit/currentColumnSelectors.test.js
+++ b/test/unit/currentColumnSelectors.test.js
@@ -3,7 +3,8 @@ import {
   getUniqueOptionsCurrentColumn,
   getExtremaCurrentColumn,
   getOptionFrequenciesCurrentColumn,
-  isCurrentColumnReadOnly
+  isCurrentColumnReadOnly,
+  currentColumnContainsOnlyNumbers
 } from "../../src/selectors/currentColumnSelectors";
 import {
   classificationState,
@@ -11,7 +12,7 @@ import {
   premadeDatasetState
 } from "./testData";
 
-describe("derives details about current column", () => {
+describe("derives details about current categorical column", () => {
   test("gets unique options current column", async () => {
     const uniqueOptions = getUniqueOptionsCurrentColumn.resultFunc(
       classificationState.currentColumn,
@@ -28,6 +29,16 @@ describe("derives details about current column", () => {
     expect(optionFrequencies).toEqual({ hot: 2, mild: 2, cool: 2 });
   });
 
+  test("current column does not contain only numbers", () => {
+    const containsOnlyNumbers = currentColumnContainsOnlyNumbers.resultFunc(
+      classificationState.currentColumn,
+      classificationState.data
+    )
+    expect(containsOnlyNumbers).toBe(false);
+  })
+});
+
+describe("derives details about current numerical column", () => {
   test("gets extrema current column", async () => {
     const extrema = getExtremaCurrentColumn.resultFunc(
       allNumericalState.currentColumn,
@@ -37,9 +48,17 @@ describe("derives details about current column", () => {
     expect(extrema.min).toBe(40);
     expect(extrema.range).toBe(60);
   });
+
+  test("current column contains only numbers", () => {
+    const containsOnlyNumbers = currentColumnContainsOnlyNumbers.resultFunc(
+      allNumericalState.currentColumn,
+      allNumericalState.data
+    )
+    expect(containsOnlyNumbers).toBe(true);
+  })
 });
 
-describe("is current column readOnly", () => {
+describe("derives details about current column", () => {
   test("current column is readOnly", async () => {
     const isReadOnly = isCurrentColumnReadOnly.resultFunc(
       premadeDatasetState.currentColumn,

--- a/test/unit/currentColumnSelectors.test.js
+++ b/test/unit/currentColumnSelectors.test.js
@@ -1,0 +1,58 @@
+import { getSelectedColumns } from "../../src/selectors.js";
+import {
+  getUniqueOptionsCurrentColumn,
+  getExtremaCurrentColumn,
+  getOptionFrequenciesCurrentColumn,
+  isCurrentColumnReadOnly
+} from "../../src/selectors/currentColumnSelectors";
+import {
+  classificationState,
+  allNumericalState,
+  premadeDatasetState
+} from "./testData";
+
+describe("derives details about current column", () => {
+  test("gets unique options current column", async () => {
+    const uniqueOptions = getUniqueOptionsCurrentColumn.resultFunc(
+      classificationState.currentColumn,
+      classificationState.data
+    )
+    expect(uniqueOptions).toEqual(['cool', 'hot', 'mild']);
+  });
+
+  test("gets option frequencies current column", async () => {
+    const optionFrequencies = getOptionFrequenciesCurrentColumn.resultFunc(
+      classificationState.currentColumn,
+      classificationState.data
+    )
+    expect(optionFrequencies).toEqual({ hot: 2, mild: 2, cool: 2 });
+  });
+
+  test("gets extrema current column", async () => {
+    const extrema = getExtremaCurrentColumn.resultFunc(
+      allNumericalState.currentColumn,
+      allNumericalState.data
+    )
+    expect(extrema.max).toBe(100);
+    expect(extrema.min).toBe(40);
+    expect(extrema.range).toBe(60);
+  });
+});
+
+describe("is current column readOnly", () => {
+  test("current column is readOnly", async () => {
+    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
+      premadeDatasetState.currentColumn,
+      premadeDatasetState.metadata
+    )
+    expect(isReadOnly).toBe(true)
+  });
+
+  test("current column is not readOnly", async () => {
+    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
+      allNumericalState.currentColumn,
+      allNumericalState.metadata
+    )
+    expect(isReadOnly).toBe(false)
+  });
+});

--- a/test/unit/selectors.test.js
+++ b/test/unit/selectors.test.js
@@ -1,4 +1,5 @@
 import {
+  getSelectedColumns,
   getCategoricalColumns,
   getSelectedCategoricalColumns,
   getSelectedCategoricalFeatures,
@@ -10,9 +11,14 @@ import {
   getUniqueOptionsCurrentColumn,
   getExtremaByColumn,
   getExtremaCurrentColumn,
-  getOptionFrequenciesCurrentColumn
+  getOptionFrequenciesCurrentColumn,
+  isCurrentColumnReadOnly
 } from "../../src/selectors";
-import { classificationState, allNumericalState } from "./testData";
+import {
+  classificationState,
+  allNumericalState,
+  premadeDatasetState
+} from "./testData";
 
 describe("selecting columns by data type", () => {
   test("gets selected categorical features", async () => {
@@ -40,11 +46,14 @@ describe("getting category options", () => {
   test("gets unique options by column", async () => {
     const categoricalColumns = getCategoricalColumns
       .resultFunc(classificationState.columnsByDataType).sort();
+    const selectedColumns = getSelectedColumns.resultFunc(
+      classificationState.selectedFeatures,
+      classificationState.labelColumn
+    )
     const selectedCategoricalColumns =
       getSelectedCategoricalColumns.resultFunc(
         categoricalColumns,
-        classificationState.selectedFeatures,
-        classificationState.labelColumn
+        selectedColumns
       )
     const uniqueOptionsByColumn =
       getUniqueOptionsByColumn.resultFunc(
@@ -88,10 +97,13 @@ describe("getting extrema", () => {
   test("gets extrema by column", async () => {
     const numericalColumns = getNumericalColumns
       .resultFunc(allNumericalState.columnsByDataType);
-    const selectedNumericalColumns =  getSelectedNumericalColumns.resultFunc(
-      numericalColumns,
+    const selectedColumns = getSelectedColumns.resultFunc(
       allNumericalState.selectedFeatures,
       allNumericalState.labelColumn
+    )
+    const selectedNumericalColumns =  getSelectedNumericalColumns.resultFunc(
+      numericalColumns,
+      selectedColumns
     )
     const extremaByColumn =
       getExtremaByColumn.resultFunc(
@@ -114,5 +126,23 @@ describe("getting extrema", () => {
     expect(extrema.max).toBe(100);
     expect(extrema.min).toBe(40);
     expect(extrema.range).toBe(60);
+  });
+});
+
+describe("is current column readOnly", () => {
+  test("current column is readOnly", async () => {
+    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
+      premadeDatasetState.currentColumn,
+      premadeDatasetState.metadata
+    )
+    expect(isReadOnly).toBe(true)
+  });
+
+  test("current column is not readOnly", async () => {
+    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
+      allNumericalState.currentColumn,
+      allNumericalState.metadata
+    )
+    expect(isReadOnly).toBe(false)
   });
 });

--- a/test/unit/selectors.test.js
+++ b/test/unit/selectors.test.js
@@ -8,11 +8,7 @@ import {
   getSelectedNumericalFeatures,
   getUniqueOptionsByColumn,
   getUniqueOptionsLabelColumn,
-  getUniqueOptionsCurrentColumn,
-  getExtremaByColumn,
-  getExtremaCurrentColumn,
-  getOptionFrequenciesCurrentColumn,
-  isCurrentColumnReadOnly
+  getExtremaByColumn
 } from "../../src/selectors";
 import {
   classificationState,
@@ -74,23 +70,6 @@ describe("getting category options", () => {
     )
     expect(uniqueOptions).toEqual(['no', 'yes']);
   });
-
-  test("gets unique options current column", async () => {
-    const uniqueOptions = getUniqueOptionsCurrentColumn.resultFunc(
-      classificationState.currentColumn,
-      classificationState.data
-    )
-    expect(uniqueOptions).toEqual(['cool', 'hot', 'mild']);
-  });
-
-  test("gets option frequencies current column", async () => {
-    const optionFrequencies = getOptionFrequenciesCurrentColumn.resultFunc(
-      classificationState.currentColumn,
-      classificationState.data
-    )
-    expect(optionFrequencies).toEqual({ hot: 2, mild: 2, cool: 2 });
-  });
-
 });
 
 describe("getting extrema", () => {
@@ -116,33 +95,5 @@ describe("getting extrema", () => {
     expect(extremaByColumn['mosquitoCount'].max).toBe(10);
     expect(extremaByColumn['mosquitoCount'].min).toBe(1);
     expect(extremaByColumn['mosquitoCount'].range).toBe(9);
-  });
-
-  test("gets extrema current column", async () => {
-    const extrema = getExtremaCurrentColumn.resultFunc(
-      allNumericalState.currentColumn,
-      allNumericalState.data
-    )
-    expect(extrema.max).toBe(100);
-    expect(extrema.min).toBe(40);
-    expect(extrema.range).toBe(60);
-  });
-});
-
-describe("is current column readOnly", () => {
-  test("current column is readOnly", async () => {
-    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
-      premadeDatasetState.currentColumn,
-      premadeDatasetState.metadata
-    )
-    expect(isReadOnly).toBe(true)
-  });
-
-  test("current column is not readOnly", async () => {
-    const isReadOnly = isCurrentColumnReadOnly.resultFunc(
-      allNumericalState.currentColumn,
-      allNumericalState.metadata
-    )
-    expect(isReadOnly).toBe(false)
   });
 });

--- a/test/unit/testData.js
+++ b/test/unit/testData.js
@@ -140,3 +140,23 @@ export const allNumericalState = {
     mosquitoCount: 'numerical'
   }
 };
+
+export const premadeDatasetState = {
+  ...allNumericalState,
+  metadata: {
+    name: 'bats_eat_mozzies',
+    defaultLabelColumn: 'mosquitoCount',
+    fields: [
+      {
+        id: 'mosquitoCount',
+        type: 'numerical',
+        description: 'How many mosquitoes there are.'
+      },
+      {
+        id: 'batCount',
+        type: 'numerical',
+        description: 'How many bats there are.'
+      }
+    ]
+  }
+}

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -2,6 +2,7 @@ import {
   isEmpty,
   getKeyByValue,
   areArraysEqual,
+  arrayIntersection,
   getRandomInt
 } from '../../src/helpers/utils.js';
 
@@ -10,6 +11,8 @@ const menu = {
   lunch: "sushi",
   dinner: "lasagna"
 };
+
+const flavors = ["chocolate", "vanilla", "strawberry"];
 
 describe("isEmpty", () => {
   test("empty", async () => {
@@ -36,8 +39,6 @@ describe("getKeyByValue", () => {
 });
 
 describe("areArraysEqual", () => {
-  const flavors = ["chocolate", "vanilla", "strawberry"];
-
   test("equal", async () => {
     const result = areArraysEqual(flavors, flavors);
     expect(result).toBe(true);
@@ -52,6 +53,20 @@ describe("areArraysEqual", () => {
   test("not equal", async () => {
     const result = areArraysEqual(flavors, []);
     expect(result).toBe(false);
+  });
+});
+
+describe("arrayIntersection", () => {
+  test("element in both", async () => {
+    const berries = ["strawberry", "raspberry"]
+    const result = arrayIntersection(flavors, berries);
+    expect(result).toEqual(["strawberry"]);
+  });
+
+  test("no intersection", async () => {
+    const empty = [];
+    const result = arrayIntersection(flavors, empty);
+    expect(result).toEqual(empty);
   });
 });
 


### PR DESCRIPTION
Continuation of #251 and #243 

- extracts `UniqueOptionsWarning` from `ColumnInspector` 
- connects `ColumnDetailsCategorical` and `ColumnDetailsNumerical`
- changes "currentColumnData" to "currentColumnDetails"  in `ColumnInspector` to avoid confusion with the actual data from the dataset stored in a column 
- moves a bunch of redux and columnDetails functions into the new `currentColumnsSelectors` file 
- initial tests for `currentColumnsSelectors` 