### PR TITLE
Update PropType for percentCorrect

### DIFF
--- a/src/UIComponents/ResultsDetails.jsx
+++ b/src/UIComponents/ResultsDetails.jsx
@@ -19,7 +19,7 @@ class ResultsDetails extends Component {
     resultsTab: PropTypes.string,
     selectedFeatures: PropTypes.array,
     labelColumn: PropTypes.string,
-    percentCorrect: PropTypes.number,
+    percentCorrect: PropTypes.string,
     setShowResultsDetails: PropTypes.func,
     correctResults: PropTypes.object,
     incorrectResults: PropTypes.object,


### PR DESCRIPTION
In `ResultsDetails` we were hitting an error because the PropTypes validation expected `percentCorrect` to be a number, but it was a string. 

![Screen Shot 2021-06-30 at 10 13 00 PM](https://user-images.githubusercontent.com/12300669/124054633-62ecda00-d9f0-11eb-91b6-5dc4132d6afe.png)

I updated the PropTypes validation for `percentCorrect` to expect a string.  We want two decimal places to show consistently for the accuracy score, so we call `toFixed(2)` on the value calculated for `percentCorrect`, which converts it to a string. We're using `percentCorrect` in the display, not for any mathematical calculation, so it's perfectly fine that it's a string. 