### PR TITLE
Update tests to match new setTestData params

### DIFF
--- a/test/unit/train.test.js
+++ b/test/unit/train.test.js
@@ -38,7 +38,8 @@ describe("train functions", () => {
     train.init(store);
     train.onClickTrain(store);
 
-    store.dispatch(setTestData({temperature: "10", rain: "1010"}));
+    store.dispatch(setTestData("temperature", 10));
+    store.dispatch(setTestData("rain", 1010));
 
     train.onClickPredict(store);
 
@@ -72,7 +73,8 @@ describe("train functions", () => {
     train.init(store);
     train.onClickTrain(store);
 
-    store.dispatch(setTestData({flavor: "sweet", texture: "crunchy"}));
+    store.dispatch(setTestData("flavor", "sweet"));
+    store.dispatch(setTestData("texture", "crunchy"));
 
     train.onClickPredict(store);
 


### PR DESCRIPTION
In #272 we updated the parameters for `setTestData` but did not update the corresponding tests. The full test suite stopped running on PRs when Travis stopped working so we didn't catch this until #280. Fixing now! No user impact since the problem was contained completely to the test set up. 