### PR TITLE
Fix manual column descriptions for user-uploaded CSV

### DIFF
--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -61,11 +61,11 @@ export function containsOnlyNumbers(data, column) {
   return columnData.every(cell => !isNaN(cell));
 }
 
-export function getColumnDescription(column, metadata, trainedModelDetails) {
+export function getColumnDescription(columnId, metadata, trainedModelDetails) {
   // Use metadata if available.
-  if (column && metadata && metadata.fields) {
+  if (columnId && metadata && metadata.fields) {
     const field = metadata.fields.find(field => {
-      return field.id === column;
+      return field.id === columnId;
     });
     return field.description;
   }
@@ -73,7 +73,7 @@ export function getColumnDescription(column, metadata, trainedModelDetails) {
   // Try using a user-entered column description if available.
   if (trainedModelDetails && trainedModelDetails.columns) {
     const matchedColumn = trainedModelDetails.columns.find(column => {
-      return column.id === column;
+      return column.id === columnId;
     });
     if (matchedColumn) {
       return matchedColumn.description;

--- a/src/redux.js
+++ b/src/redux.js
@@ -435,7 +435,7 @@ export default function rootReducer(state = initialState, action) {
     };
   }
   if (action.type === SET_TRAINED_MODEL_DETAIL) {
-    let trainedModelDetails = state.trainedModelDetails;
+    let trainedModelDetails = {...state.trainedModelDetails};
 
     if (action.isColumn) {
       if (!trainedModelDetails.columns) {
@@ -460,7 +460,7 @@ export default function rootReducer(state = initialState, action) {
 
     return {
       ...state,
-      ...trainedModelDetails
+      trainedModelDetails
     };
   }
   if (action.type === SET_INSTRUCTIONS_KEY_CALLBACK) {


### PR DESCRIPTION
This should fix the issue described in https://github.com/code-dot-org/ml-playground/pull/259 which was a regression introduced in https://github.com/code-dot-org/ml-playground/pull/254.

There were three things causing text entered in the "Column Descriptions" fields to not be visible to the user:

- `getColumnDescription` had a collision between two `column` variables.
- The `SET_TRAINED_MODEL_DETAIL` action needed to make a fresh copy of the `trainedModelDetails` so that the memoized selector would notice that a value inside of it had changed, per [this advice](https://github.com/reduxjs/reselect#q-why-isnt-my-selector-recomputing-when-the-input-state-changes).
- The `SET_TRAINED_MODEL_DETAIL` action needed to set the `trainedModelDetails` field when returning the new state.  (Interestingly, this issue had been around since the code was first written five months ago, but not noticed because it was also modifying the `trainedModelDetails` value in-place!)