### PR TITLE
Move `yarn` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/ml-playground",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "main": "dist/main.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "webpack": "4.19.1",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.6",
-    "webpack-dev-server": "^3.1.4"
+    "webpack-dev-server": "^3.1.4",
+    "yarn": "^1.22.10"
   },
   "files": [
     "dist/**/!(mainDev.js)",
@@ -79,7 +80,6 @@
     "@fortawesome/react-fontawesome": "^0.1.7",
     "chart.js": "^2.9.4",
     "react-chartjs-2": "^2.11.1",
-    "reselect": "^4.0.0",
-    "yarn": "^1.22.10"
+    "reselect": "^4.0.0"
   }
 }


### PR DESCRIPTION
As title states. Our dependency on `yarn` doesn't follow Node convention. `devDependency` is a better fit being that `yarn` falls under "a package that's only needed for local development and testing".

Here is [slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1666651217612399) for reference.