### PR TITLE
Give relationship information some breathing room

### DIFF
--- a/src/UIComponents/CrossTab.jsx
+++ b/src/UIComponents/CrossTab.jsx
@@ -48,6 +48,7 @@ class CrossTab extends Component {
             <div>
               The currently-selected data is too large to show in a table.
             </div>
+            <br />
           </div>
         )}
 


### PR DESCRIPTION
Things were a little squished in the column details panel when the selected column had too many options to show a table. I added spacing between the "Relationship information" and the "Column information" sections.

BEFORE 
![Screen Shot 2021-06-29 at 11 24 28 AM](https://user-images.githubusercontent.com/12300669/123858784-ebd11c00-d8f1-11eb-95ee-3cbe14e1349c.png)

AFTER 
![Screen Shot 2021-06-29 at 3 48 13 PM](https://user-images.githubusercontent.com/12300669/123858834-f8ee0b00-d8f1-11eb-8fc3-67906dcac44c.png)

