### PR TITLE
Save model form and Model Card updates 

### DIFF
--- a/src/UIComponents/ModelCard.jsx
+++ b/src/UIComponents/ModelCard.jsx
@@ -45,21 +45,39 @@ class ModelCard extends Component {
         <div style={styles.modelCardContainer}>
           <h3 style={styles.modelCardHeader}>{trainedModelDetails.name}</h3>
           <div style={styles.modelCardSubpanel}>
-            <h5 style={styles.modelCardHeading}>Summary</h5>
+            <h5 style={styles.modelCardHeading}>Accuracy</h5>
             <div style={styles.modelCardContent}>
               <p style={styles.modelCardDetails}>
-                Predict {label.id} based on{" "}
-                {selectedFeatures.length > 0 && percentCorrect && (
+                {percentCorrect && (
                   <span>
-                    {selectedFeatures.join(", ")} with {percentCorrect}%
-                    accuracy.
+                    {percentCorrect}%
                   </span>
                 )}
               </p>
             </div>
           </div>
           <div style={styles.modelCardSubpanel}>
-            <h5 style={styles.modelCardHeading}>About the Data </h5>
+            <h5 style={styles.modelCardHeading}>Intended Use</h5>
+            <div style={styles.modelCardContent}>
+              {trainedModelDetails.potentialUses && (
+                <p style={styles.modelCardDetails}>
+                  {trainedModelDetails.potentialUses}
+                </p>
+              )}
+            </div>
+          </div>
+          <div style={styles.modelCardSubpanel}>
+            <h5 style={styles.modelCardHeading}>Limitations and Warnings</h5>
+            <div style={styles.modelCardContent}>
+              {trainedModelDetails.potentialMisuses && (
+                <p style={styles.modelCardDetails}>
+                  {trainedModelDetails.potentialMisuses}
+                </p>
+              )}
+            </div>
+          </div>
+          <div style={styles.modelCardSubpanel}>
+            <h5 style={styles.modelCardHeading}>About the Data</h5>
             <div style={styles.modelCardContent}>
               {datasetDetails.description && (
                 <p style={styles.modelCardDetails}>
@@ -74,23 +92,16 @@ class ModelCard extends Component {
             </div>
           </div>
           <div style={styles.modelCardSubpanel}>
-            <h5 style={styles.modelCardHeading}>Intended Use</h5>
+            <h5 style={styles.modelCardHeading}>Features and Label</h5>
             <div style={styles.modelCardContent}>
-              {trainedModelDetails.potentialUses && (
-                <p style={styles.modelCardDetails}>
-                  {trainedModelDetails.potentialUses}
-                </p>
-              )}
-            </div>
-          </div>
-          <div style={styles.modelCardSubpanel}>
-            <h5 style={styles.modelCardHeading}>Warnings</h5>
-            <div style={styles.modelCardContent}>
-              {trainedModelDetails.potentialMisuses && (
-                <p style={styles.modelCardDetails}>
-                  {trainedModelDetails.potentialMisuses}
-                </p>
-              )}
+              <p style={styles.modelCardDetails}>
+                Predict {label.id} based on{" "}
+                {selectedFeatures.length > 0 && (
+                  <span>
+                    {selectedFeatures.join(", ")}.
+                  </span>
+                )}
+              </p>
             </div>
           </div>
           <div style={styles.modelCardSubpanel}>

--- a/src/UIComponents/ModelCard.jsx
+++ b/src/UIComponents/ModelCard.jsx
@@ -48,11 +48,9 @@ class ModelCard extends Component {
             <h5 style={styles.modelCardHeading}>Accuracy</h5>
             <div style={styles.modelCardContent}>
               <p style={styles.modelCardDetails}>
-                {percentCorrect && (
-                  <span>
-                    {percentCorrect}%
-                  </span>
-                )}
+                <span>
+                  {percentCorrect}%
+                </span>
               </p>
             </div>
           </div>

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -69,14 +69,16 @@ class SaveModel extends Component {
     });
     fields.push({
       id: "potentialMisuses",
-      text: "Warnings:",
+      text: "Limitations and Warnings:",
       description:
-        "Describe any situations where this model could potentially \
-        be misused, or any places where bias could potentially show up in the \
-        model. Important questions to consider are:",
+        `Describe any limitations in how this model was created or how it \
+        should be used. You may say things like "Avoid using this model \
+        for..." or "Be cautious about...". \n
+        Important questions to consider are:`,
       descriptionDetails: [
-        "Is there enough data to create an accurate model?",
-        "Does the data represent all possible users and scenarios?"
+        "Does the data represent all possible users and scenarios?",
+        "Did you gather enough data to be confident in the model's accuracy?",
+        "Are there situations where this model definitely shouldn't be used?"
       ],
       placeholder: "Write a brief description."
     });
@@ -92,7 +94,7 @@ class SaveModel extends Component {
 
     const dataDescriptionField = {
       id: "datasetDescription",
-      text: "Description:",
+      text: "About the Data:",
       placeholder:
         "How was the data collected? Who collected it? When was it collected?",
       answer: this.props.dataDescription
@@ -119,6 +121,39 @@ class SaveModel extends Component {
                 maxLength={ModelNameMaxLength}
               />
             </div>
+          </div>
+          <div>
+            {this.getUsesFields().map(field => {
+              return (
+                <div key={field.id} style={styles.cardRow}>
+                  <div style={styles.bold}>{field.text}</div>
+                  <div>{field.description}</div>
+                  <ul>
+                    {field.descriptionDetails &&
+                      field.descriptionDetails.map((detail, index) => {
+                        return (
+                          <li style={styles.regularText} key={index}>
+                            {detail}
+                          </li>
+                        );
+                      })}
+                  </ul>
+                  {!field.answer && (
+                    <div>
+                      <textarea
+                        rows="4"
+                        onChange={event =>
+                          this.handleChange(event, field.id, field.isColumn)
+                        }
+                        placeholder={field.placeholder}
+                        style={styles.saveInputsWidth}
+                      />
+                    </div>
+                  )}
+                  {field.answer && <div>{field.answer}</div>}
+                </div>
+              );
+            })}
           </div>
           <div key={dataDescriptionField.id} style={styles.cardRow}>
             <div style={styles.bold}>{dataDescriptionField.text}</div>
@@ -177,39 +212,6 @@ class SaveModel extends Component {
                 })}
               </div>
             )}
-          </div>
-          <div>
-            {this.getUsesFields().map(field => {
-              return (
-                <div key={field.id} style={styles.cardRow}>
-                  <div style={styles.bold}>{field.text}</div>
-                  <div>{field.description}</div>
-                  <ul>
-                    {field.descriptionDetails &&
-                      field.descriptionDetails.map((detail, index) => {
-                        return (
-                          <li style={styles.regularText} key={index}>
-                            {detail}
-                          </li>
-                        );
-                      })}
-                  </ul>
-                  {!field.answer && (
-                    <div>
-                      <textarea
-                        rows="4"
-                        onChange={event =>
-                          this.handleChange(event, field.id, field.isColumn)
-                        }
-                        placeholder={field.placeholder}
-                        style={styles.saveInputsWidth}
-                      />
-                    </div>
-                  )}
-                  {field.answer && <div>{field.answer}</div>}
-                </div>
-              );
-            })}
           </div>
         </ScrollableContent>
       </div>

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -201,6 +201,7 @@ class SaveModel extends Component {
                             }
                             placeholder={field.placeholder}
                             value={field.answer || ""}
+                            style={styles.saveInputsWidth}
                           />
                         </div>
                       )}


### PR DESCRIPTION
Re-ordered sections of the Save Model form and the Model Card and updated a few strings per [request](https://docs.google.com/document/d/1GLDEz5Nb6SYqTohXU992fAxS-D0Lg8cQA5ic9dJCNXA/edit) from the Curriculum team. I also widened the column description entry boxes to match other save form fields. 

Save form
![Screen Shot 2021-06-29 at 1 34 26 PM](https://user-images.githubusercontent.com/12300669/123854696-094fb700-d8ed-11eb-95dd-47aaf2ba85d8.png)
![Screen Shot 2021-06-29 at 3 25 15 PM](https://user-images.githubusercontent.com/12300669/123855893-6a2bbf00-d8ee-11eb-900b-739ed464118c.png)

Summary screen 
![Screen Shot 2021-06-29 at 3 13 48 PM](https://user-images.githubusercontent.com/12300669/123854791-25ebef00-d8ed-11eb-9361-3c817e2ebbb1.png)
![Screen Shot 2021-06-29 at 3 13 54 PM](https://user-images.githubusercontent.com/12300669/123855106-7e22f100-d8ed-11eb-8e69-e1b10eeff3db.png)
