### PR TITLE
Fix column description input bug 

### DIFF
--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -5,9 +5,9 @@ import { connect } from "react-redux";
 import {
   setTrainedModelDetail,
   getDataDescription,
-  isUserUploadedDataset
+  isUserUploadedDataset,
+  getSelectedColumnsDescriptions
 } from "../redux";
-import { getSelectedColumnsDescriptions } from "../selectors";
 import { styles, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
 import ScrollableContent from "./ScrollableContent";

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -72,8 +72,8 @@ export function getColumnDescription(column, metadata, trainedModelDetails) {
 
   // Try using a user-entered column description if available.
   if (trainedModelDetails && trainedModelDetails.columns) {
-    const matchedColumn = trainedModelDetails.columns.find(column => {
-      return column.id === column;
+    const matchedColumn = trainedModelDetails.columns.find(col => {
+      return col.id === column;
     });
     if (matchedColumn) {
       return matchedColumn.description;

--- a/src/redux.js
+++ b/src/redux.js
@@ -12,6 +12,7 @@ import {
   isColumnNumerical,
   isColumnCategorical,
   getColumnDataToSave,
+  getColumnDescription
 } from "./helpers/columnDetails.js";
 import { getUniqueOptionsLabelColumn } from "./selectors";
 import { convertValueForDisplay } from "./helpers/valueConversion.js";
@@ -457,7 +458,6 @@ export default function rootReducer(state = initialState, action) {
     } else {
       trainedModelDetails[action.field] = action.value;
     }
-
     return {
       ...state,
       ...trainedModelDetails
@@ -938,6 +938,20 @@ export function getDatasetDetails(state) {
   datasetDetails.numRows = state.data.length;
   datasetDetails.isUserUploaded = isUserUploadedDataset(state);
   return datasetDetails;
+}
+
+export function getSelectedColumnsDescriptions(state) {
+  const selectedColumns = [...state.selectedFeatures, state.labelColumn];
+  return selectedColumns.map(column => {
+    return {
+      id: column,
+      description: getColumnDescription(
+        column,
+        state.metadata,
+        state.trainedModelDetails
+      )
+    };
+  });
 }
 
 export function getFeaturesToSave(state) {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -3,8 +3,7 @@ import { ColumnTypes } from "./constants.js";
 import {
   filterColumnsByType,
   getUniqueOptions,
-  getExtrema,
-  getColumnDescription
+  getExtrema
  } from './helpers/columnDetails';
 import { arrayIntersection } from './helpers/utils';
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -13,7 +13,6 @@ export const getColumnsByDataType = state => state.columnsByDataType;
 const getSelectedFeatures = state => state.selectedFeatures;
 const getLabelColumn = state => state.labelColumn;
 export const getMetadata = state => state.metadata;
-export const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -91,21 +90,5 @@ export const getExtremaByColumn = createSelector(
       extremaByColumn[column] = getExtrema(data, column)
     ))
     return extremaByColumn;
-  }
-)
-
-export const getSelectedColumnsDescriptions = createSelector(
-  [getSelectedColumns, getMetadata, getTrainedModelDetails],
-  (selectedColumns, metadata, trainedModelDetails) => {
-    return selectedColumns.map(column => {
-      return {
-        id: column,
-        description: getColumnDescription(
-          column,
-          metadata,
-          trainedModelDetails
-        )
-      };
-    });
   }
 )

--- a/src/selectors/currentColumnSelectors.js
+++ b/src/selectors/currentColumnSelectors.js
@@ -11,12 +11,12 @@ import {
   getSelectedColumns,
   getData,
   getColumnsByDataType,
-  getMetadata,
-  getTrainedModelDetails
+  getMetadata
  } from '../selectors';
 import { ColumnTypes } from "../constants.js";
 
 const getCurrentColumn = state => state.currentColumn;
+const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCurrentColumnDetails = createSelector(
   [

--- a/test/unit/columnDetails.test.js
+++ b/test/unit/columnDetails.test.js
@@ -16,7 +16,8 @@ import {
   premadeDatasetState,
   mosquitoCountMax,
   mosquitoCountMin,
-  mosquitoDescription
+  mosquitoDescription,
+  sunDescription
 } from './testData';
 import { ColumnTypes, UNIQUE_OPTIONS_MAX } from "../../src/constants.js";
 
@@ -121,6 +122,15 @@ describe("getColumnDescription", () => {
       {}
     );
     expect(result).toEqual(mosquitoDescription);
+  });
+
+  test("gets description from trained model details", async () => {
+    const result = getColumnDescription(
+      'sun',
+      {},
+      regressionState.trainedModelDetails
+    );
+    expect(result).toEqual(sunDescription);
   });
 
   test("no description", async () => {

--- a/test/unit/testData.js
+++ b/test/unit/testData.js
@@ -1,5 +1,7 @@
 /* Mock state to be used across the testing suite. */
 
+export const sunDescription = "How sunny was it.";
+
 export const regressionState = {
   data: [
     {
@@ -42,6 +44,14 @@ export const regressionState = {
       'medium' : 1,
       'high' : 2,
     }
+  },
+  trainedModelDetails: {
+    columns: [
+      {
+        id: 'sun',
+        description: sunDescription
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
I introduced a regression in #254 where the input boxes for column descriptions for user uploaded data on the Save Model form no longer worked. 

The first issue was that `getColumnDescription` wasn't correctly retrieving column descriptions if they were set in `trainedModelDetails`.  I fixed and added a test for this case. 

Secondly, the `getSelectedColumnsDescriptions` selector wasn't updating as expected when `trainedModelDetails` updated. This issue is still unclear to me, but may have something to do with this [FAQ](https://github.com/reduxjs/reselect#q-why-isnt-my-selector-recomputing-when-the-input-state-changes) from the reselect docs. Regardless, I went back to using a regular old function and not a selector for `getSelectedColumnsDescriptions` and now the input boxes work.  I feel ok about this since the biggest value in using selectors comes for expensive derived state calculation - say, for example, when we're looking at all of the data in a column - and getting the description is not particularly expensive. 

BEFORE - nothing appears when typing in the input box 

https://user-images.githubusercontent.com/12300669/123886017-8e9e9000-d91c-11eb-841f-ccbfb76d85e9.mo

AFTER - inputs work and column description data is stored 

https://user-images.githubusercontent.com/12300669/123886064-a249f680-d91c-11eb-9daa-f40f4c8dbad3.mov


