### PR TITLE
Move results functions into accuracy.js

### DIFF
--- a/src/UIComponents/ResultsDetails.jsx
+++ b/src/UIComponents/ResultsDetails.jsx
@@ -2,12 +2,12 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { setShowResultsDetails } from "../redux";
 import {
-  setShowResultsDetails,
+  getPercentCorrect,
   getCorrectResults,
   getIncorrectResults
-} from "../redux";
-import { getPercentCorrect } from "../helpers/accuracy";
+} from "../helpers/accuracy";
 import { ResultsGrades, styles } from "../constants";
 import ResultsToggle from "./ResultsToggle";
 import ResultsTable from "./ResultsTable";

--- a/src/helpers/accuracy.js
+++ b/src/helpers/accuracy.js
@@ -6,7 +6,11 @@
   of the range of labels to count as "correct".
 */
 
-import { ResultsGrades, REGRESSION_ERROR_TOLERANCE } from "../constants.js";
+import {
+  ResultsGrades,
+  REGRESSION_ERROR_TOLERANCE,
+  MLTypes
+} from "../constants.js";
 import { getExtrema } from "./columnDetails.js";
 import {
   getConvertedLabels,
@@ -76,6 +80,15 @@ export function getAccuracyGrades(state) {
     ? getAccuracyRegression(state).grades
     : getAccuracyClassification(state).grades;
   return grades;
+}
+
+export function getSummaryStat(state) {
+  let summaryStat = {};
+  summaryStat.type = isRegression(state)
+    ? MLTypes.REGRESSION
+    : MLTypes.CLASSIFICATION;
+  summaryStat.stat = getPercentCorrect(state);
+  return summaryStat;
 }
 
 export function getPercentCorrect(state) {

--- a/src/helpers/accuracy.js
+++ b/src/helpers/accuracy.js
@@ -1,9 +1,9 @@
 /*
-  Functions for calculating the accuracy of trained machine learning models.
-  "Grade" is "correct" or "incorrect". Categorical predicted and expected
-  labels must match exactly to count as "correct". Numerical predicted and
-  expected labels must be within 5% of the range of labels to count as
-  "correct".
+  Functions for calculating the accuracy of trained machine learning models
+  based on the results returned from testing the model. "Grade" is "correct" or
+  "incorrect". Categorical predicted and expected labels must match exactly to
+  count as "correct". Numerical predicted and expected labels must be within 5%
+  of the range of labels to count as "correct".
 */
 
 import { ResultsGrades, REGRESSION_ERROR_TOLERANCE } from "../constants.js";
@@ -13,6 +13,70 @@ import {
   getConvertedAccuracyCheckExamples
 } from "./valueConversion.js";
 import { isRegression } from "../redux.js"
+
+// Return results data so that it looks like regular data provided to the
+// DataTable.
+export function getResultsDataInDataTableForm(state) {
+  const resultsByGrades = getAllResults(state);
+
+  if (!resultsByGrades || resultsByGrades.examples.length === 0) {
+    return null;
+  }
+
+  // None of the existing uses of this function should need more than 10
+  // items.  Increase the value here if they do.
+  const numItems = Math.min(10, resultsByGrades.examples.length);
+
+  const results = [];
+  for (var i = 0; i < numItems; i++) {
+    results[i] = {};
+
+    state.selectedFeatures.map((feature, index) => {
+      results[i][feature] = resultsByGrades.examples[i][index];
+    })
+
+    results[i][state.labelColumn] = resultsByGrades.predictedLabels[i];
+  }
+
+  return results;
+}
+
+export function getAllResults(state) {
+  return getResultsByGrade(state, ResultsGrades.ALL);
+}
+
+export function getCorrectResults(state) {
+  return getResultsByGrade(state, ResultsGrades.CORRECT);
+}
+
+export function getIncorrectResults(state) {
+  return getResultsByGrade(state, ResultsGrades.INCORRECT);
+}
+
+export function getResultsByGrade(state, grade) {
+  const results = {};
+  const accuracyGrades = getAccuracyGrades(state);
+  const examples = getConvertedAccuracyCheckExamples(state).filter((example, index) => {
+    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
+  });
+  const labels = getConvertedLabels(state, state.accuracyCheckLabels).filter((example, index) => {
+    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
+  });
+  const predictedLabels = getConvertedLabels(state, state.accuracyCheckPredictedLabels).filter((example, index) => {
+    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
+  });
+  results.examples = examples;
+  results.labels = labels;
+  results.predictedLabels = predictedLabels;
+  return results;
+}
+
+export function getAccuracyGrades(state) {
+  const grades = isRegression(state)
+    ? getAccuracyRegression(state).grades
+    : getAccuracyClassification(state).grades;
+  return grades;
+}
 
 export function getPercentCorrect(state) {
   const percentCorrect = isRegression(state)
@@ -69,29 +133,4 @@ export function getAccuracyRegression(state) {
   );
   accuracy.grades = grades;
   return accuracy;
-}
-
-export function getAccuracyGrades(state) {
-  const grades = isRegression(state)
-    ? getAccuracyRegression(state).grades
-    : getAccuracyClassification(state).grades;
-  return grades;
-}
-
-export function getResultsByGrade(state, grade) {
-  const results = {};
-  const accuracyGrades = getAccuracyGrades(state);
-  const examples = getConvertedAccuracyCheckExamples(state).filter((example, index) => {
-    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
-  });
-  const labels = getConvertedLabels(state, state.accuracyCheckLabels).filter((example, index) => {
-    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
-  });
-  const predictedLabels = getConvertedLabels(state, state.accuracyCheckPredictedLabels).filter((example, index) => {
-    return grade === ResultsGrades.ALL || grade === accuracyGrades[index];
-  });
-  results.examples = examples;
-  results.labels = labels;
-  results.predictedLabels = predictedLabels;
-  return results;
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -4,8 +4,8 @@ import {
 } from "./helpers/navigationValidation.js";
 import { reportPanelView } from "./helpers/metrics.js";
 import {
-  getResultsByGrade,
-  getPercentCorrect
+  getPercentCorrect,
+  getResultsDataInDataTableForm
 } from "./helpers/accuracy.js";
 import {
   isColumnNumerical,
@@ -822,45 +822,6 @@ export function getTableData(state, useResultsData) {
 
 export function isRegression(state) {
   return isColumnNumerical(state, state.labelColumn);
-}
-
-export function getCorrectResults(state) {
-  return getResultsByGrade(state, ResultsGrades.CORRECT);
-}
-
-export function getIncorrectResults(state) {
-  return getResultsByGrade(state, ResultsGrades.INCORRECT);
-}
-
-export function getAllResults(state) {
-  return getResultsByGrade(state, ResultsGrades.ALL);
-}
-
-// Return results data so that it looks like regular data provided to the
-// DataTable.
-export function getResultsDataInDataTableForm(state) {
-  const resultsByGrades = getAllResults(state);
-
-  if (!resultsByGrades || resultsByGrades.examples.length === 0) {
-    return null;
-  }
-
-  // None of the existing uses of this function should need more than 10
-  // items.  Increase the value here if they do.
-  const numItems = Math.min(10, resultsByGrades.examples.length);
-
-  const results = [];
-  for (var i = 0; i < numItems; i++) {
-    results[i] = {};
-
-    state.selectedFeatures.map((feature, index) => {
-      results[i][feature] = resultsByGrades.examples[i][index];
-    })
-
-    results[i][state.labelColumn] = resultsByGrades.predictedLabels[i];
-  }
-
-  return results;
 }
 
 /* Functions for processing data about a trained model to save. */

--- a/src/redux.js
+++ b/src/redux.js
@@ -4,7 +4,7 @@ import {
 } from "./helpers/navigationValidation.js";
 import { reportPanelView } from "./helpers/metrics.js";
 import {
-  getPercentCorrect,
+  getSummaryStat,
   getResultsDataInDataTableForm
 } from "./helpers/accuracy.js";
 import {
@@ -16,7 +16,6 @@ import { getUniqueOptionsLabelColumn } from "./selectors";
 import { areArraysEqual } from "./helpers/utils.js";
 import {
   ColumnTypes,
-  MLTypes,
   RegressionTrainer,
   ClassificationTrainer,
   TestDataLocations,
@@ -868,15 +867,6 @@ export function getFeaturesToSave(state) {
 
 export function getLabelToSave(state) {
   return getColumnDataToSave(state, state.labelColumn);
-}
-
-function getSummaryStat(state) {
-  let summaryStat = {};
-  summaryStat.type = isRegression(state)
-    ? MLTypes.REGRESSION
-    : MLTypes.CLASSIFICATION;
-  summaryStat.stat = getPercentCorrect(state);
-  return summaryStat;
 }
 
 export function getTrainedModelDataToSave(state) {

--- a/test/unit/accuracy.test.js
+++ b/test/unit/accuracy.test.js
@@ -4,10 +4,11 @@ import {
   getAccuracyGrades,
   getResultsByGrade,
   getPercentCorrect,
-  getResultsDataInDataTableForm
+  getResultsDataInDataTableForm,
+  getSummaryStat
 } from '../../src/helpers/accuracy.js';
 import { classificationState, regressionState } from './testData';
-import { ResultsGrades, ColumnTypes } from '../../src/constants.js';
+import { ResultsGrades, ColumnTypes, MLTypes } from '../../src/constants.js';
 
 const regressionGrades = [
   ResultsGrades.INCORRECT,
@@ -209,7 +210,7 @@ describe('get results', () => {
     const resultsCount = results.examples.length;
     const expectedCount = mixedGrades.length;
     expect(resultsCount).toEqual(expectedCount);
-  })
+  });
 });
 
 describe('get results data in data table form', () => {
@@ -221,5 +222,19 @@ describe('get results data in data table form', () => {
   test('classification', async () => {
     const resultsData = getResultsDataInDataTableForm(classificationState);
     expect(resultsData).toEqual(classificationDataForTable);
+  });
+});
+
+describe('get summary stat', () => {
+  test('classification', async () => {
+    const summaryStat = getSummaryStat(classificationState);
+    expect(summaryStat.stat).toBe(lowAccuracyPercent);
+    expect(summaryStat.type).toBe(MLTypes.CLASSIFICATION);
+  });
+
+  test('regression', async () => {
+    const summaryStat = getSummaryStat(regressionState);
+    expect(summaryStat.stat).toBe(regressionPercent);
+    expect(summaryStat.type).toBe(MLTypes.REGRESSION);
   });
 });

--- a/test/unit/accuracy.test.js
+++ b/test/unit/accuracy.test.js
@@ -3,7 +3,8 @@ import {
   getAccuracyClassification,
   getAccuracyGrades,
   getResultsByGrade,
-  getPercentCorrect
+  getPercentCorrect,
+  getResultsDataInDataTableForm
 } from '../../src/helpers/accuracy.js';
 import { classificationState, regressionState } from './testData';
 import { ResultsGrades, ColumnTypes } from '../../src/constants.js';
@@ -90,7 +91,52 @@ const classificationTestCases = [
     grades: mixedGrades,
     percent: lowAccuracyPercent
   }
+];
+
+const gradesTestCases = [
+  {
+    case: "getResultsByGrade - correct, regression",
+    state: regressionState,
+    grades: regressionGrades,
+    gradeType: ResultsGrades.CORRECT
+  },
+  {
+    case: "getResultsByGrade - incorrect, regression",
+    state: regressionState,
+    grades: regressionGrades,
+    gradeType: ResultsGrades.INCORRECT
+  },
+  {
+    case: "getResultsByGrade - correct, classification",
+    state: classificationState,
+    grades: mixedGrades,
+    gradeType: ResultsGrades.CORRECT
+  },
+  {
+    case: "getResultsByGrade - incorrect, classification",
+    state: classificationState,
+    grades: mixedGrades,
+    gradeType: ResultsGrades.INCORRECT
+  }
 ]
+
+const regressionDataForTable = [
+  { sun: 'high', height: 4 },
+  { sun: 'high', height: 3.75 },
+  { sun: 'medium', height: 2.63 },
+  { sun: 'medium', height: 2.46 },
+  { sun: 'low', height: 1.6 },
+  { sun: 'low', height: 1 }
+];
+
+const classificationDataForTable = [
+  { temp: 'cool', weather: 'rainy', play: 'yes' },
+  { temp: 'mild', weather: 'rainy', play: 'yes' },
+  { temp: 'mild', weather: 'overcast', play: 'yes' },
+  { temp: 'mild', weather: 'sunny', play: 'no' },
+  { temp: 'hot', weather: 'overcast', play: 'no' },
+  { temp: 'hot', weather: 'sunny', play: 'yes' }
+];
 
 describe('get accuracy', () => {
   classificationTestCases.forEach(testCase => {
@@ -140,41 +186,40 @@ describe('get percent correct', () => {
 });
 
 describe('get results', () => {
-  test("getResultsByGrade - correct, regression", async () => {
-    const results = getResultsByGrade(regressionState, ResultsGrades.CORRECT);
-    const resultsCount = results.examples.length;
-    const expectedCount = regressionGrades.filter(
-      grade => grade === ResultsGrades.CORRECT
-    ).length;
-    expect(resultsCount).toBe(expectedCount);
+  gradesTestCases.forEach(testCase => {
+    test(testCase.case, async () => {
+      const results = getResultsByGrade(testCase.state, testCase.gradeType);
+      const resultsCount = results.examples.length;
+      const expectedCount = testCase.grades.filter(
+        grade => grade === testCase.gradeType
+      ).length;
+      expect(resultsCount).toBe(expectedCount);
+    })
   });
 
-  test("getResultsByGrade - incorrect, regression", async () => {
-    const results = getResultsByGrade(regressionState, ResultsGrades.INCORRECT);
+  test('regression - all', async () => {
+    const results = getResultsByGrade(regressionState, ResultsGrades.ALL);
     const resultsCount = results.examples.length;
-    const expectedCount = regressionGrades.filter(
-      grade => grade === ResultsGrades.INCORRECT
-    ).length;
-    expect(resultsCount).toBe(expectedCount);
+    const expectedCount = regressionGrades.length;
+    expect(resultsCount).toEqual(expectedCount);
   });
 
-  test("getResultsByGrade - correct, classification", async () => {
-    classificationState['accuracyCheckPredictedLabels'] = mixedResults;
-    const results = getResultsByGrade(classificationState, ResultsGrades.CORRECT);
+  test('classification - all', async () => {
+    const results = getResultsByGrade(classificationState, ResultsGrades.ALL);
     const resultsCount = results.examples.length;
-    const expectedCount = mixedGrades.filter(
-      grade => grade === ResultsGrades.CORRECT
-    ).length;
-    expect(resultsCount).toBe(expectedCount);
+    const expectedCount = mixedGrades.length;
+    expect(resultsCount).toEqual(expectedCount);
+  })
+});
+
+describe('get results data in data table form', () => {
+  test('regression', async () => {
+    const resultsData = getResultsDataInDataTableForm(regressionState);
+    expect(resultsData).toEqual(regressionDataForTable);
   });
 
-  test("getResultsByGrade - incorrect, classification", async () => {
-    classificationState['accuracyCheckPredictedLabels'] = mixedResults;
-    const results = getResultsByGrade(classificationState, ResultsGrades.INCORRECT);
-    const resultsCount = results.examples.length;
-    const expectedCount = mixedGrades.filter(
-      grade => grade === ResultsGrades.INCORRECT
-    ).length;
-    expect(resultsCount).toBe(expectedCount);
+  test('classification', async () => {
+    const resultsData = getResultsDataInDataTableForm(classificationState);
+    expect(resultsData).toEqual(classificationDataForTable);
   });
 });


### PR DESCRIPTION
`getSummaryStat`, `getResultsDataInDataTableForm`, `getAllResults`, `getCorrectResults` and `getIncorrectResults` functions now all live with the other results/grades/accuracy functions in accuracy.js. I added test for these functions and updated imports accordingly. 