### PR TITLE
Adding support for i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "file-loader": "^4.2.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
+    "messageformat": "^1.1.0",
     "ml-knn": "^3.0.0",
     "query-string": "4.1.0",
     "react": "~15.4.0",

--- a/src/helpers/navigationValidation.js
+++ b/src/helpers/navigationValidation.js
@@ -1,3 +1,4 @@
+import I18n from '../i18n'
 /*
 Validation checks to determine if app set up is ready for machine learning
 training. Panels prompt users to incrementally complete actions in preparation
@@ -175,7 +176,7 @@ export function prevNextButtons(state) {
       ? { panel: "dataDisplayLabel", text: "Back" }
       : null;
     next = isPanelAvailable(state, "trainModel")
-      ? { panel: "trainModel", text: "Train" }
+      ? { panel: "trainModel", text: I18n.t('trainModelButtonText') }
       : null;
   } else if (state.currentPanel === "trainModel") {
     if (state.trainedModel) {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,31 @@
+import data from './i18n/ailab.json';
+import MessageFormat from 'messageformat'
+
+let messages;
+
+const initI18n = (i18n = {}) => {
+  // For now, use English pluralization rules.
+  const mf = new MessageFormat('en');
+  messages = {...mf.compile(data), ...i18n};
+};
+
+const t = (key, options) => {
+  if (!messages) {
+    throw "I18n must be initialized before calling t";
+  }
+  return messages[key](options);
+};
+
+/*
+  Used to reset the state to before it was initialized.
+  This should only be used in tests.
+ */
+const reset = () => {
+  messages = undefined;
+}
+
+export default {
+  initI18n,
+  t,
+  reset
+};

--- a/src/i18n/ailab.json
+++ b/src/i18n/ailab.json
@@ -1,0 +1,3 @@
+{
+  "trainModelButtonText": "Train"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import { allDatasets } from "./datasetManifest";
 import { parseCSV } from "./csvReaderWrapper";
 import { parseJSON } from "./jsonReaderWrapper";
 import { TestDataLocations } from "./constants";
+import I18n from './i18n';
 
 export const store = createStore(rootReducer);
 
@@ -25,6 +26,7 @@ let saveTrainedModel = null;
 let onContinue = null;
 
 export const initAll = function (options) {
+  I18n.initI18n(options.i18n);
   // Handle an optional mode.
   const mode = options && options.mode;
   onContinue = options && options.onContinue;

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,10 @@ export const store = createStore(rootReducer);
 let saveTrainedModel = null;
 let onContinue = null;
 
+/**
+ * @param {Object} options.i18n Optional. Object where each method returns the locale relevant
+ * string to display. If this is not defined, an English string will be provided.
+ */
 export const initAll = function (options) {
   I18n.initI18n(options.i18n);
   // Handle an optional mode.

--- a/test/unit/i18n.test.js
+++ b/test/unit/i18n.test.js
@@ -1,0 +1,21 @@
+import I18n from '../../src/i18n';
+import MessageFormat from "messageformat";
+
+let testTranslations = new MessageFormat('en').compile({
+  "hello": "hello {name}"
+});
+
+describe('I18n.t', () => {
+  test('throws error when called before initialized', async () => {
+    expect(() => {
+      I18n.reset();
+      I18n.t("hello");
+    }).toThrow();
+  });
+
+  test('returns expected string', async () => {
+    I18n.reset();
+    I18n.initI18n(testTranslations);
+    expect(I18n.t("hello", {"name": "test"})).toEqual("hello test");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,6 +306,11 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -3368,6 +3373,18 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@~7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  integrity sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -4950,6 +4967,13 @@ make-dir@^2.0.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-plural@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-4.3.0.tgz#f23de08efdb0cac2e0c9ba9f315b0dff6b4c2735"
+  integrity sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==
+  optionalDependencies:
+    minimist "^1.2.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -5041,6 +5065,22 @@ merge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+
+messageformat-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-1.1.0.tgz#13ba2250a76bbde8e0fca0dbb3475f95c594a90a"
+  integrity sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==
+
+messageformat@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-1.1.1.tgz#ceaa2e6c86929d4807058275a7372b1bd963bdf6"
+  integrity sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==
+  dependencies:
+    glob "~7.0.6"
+    make-plural "^4.1.1"
+    messageformat-parser "^1.1.0"
+    nopt "~3.0.6"
+    reserved-words "^0.1.2"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -5134,6 +5174,13 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
+
+minimatch@^3.0.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -5355,6 +5402,13 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+nopt@~3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -6402,6 +6456,11 @@ reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+  integrity sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Laying the foundation for internationalization(i18n) support in ml-playground. This adds `i18n.js` which provides the `I18n.t` API for getting translated content. For example, calling `I18n.t('trainModelButtonText')` returns "Train" which is a string stored in `i18n/ailab.json`

This implementation follows the same pattern as [AI for Oceans](https://github.com/code-dot-org/ml-activities)

`i18n/ailab.json` will store key/value pairs where the key is a unique identifier for a string in the AI Lab UI, and the value is a MessageFormatted string to display in the UI. We use MessageFormat so we can support strings with dynamic content. See the unit tests for an example string.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2082)

## Testing done
* Manual testing done to change the "Train" button to be "!Train". See screenshot below
* Added unit tests.

## Screenshot
Note the button text "!Train". This translation was manually added to verify that the `I18n` library was being used by the frontend.
![Screen Shot 2022-10-07 at 5 30 07 PM](https://user-images.githubusercontent.com/1372238/194680849-3ba292d5-47fb-4a5b-8a4f-a16d3b8042b6.png)

## Follow-up work
* Separate PR for making the rest of the UI strings translatable.
* Separate PR for adding `ailab.json` to the code-dot-org i18n sync and getting it translated in Crowdin.