### PR TITLE
Remove unused levelbuilder parameters

### DIFF
--- a/src/indexDev.js
+++ b/src/indexDev.js
@@ -6,21 +6,17 @@ import queryString from "query-string";
 const sampleModes = {
   minimal: {
     datasets: ["tacos_toy"],
-    hideModelCard: true,
     hideSelectLabel: true
   },
 
   "preload-metadata": {
     requireAccuracy: 50,
-    hideSpecifyColumns: true,
-    hideChooseReserve: true,
     hideInstructionsOverlay: true
   },
 
   "intro-ai-tacos": {
     datasets: ["tacos_toy"],
     hideSelectLabel: true,
-    hideModelCard: true,
     hideSave: true
   },
 
@@ -36,14 +32,12 @@ const sampleModes = {
       "salsa_toy"
     ],
     hideSelectLabel: true,
-    hideModelCard: true,
     hideSave: true
   },
 
   safari: {
     datasets: ["safari_toy"],
     hideSelectLabel: true,
-    hideModelCard: true,
     hideSave: true
   },
 


### PR DESCRIPTION
Based on @made-line's handy [doc](https://docs.google.com/document/d/19vnc_Vu0BukmUhFuTVHh08j9sLSCHcnXbRaewHIF0Sk/edit) (thank you!) I removed unused levelbuilder parameters from the example levels outlined in indexDev.js. These parameters are no longer referenced anywhere else in the codebase. 