### PR TITLE
Catch too-small CSV files

### DIFF
--- a/src/UIComponents/SelectDataset.jsx
+++ b/src/UIComponents/SelectDataset.jsx
@@ -27,7 +27,8 @@ class SelectDataset extends Component {
     resetState: PropTypes.func.isRequired,
     specifiedDatasets: PropTypes.arrayOf(PropTypes.string),
     name: PropTypes.string,
-    highlightDataset: PropTypes.string
+    highlightDataset: PropTypes.string,
+    invalidData: PropTypes.string
   };
 
   constructor(props) {
@@ -69,6 +70,16 @@ class SelectDataset extends Component {
       download: false
     });
     parseCSV(event.target.files[0], false, true);
+  };
+
+  getInvalidDataMessage = () => {
+    if (this.props.invalidData === "tooFewRows") {
+      return "Please upload a CSV with at least 2 rows.";
+    } else if (this.props.invalidData === "tooFewColumns") {
+      return "Please upload a CSV with at least 2 columns.";
+    } else {
+      return null;
+    }
   };
 
   render() {
@@ -130,6 +141,9 @@ class SelectDataset extends Component {
                 value=""
               />
             </label>
+            <span style={styles.invalidDataMessageContainer}>
+              {this.getInvalidDataMessage()}
+            </span>
           </div>
         )}
       </div>
@@ -143,7 +157,8 @@ export default connect(
     jsonfile: state.jsonfile,
     specifiedDatasets: getSpecifiedDatasets(state),
     name: state.name,
-    highlightDataset: state.highlightDataset
+    highlightDataset: state.highlightDataset,
+    invalidData: state.invalidData
   }),
   dispatch => ({
     resetState() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -316,6 +316,10 @@ export const styles = {
     cursor: "pointer"
   },
 
+  invalidDataMessageContainer: {
+    margin: 20
+  },
+
   specifyColumnsItem: {
     display: "inline-block",
     width: "20%"

--- a/src/csvReaderWrapper.js
+++ b/src/csvReaderWrapper.js
@@ -2,6 +2,7 @@ import Papa from "papaparse";
 import { store } from "./index.js";
 import {
   setImportedData,
+  setInvalidData,
   setColumnsByDataType,
   setRemovedRowsCount
 } from "./redux";
@@ -57,6 +58,12 @@ const updateData = (result, useDefaultColumnDataType, userUploadedData) => {
   store.dispatch(setImportedData(cleanedData, userUploadedData));
   if (useDefaultColumnDataType) {
     setDefaultColumnDataType(cleanedData);
+  }
+
+  if (cleanedData.length < 2) {
+    store.dispatch(setInvalidData("tooFewRows"));
+  } else if (Object.keys(cleanedData[0]).length < 2) {
+    store.dispatch(setInvalidData("tooFewColumns"));
   }
 }
 

--- a/src/helpers/navigationValidation.js
+++ b/src/helpers/navigationValidation.js
@@ -93,7 +93,7 @@ function isPanelAvailable(state, panelId) {
 }
 
 function isDataUploaded(state) {
-  return state.data.length > 0;
+  return state.data.length > 0 && !state.invalidData;
 }
 
 function minOneFeatureSelected(state) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -31,6 +31,7 @@ const SET_MODE = "SET_MODE";
 const SET_SELECTED_NAME = "SET_SELECTED_NAME";
 const SET_SELECTED_CSV = "SET_SELECTED_CSV";
 const SET_SELECTED_JSON = "SET_SELECTED_JSON";
+const SET_INVALID_DATA = "SET_INVALID_DATA";
 const SET_IMPORTED_DATA = "SET_IMPORTED_DATA";
 const SET_IMPORTED_METADATA = "SET_IMPORTED_METADATA";
 const SET_REMOVED_ROWS_COUNT = "SET_REMOVED_ROWS_COUNT";
@@ -80,6 +81,10 @@ export function setSelectedCSV(csvfile) {
 
 export function setSelectedJSON(jsonfile) {
   return { type: SET_SELECTED_JSON, jsonfile };
+}
+
+export function setInvalidData(invalidData) {
+  return { type: SET_INVALID_DATA, invalidData };
 }
 
 export function setImportedData(data, userUploadedData) {
@@ -235,6 +240,8 @@ const initialState = {
   name: undefined,
   csvfile: undefined,
   jsonfile: undefined,
+  // Possible values for invalidData: "tooFewRows", and "tooFewColumns".
+  invalidData: undefined,
   data: [],
   metadata: {},
   removedRowsCount: 0,
@@ -295,6 +302,12 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       jsonfile: action.jsonfile
+    };
+  }
+  if (action.type === SET_INVALID_DATA) {
+    return {
+      ...state,
+      invalidData: action.invalidData
     };
   }
   if (action.type === SET_IMPORTED_DATA) {


### PR DESCRIPTION
Catch user-uploaded CSV files that are too small and show an error message instead of allowing them to proceed.  Too small here is where the file has fewer than two rows or two columns.

Ideally this validation could be hoised to `redux.js`, but since `csvReaderWrapper` also does some other manipulation of the uploaded data, it seemed least invasive to do these checks here as well.

### not enough rows

![Screen Shot 2021-06-30 at 2 52 18 PM](https://user-images.githubusercontent.com/2205926/123903862-556a1e00-d924-11eb-80d3-9bc46474fa7d.png)

### not enough columns

![Screen Shot 2021-06-30 at 2 52 07 PM](https://user-images.githubusercontent.com/2205926/123903856-526f2d80-d924-11eb-9092-571a4f9f8cd3.png)

