### PR TITLE
Document PropType shapes for results

### DIFF
--- a/src/UIComponents/ResultsDetails.jsx
+++ b/src/UIComponents/ResultsDetails.jsx
@@ -9,6 +9,7 @@ import {
   getIncorrectResults
 } from "../helpers/accuracy";
 import { ResultsGrades, styles } from "../constants";
+import { resultsShape } from "./shapes";
 import ResultsToggle from "./ResultsToggle";
 import ResultsTable from "./ResultsTable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -21,8 +22,8 @@ class ResultsDetails extends Component {
     labelColumn: PropTypes.string,
     percentCorrect: PropTypes.string,
     setShowResultsDetails: PropTypes.func,
-    correctResults: PropTypes.object,
-    incorrectResults: PropTypes.object,
+    correctResults: resultsShape,
+    incorrectResults: resultsShape,
   };
 
   onClose = () => {

--- a/src/UIComponents/ResultsDetails.jsx
+++ b/src/UIComponents/ResultsDetails.jsx
@@ -9,7 +9,7 @@ import {
   getIncorrectResults
 } from "../helpers/accuracy";
 import { ResultsGrades, styles } from "../constants";
-import { resultsShape } from "./shapes";
+import { resultsPropType } from "./shapes";
 import ResultsToggle from "./ResultsToggle";
 import ResultsTable from "./ResultsTable";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -22,8 +22,8 @@ class ResultsDetails extends Component {
     labelColumn: PropTypes.string,
     percentCorrect: PropTypes.string,
     setShowResultsDetails: PropTypes.func,
-    correctResults: resultsShape,
-    incorrectResults: resultsShape,
+    correctResults: resultsPropType,
+    incorrectResults: resultsPropType,
   };
 
   onClose = () => {

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -4,12 +4,13 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { isRegression, setResultsHighlightRow } from "../redux";
 import { styles, colors, REGRESSION_ERROR_TOLERANCE } from "../constants";
+import { resultsPropType } from "./shapes";
 
 class ResultsTable extends Component {
   static propTypes = {
     selectedFeatures: PropTypes.array,
     labelColumn: PropTypes.string,
-    results: PropTypes.object,
+    results: resultsPropType,
     isRegression: PropTypes.bool,
     setResultsHighlightRow: PropTypes.func,
     resultsHighlightRow: PropTypes.number

--- a/src/UIComponents/shapes.js
+++ b/src/UIComponents/shapes.js
@@ -2,6 +2,6 @@ import PropTypes from 'prop-types';
 
 export const resultsShape = PropTypes.shape({
   examples: PropTypes.arrayOf(PropTypes.array).isRequired,
-  labels: PropTypes.arrayOf(PropTypes.string).isRequired,
-  predictedLabels: PropTypes.arrayOf(PropTypes.string).isRequired
+  labels: PropTypes.array.isRequired,
+  predictedLabels: PropTypes.array.isRequired
 });

--- a/src/UIComponents/shapes.js
+++ b/src/UIComponents/shapes.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+export const resultsShape = PropTypes.shape({
+  examples: PropTypes.arrayOf(PropTypes.array).isRequired,
+  labels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  predictedLabels: PropTypes.arrayOf(PropTypes.string).isRequired
+});

--- a/src/UIComponents/shapes.js
+++ b/src/UIComponents/shapes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-export const resultsShape = PropTypes.shape({
+export const resultsPropType = PropTypes.shape({
   examples: PropTypes.arrayOf(PropTypes.array).isRequired,
   labels: PropTypes.array.isRequired,
   predictedLabels: PropTypes.array.isRequired


### PR DESCRIPTION
This is the initial work to document the expected PropTypes for components with nested or complex state to make the codebase more readable and easier to modify over the long term. Specifically this PR defines a `resultsPropType` shape used by the `ResultsTable` and `ResultsDetails` component. 