### PR TITLE
Add I18n for dataset metadata.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "git+ssh://git@github.com/code-dot-org/ml-playground.git"
   },
   "jest": {
-    "silent": true,
     "moduleNameMapper": {
       ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav|gif)$": "identity-obj-proxy",
       "^@public(.*)$": "<rootDir>/public/$1"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+ssh://git@github.com/code-dot-org/ml-playground.git"
   },
   "jest": {
+    "silent": true,
     "moduleNameMapper": {
       ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav|gif)$": "identity-obj-proxy",
       "^@public(.*)$": "<rootDir>/public/$1"

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -22,7 +22,8 @@ import I18n from "../i18n";
 class ColumnInspector extends Component {
   static propTypes = {
     currentColumnDetails: currentColumnInspectorShape,
-    currentPanel: PropTypes.string
+    currentPanel: PropTypes.string,
+    datasetId: PropTypes.string
   };
 
   render() {
@@ -41,6 +42,12 @@ class ColumnInspector extends Component {
     }
 
     const localizedDataType = I18n.t(`columnType_${currentColumnDetails.dataType}`)
+    const localizedColumnName = I18n.t("id",
+      {
+        scope: ["datasets", this.props.datasetId, "fields", currentColumnDetails.id],
+        "default": currentColumnDetails.id
+      }
+    );
     return (
       currentColumnDetails && (
         <div
@@ -95,6 +102,7 @@ class ColumnInspector extends Component {
 export default connect(
   state => ({
     currentColumnDetails: getCurrentColumnDetails(state),
-    currentPanel: state.currentPanel
+    currentPanel: state.currentPanel,
+    datasetId: state.metadata.name
   })
 )(ColumnInspector);

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -100,6 +100,6 @@ export default connect(
   state => ({
     currentColumnDetails: getCurrentColumnDetails(state),
     currentPanel: state.currentPanel,
-    datasetId: state.metadata.name
+    datasetId: state.metadata && state.metadata.name
   })
 )(ColumnInspector);

--- a/src/UIComponents/ColumnInspector.jsx
+++ b/src/UIComponents/ColumnInspector.jsx
@@ -18,6 +18,7 @@ import SelectLabelButton from "./SelectLabelButton";
 import UniqueOptionsWarning from "./UniqueOptionsWarning";
 import { currentColumnInspectorShape } from "./shapes";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class ColumnInspector extends Component {
   static propTypes = {
@@ -27,7 +28,7 @@ class ColumnInspector extends Component {
   };
 
   render() {
-    const { currentColumnDetails, currentPanel } = this.props;
+    const { currentColumnDetails, currentPanel, datasetId } = this.props;
 
     const selectingFeatures = currentPanel === "dataDisplayFeatures";
     const selectingLabel = currentPanel === "dataDisplayLabel";
@@ -42,12 +43,8 @@ class ColumnInspector extends Component {
     }
 
     const localizedDataType = I18n.t(`columnType_${currentColumnDetails.dataType}`)
-    const localizedColumnName = I18n.t("id",
-      {
-        scope: ["datasets", this.props.datasetId, "fields", currentColumnDetails.id],
-        "default": currentColumnDetails.id
-      }
-    );
+    const localizedColumnName = getLocalizedColumnName(datasetId, currentColumnDetails.id);
+
     return (
       currentColumnDetails && (
         <div
@@ -57,7 +54,7 @@ class ColumnInspector extends Component {
             ...styles.rightPanel
           }}
         >
-          <div style={styles.largeText}>{currentColumnDetails.id}</div>
+          <div style={styles.largeText}>{localizedColumnName}</div>
           <ScrollableContent>
             <div style={styles.cardRow}>
               <span style={styles.bold}>{I18n.t("columnInspectorDataType")}</span>

--- a/src/UIComponents/DataCard.jsx
+++ b/src/UIComponents/DataCard.jsx
@@ -4,20 +4,22 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { styles } from "../constants.js";
 import ScrollableContent from "./ScrollableContent";
-import { metadataShape } from "./shapes.js";
+import { metadataShape, datasetDetailsShape } from "./shapes.js";
 import I18n from "../i18n";
+import { getDatasetDetails } from "../helpers/datasetDetails";
 
 class DataCard extends Component {
   static propTypes = {
     name: PropTypes.string,
     metadata: metadataShape,
+    datasetDetails: datasetDetailsShape,
     dataLength: PropTypes.number,
     removedRowsCount: PropTypes.number
   };
 
   render() {
 
-    const { name, metadata, dataLength, removedRowsCount  } = this.props;
+    const { name, metadata, datasetDetails, dataLength, removedRowsCount  } = this.props;
 
     const card = metadata && metadata.card;
 
@@ -40,7 +42,7 @@ class DataCard extends Component {
           <ScrollableContent>
             {card && (
               <div>
-                <div style={styles.cardRow}>{metadata.card.description}</div>
+                <div style={styles.cardRow}>{datasetDetails.description}</div>
                 <div style={styles.cardRow}>
                   <span style={styles.italic}>
                     {I18n.t("dataCardSource")}
@@ -69,7 +71,7 @@ class DataCard extends Component {
                   <div style={styles.cardRow}>
                     <div style={styles.bold}>{I18n.t("dataCardPotentialUses")}</div>
                     <div style={styles.italic}>
-                      {metadata.card.context.potentialUses}
+                      {datasetDetails.potentialUses}
                     </div>
                   </div>
                 )}
@@ -77,7 +79,7 @@ class DataCard extends Component {
                   <div style={styles.cardRow}>
                     <div style={styles.bold}>{I18n.t("dataCardPotentialMisuses")}</div>
                     <div style={styles.italic}>
-                      {metadata.card.context.potentialMisuses}
+                      {datasetDetails.potentialMisuses}
                     </div>
                   </div>
                 )}
@@ -110,6 +112,7 @@ class DataCard extends Component {
 export default connect(state => ({
   name: state.name,
   metadata: state.metadata,
+  datasetDetails: getDatasetDetails(state),
   dataLength: state.data.length,
   removedRowsCount: state.removedRowsCount
 }))(DataCard);

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -4,11 +4,13 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getTableData, setCurrentColumn, setHighlightColumn } from "../redux";
 import { styles } from "../constants";
+import I18n from "../i18n";
 
 class DataTable extends Component {
   static propTypes = {
     currentPanel: PropTypes.string,
     data: PropTypes.array,
+    datasetId: PropTypes.string,
     labelColumn: PropTypes.string,
     selectedFeatures: PropTypes.array,
     setCurrentColumn: PropTypes.func,
@@ -121,7 +123,12 @@ class DataTable extends Component {
                   onMouseEnter={() => this.setHighlightColumn(columnId)}
                   onMouseLeave={() => this.setHighlightColumn(undefined)}
                 >
-                  {columnId}
+                  {I18n.t("id",
+                    {
+                      scope: ["datasets", this.props.datasetId, "fields", columnId],
+                      "default": columnId
+                    }
+                  )}
                 </th>
               );
             })}
@@ -163,6 +170,7 @@ class DataTable extends Component {
 export default connect(
   (state, props) => ({
     data: getTableData(state, props.useResultsData),
+    datasetId: state.metadata.name,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
     currentColumn: state.currentColumn,

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -4,7 +4,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { getTableData, setCurrentColumn, setHighlightColumn } from "../redux";
 import { styles } from "../constants";
-import I18n from "../i18n";
 import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class DataTable extends Component {

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -165,7 +165,7 @@ class DataTable extends Component {
 export default connect(
   (state, props) => ({
     data: getTableData(state, props.useResultsData),
-    datasetId: state.metadata.name,
+    datasetId: state.metadata && state.metadata.name,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
     currentColumn: state.currentColumn,

--- a/src/UIComponents/DataTable.jsx
+++ b/src/UIComponents/DataTable.jsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { getTableData, setCurrentColumn, setHighlightColumn } from "../redux";
 import { styles } from "../constants";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class DataTable extends Component {
   static propTypes = {
@@ -123,12 +124,7 @@ class DataTable extends Component {
                   onMouseEnter={() => this.setHighlightColumn(columnId)}
                   onMouseLeave={() => this.setHighlightColumn(undefined)}
                 >
-                  {I18n.t("id",
-                    {
-                      scope: ["datasets", this.props.datasetId, "fields", columnId],
-                      "default": columnId
-                    }
-                  )}
+                  {getLocalizedColumnName(this.props.datasetId, columnId)}
                 </th>
               );
             })}

--- a/src/UIComponents/ModelCard.jsx
+++ b/src/UIComponents/ModelCard.jsx
@@ -10,6 +10,7 @@ import Statement from "./Statement";
 import aiBotBorder from "@public/images/ai-bot/ai-bot-border.png";
 import { modelCardDatasetDetailsShape, trainedModelDetailsShape, modelCardColumnShape } from "./shapes";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class ModelCard extends Component {
   static propTypes = {
@@ -31,8 +32,11 @@ class ModelCard extends Component {
       datasetDetails
     } = this.props;
     console.log("trainedModelDetails", trainedModelDetails)
+    const localizedLabel = getLocalizedColumnName(datasetDetails.name, label.id);
+    const localizedFeatures =
+      selectedFeatures.map(feature => getLocalizedColumnName(datasetDetails.name, feature));
     const predictionStatement = I18n.t("predictionStatement",
-      {"output": label.id, "inputs": selectedFeatures.join(", ")})
+      {"output": localizedLabel, "inputs": localizedFeatures.join(", ")})
     return (
       <div style={styles.panel}>
         <Statement />
@@ -104,7 +108,7 @@ class ModelCard extends Component {
           <div style={styles.modelCardSubpanel}>
             <h5 style={styles.modelCardHeading}>{I18n.t("modelCardLabel")}</h5>
             <div style={styles.modelCardContent}>
-              <p style={styles.bold}>{label.id}</p>
+              <p style={styles.bold}>{localizedLabel}</p>
               {label.description && <p>{label.description}</p>}
               {!label.values && (
                 <p style={styles.modelCardDetails}>

--- a/src/UIComponents/ModelCard.jsx
+++ b/src/UIComponents/ModelCard.jsx
@@ -8,7 +8,7 @@ import { getPercentCorrect } from "../helpers/accuracy";
 import { getDatasetDetails } from "../helpers/datasetDetails";
 import Statement from "./Statement";
 import aiBotBorder from "@public/images/ai-bot/ai-bot-border.png";
-import { modelCardDatasetDetailsShape, trainedModelDetailsShape, modelCardColumnShape } from "./shapes";
+import { datasetDetailsShape, trainedModelDetailsShape, modelCardColumnShape } from "./shapes";
 import I18n from "../i18n";
 import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
@@ -19,7 +19,7 @@ class ModelCard extends Component {
     percentCorrect: PropTypes.string,
     label: modelCardColumnShape,
     features: PropTypes.arrayOf(PropTypes.string),
-    datasetDetails: modelCardDatasetDetailsShape
+    datasetDetails: datasetDetailsShape
   };
 
   render() {

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -143,7 +143,7 @@ export default connect(
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
     getPredictAvailable: getPredictAvailable(state),
     extremaByColumn: getExtremaByColumn(state),
-    datasetId: state.metadata.name
+    datasetId: state.metadata && state.metadata.name
   }),
   dispatch => ({
     setTestData(feature, value) {

--- a/src/UIComponents/Predict.jsx
+++ b/src/UIComponents/Predict.jsx
@@ -16,6 +16,7 @@ import { styles } from "../constants";
 import aiBotBorder from "@public/images/ai-bot/ai-bot-border.png";
 import ScrollableContent from "./ScrollableContent";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class Predict extends Component {
   static propTypes = {
@@ -27,7 +28,8 @@ class Predict extends Component {
     setTestData: PropTypes.func.isRequired,
     predictedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     getPredictAvailable: PropTypes.bool,
-    extremaByColumn: PropTypes.object
+    extremaByColumn: PropTypes.object,
+    datasetId: PropTypes.string
   };
 
   handleChange = (event, feature) => {
@@ -39,6 +41,7 @@ class Predict extends Component {
   };
 
   render() {
+    const { datasetId, labelColumn, predictedLabel } = this.props;
     return (
       <div id="predict" style={{ ...styles.panel, ...styles.rightPanel }}>
         <div style={styles.largeText}>{I18n.t("predictHeader")}</div>
@@ -51,7 +54,7 @@ class Predict extends Component {
               return (
                 <div style={styles.cardRow} key={index}>
                   <label>
-                    {feature}
+                    {getLocalizedColumnName(datasetId, feature)}
                     &nbsp;
                     <input
                       type="number"
@@ -70,7 +73,7 @@ class Predict extends Component {
             {this.props.selectedCategoricalFeatures.map((feature, index) => {
               return (
                 <div style={styles.cardRow} key={index}>
-                  <div>{feature}&nbsp;</div>
+                  <div>{getLocalizedColumnName(datasetId, feature)}&nbsp;</div>
                   <div>
                     <select
                       onChange={event => this.handleChange(event, feature)}
@@ -120,8 +123,8 @@ class Predict extends Component {
             </div>
             <div style={styles.predictBotRight}>
               <div style={styles.statement}>{I18n.t("predictAIBotPredicts")}</div>
-              <div>{this.props.labelColumn}</div>
-              <div>{this.props.predictedLabel}</div>
+              <div>{getLocalizedColumnName(datasetId, labelColumn)}</div>
+              <div>{getLocalizedColumnName(datasetId, predictedLabel)}</div>
             </div>
           </div>
         )}
@@ -139,7 +142,8 @@ export default connect(
     selectedCategoricalFeatures: getSelectedCategoricalFeatures(state),
     uniqueOptionsByColumn: getUniqueOptionsByColumn(state),
     getPredictAvailable: getPredictAvailable(state),
-    extremaByColumn: getExtremaByColumn(state)
+    extremaByColumn: getExtremaByColumn(state),
+    datasetId: state.metadata.name
   }),
   dispatch => ({
     setTestData(feature, value) {

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -145,7 +145,7 @@ export default connect(
     labelColumn: state.labelColumn,
     isRegression: isRegression(state),
     resultsHighlightRow: state.resultsHighlightRow,
-    datasetId: state.metadata.name
+    datasetId: state.metadata && state.metadata.name
   }),
   dispatch => ({
     setResultsHighlightRow(column) {

--- a/src/UIComponents/ResultsTable.jsx
+++ b/src/UIComponents/ResultsTable.jsx
@@ -6,6 +6,7 @@ import { isRegression, setResultsHighlightRow } from "../redux";
 import { styles, colors, REGRESSION_ERROR_TOLERANCE } from "../constants";
 import { resultsPropType } from "./shapes";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class ResultsTable extends Component {
   static propTypes = {
@@ -14,7 +15,8 @@ class ResultsTable extends Component {
     results: resultsPropType,
     isRegression: PropTypes.bool,
     setResultsHighlightRow: PropTypes.func,
-    resultsHighlightRow: PropTypes.number
+    resultsHighlightRow: PropTypes.number,
+    datasetId: PropTypes.string
   };
 
   getRowCellStyle = index => {
@@ -26,7 +28,7 @@ class ResultsTable extends Component {
   };
 
   render() {
-    const { setResultsHighlightRow } = this.props;
+    const { setResultsHighlightRow, datasetId } = this.props;
     const featureCount = this.props.selectedFeatures.length;
 
     return (
@@ -81,7 +83,7 @@ class ResultsTable extends Component {
                       }}
                       key={index}
                     >
-                      {feature}
+                      {getLocalizedColumnName(datasetId, feature)}
                     </th>
                   );
                 })}
@@ -92,7 +94,7 @@ class ResultsTable extends Component {
                     ...styles.resultsTableSecondHeader
                   }}
                 >
-                  {this.props.labelColumn}
+                  {getLocalizedColumnName(datasetId, this.props.labelColumn)}
                 </th>
                 <th
                   style={{
@@ -101,7 +103,7 @@ class ResultsTable extends Component {
                     ...styles.resultsTableSecondHeader
                   }}
                 >
-                  {this.props.labelColumn}
+                  {getLocalizedColumnName(datasetId, this.props.labelColumn)}
                 </th>
               </tr>
             </thead>
@@ -142,7 +144,8 @@ export default connect(
     selectedFeatures: state.selectedFeatures,
     labelColumn: state.labelColumn,
     isRegression: isRegression(state),
-    resultsHighlightRow: state.resultsHighlightRow
+    resultsHighlightRow: state.resultsHighlightRow,
+    datasetId: state.metadata.name
   }),
   dispatch => ({
     setResultsHighlightRow(column) {

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -12,7 +12,7 @@ import { styles, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
 import ScrollableContent from "./ScrollableContent";
 import I18n from "../i18n";
-import { getLocalizedColumnName, getLocalizedColumnDescription } from "../helpers/columnDetails.js";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class SaveModel extends Component {
   static propTypes = {
@@ -57,7 +57,7 @@ class SaveModel extends Component {
         id: columnDescription.id,
         isColumn: true,
         columnType,
-        answer: getLocalizedColumnDescription(datasetId, columnDescription.description),
+        answer: columnDescription.description,
         localizedName: getLocalizedColumnName(datasetId, columnDescription.id)
       });
     }

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -12,6 +12,7 @@ import { styles, ModelNameMaxLength } from "../constants";
 import Statement from "./Statement";
 import ScrollableContent from "./ScrollableContent";
 import I18n from "../i18n";
+import { getLocalizedColumnName, getLocalizedColumnDescription } from "../helpers/columnDetails.js";
 
 class SaveModel extends Component {
   static propTypes = {
@@ -21,7 +22,8 @@ class SaveModel extends Component {
     labelColumn: PropTypes.string,
     columnDescriptions: PropTypes.array,
     dataDescription: PropTypes.string,
-    isUserUploadedDataset: PropTypes.bool
+    isUserUploadedDataset: PropTypes.bool,
+    datasetId: PropTypes.string
   };
 
   constructor(props) {
@@ -46,6 +48,7 @@ class SaveModel extends Component {
     var fields = [];
 
     for (const columnDescription of this.props.columnDescriptions) {
+      const datasetId = this.props.datasetId;
       const labelType = I18n.t("saveModelColumnTypeLabel");
       const featureType = I18n.t("saveModelColumnTypeFeature");
       const columnType =
@@ -54,8 +57,8 @@ class SaveModel extends Component {
         id: columnDescription.id,
         isColumn: true,
         columnType,
-        answer: columnDescription.description,
-        localizedName: columnDescription.localizedName
+        answer: getLocalizedColumnDescription(datasetId, columnDescription.description),
+        localizedName: getLocalizedColumnName(datasetId, columnDescription.id)
       });
     }
     return fields;
@@ -230,7 +233,8 @@ export default connect(
     labelColumn: state.labelColumn,
     columnDescriptions: getSelectedColumnsDescriptions(state),
     dataDescription: getDatasetDescription(state),
-    isUserUploadedDataset: isUserUploadedDataset(state)
+    isUserUploadedDataset: isUserUploadedDataset(state),
+    datasetId: state.metadata && state.metadata.name
   }),
   dispatch => ({
     setTrainedModelDetail(field, value, isColumn) {

--- a/src/UIComponents/SaveModel.jsx
+++ b/src/UIComponents/SaveModel.jsx
@@ -54,7 +54,8 @@ class SaveModel extends Component {
         id: columnDescription.id,
         isColumn: true,
         columnType,
-        answer: columnDescription.description
+        answer: columnDescription.description,
+        localizedName: columnDescription.localizedName
       });
     }
     return fields;
@@ -191,7 +192,7 @@ class SaveModel extends Component {
                   return (
                     <div key={field.id} style={styles.cardRow}>
                       <div>
-                        <span style={styles.bold}>{field.id}</span> (
+                        <span style={styles.bold}>{field.localizedName}</span> (
                         {field.columnType})
                       </div>
                       {this.props.isUserUploadedDataset && (

--- a/src/UIComponents/Statement.jsx
+++ b/src/UIComponents/Statement.jsx
@@ -7,6 +7,7 @@ import { styles } from "../constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import I18n from "../i18n";
+import { getLocalizedColumnName } from "../helpers/columnDetails.js";
 
 class Statement extends Component {
   static propTypes = {
@@ -17,7 +18,8 @@ class Statement extends Component {
     labelColumn: PropTypes.string,
     selectedFeatures: PropTypes.array,
     setLabelColumn: PropTypes.func,
-    removeSelectedFeature: PropTypes.func
+    removeSelectedFeature: PropTypes.func,
+    datasetId: PropTypes.string
   };
 
   removeLabel = () => {
@@ -29,9 +31,10 @@ class Statement extends Component {
   };
 
   labelHTML = (label , currentPanel) => {
+    const localizedLabel = getLocalizedColumnName(this.props.datasetId, label);
     return (
       <div style={styles.statementLabel}>
-        {label || "____"}
+        {(label && localizedLabel) || "____"}
         {label && currentPanel === "dataDisplayLabel" && (
           <div
             id="uitest-remove-statement-label"
@@ -55,10 +58,11 @@ class Statement extends Component {
     return (
       <span>
         {selectedFeatures.map((selectedFeature, index) => {
+          const localizedName = getLocalizedColumnName(this.props.datasetId, selectedFeature);
           return (
             <span key={index}>
               <div style={styles.statementFeature}>
-                {selectedFeature}
+                {localizedName}
                 {currentPanel === "dataDisplayFeatures" && (
                   <div
                     id="uitest-remove-statement-feature"
@@ -148,7 +152,8 @@ export default connect(
     data: state.data,
     currentPanel: state.currentPanel,
     labelColumn: state.labelColumn,
-    selectedFeatures: state.selectedFeatures
+    selectedFeatures: state.selectedFeatures,
+    datasetId: state.metadata.name
   }),
   dispatch => ({
     setLabelColumn(labelColumn) {

--- a/src/UIComponents/Statement.jsx
+++ b/src/UIComponents/Statement.jsx
@@ -153,7 +153,7 @@ export default connect(
     currentPanel: state.currentPanel,
     labelColumn: state.labelColumn,
     selectedFeatures: state.selectedFeatures,
-    datasetId: state.metadata.name
+    datasetId: state.metadata && state.metadata.name
   }),
   dispatch => ({
     setLabelColumn(labelColumn) {

--- a/src/UIComponents/Statement.jsx
+++ b/src/UIComponents/Statement.jsx
@@ -34,8 +34,8 @@ class Statement extends Component {
     const localizedLabel = getLocalizedColumnName(this.props.datasetId, label);
     return (
       <div style={styles.statementLabel}>
-        {(label && localizedLabel) || "____"}
-        {label && currentPanel === "dataDisplayLabel" && (
+        {localizedLabel || "____"}
+        {localizedLabel && currentPanel === "dataDisplayLabel" && (
           <div
             id="uitest-remove-statement-label"
             onClick={() => this.removeLabel()}

--- a/src/UIComponents/shapes.js
+++ b/src/UIComponents/shapes.js
@@ -73,9 +73,11 @@ export const modelCardColumnShape = PropTypes.shape({
   values: PropTypes.array
 });
 
-export const modelCardDatasetDetailsShape = PropTypes.shape({
+export const datasetDetailsShape = PropTypes.shape({
   description: PropTypes.string,
   isUserUploaded: PropTypes.bool.isRequired,
   name: PropTypes.string,
-  numRows: PropTypes.number.isRequired
+  numRows: PropTypes.number.isRequired,
+  potentialUses: PropTypes.string,
+  potentialMisuses: PropTypes.string
 });

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -69,7 +69,7 @@ export function getColumnDescription(columnId, metadata, trainedModelDetails) {
     const field = metadata.fields.find(field => {
       return field.id === columnId;
     });
-    return getLocalizedColumnDescription(metadata.name, columnId, field.description)
+    return getLocalizedColumnDescription(metadata.name, columnId, field.description);
   }
 
   // Try using a user-entered column description if available.

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -1,3 +1,5 @@
+import I18n from "../i18n";
+
 /* Helper functions for getting information about a column and its data. */
 
 import { ColumnTypes, UNIQUE_OPTIONS_MAX } from "../constants.js";
@@ -115,4 +117,13 @@ export function getColumnDataToSave(state, column) {
     columnData.min = min;
   }
   return columnData;
+}
+
+export function getLocalizedColumnName(datasetId, columnId) {
+  return I18n.t("id",
+    {
+      scope: ["datasets", datasetId, "fields", columnId],
+      "default": columnId
+    }
+  );
 }

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -120,7 +120,15 @@ export function getColumnDataToSave(state, column) {
 }
 
 export function getLocalizedColumnName(datasetId, columnId) {
-  return I18n.t("id",
+  return getLocalizedColumnField(datasetId, columnId, "id");
+}
+
+export function getLocalizedColumnDescription(datasetId, columnId) {
+  return getLocalizedColumnField(datasetId, columnId, "description");
+}
+
+function getLocalizedColumnField(datasetId, columnId, field) {
+  return I18n.t(field,
     {
       scope: ["datasets", datasetId, "fields", columnId],
       "default": columnId

--- a/src/helpers/columnDetails.js
+++ b/src/helpers/columnDetails.js
@@ -69,7 +69,7 @@ export function getColumnDescription(columnId, metadata, trainedModelDetails) {
     const field = metadata.fields.find(field => {
       return field.id === columnId;
     });
-    return field.description;
+    return getLocalizedColumnDescription(metadata.name, columnId, field.description)
   }
 
   // Try using a user-entered column description if available.
@@ -120,18 +120,18 @@ export function getColumnDataToSave(state, column) {
 }
 
 export function getLocalizedColumnName(datasetId, columnId) {
-  return getLocalizedColumnField(datasetId, columnId, "id");
+  return getLocalizedColumnAttr(datasetId, columnId, "id", columnId);
 }
 
-export function getLocalizedColumnDescription(datasetId, columnId) {
-  return getLocalizedColumnField(datasetId, columnId, "description");
+function getLocalizedColumnDescription(datasetId, columnId, description) {
+  return getLocalizedColumnAttr(datasetId, columnId, "description", description);
 }
 
-function getLocalizedColumnField(datasetId, columnId, field) {
-  return I18n.t(field,
+function getLocalizedColumnAttr(datasetId, columnId, attribute, fallback) {
+  return I18n.t(attribute,
     {
       scope: ["datasets", datasetId, "fields", columnId],
-      "default": columnId
+      default: fallback
     }
   );
 }

--- a/src/helpers/datasetDetails.js
+++ b/src/helpers/datasetDetails.js
@@ -13,17 +13,17 @@ export function getDatasetDetails(state) {
   return datasetDetails;
 }
 
-function getPotentialUses(state) {
+function getCardContextAttr(state, attr) {
   if (
     state.metadata &&
     state.metadata.name &&
     state.metadata.card &&
     state.metadata.card.context &&
-    state.metadata.card.context.potentialUses
+    state.metadata.card.context[attr]
   ) {
     const datasetId = state.metadata.name;
-    const fallback = state.metadata.card.context.potentialUses;
-    return I18n.t("potentialUses",
+    const fallback = state.metadata.card.context[attr];
+    return I18n.t(attr,
       {
         scope: ["datasets", datasetId, "card", "context"],
         default: fallback
@@ -32,25 +32,12 @@ function getPotentialUses(state) {
   }
   return undefined;
 }
+function getPotentialUses(state) {
+  return getCardContextAttr(state, "potentialUses");
+}
 
 function getPotentialMisuses(state) {
-  if (
-    state.metadata &&
-    state.metadata.name &&
-    state.metadata.card &&
-    state.metadata.card.context &&
-    state.metadata.card.context.potentialMisuses
-  ) {
-    const datasetId = state.metadata.name;
-    const fallback = state.metadata.card.context.potentialMisuses;
-    return I18n.t("potentialMisuses",
-      {
-        scope: ["datasets", datasetId, "card", "context"],
-        default: fallback
-      }
-    );
-  }
-  return undefined;
+  return getCardContextAttr(state, "potentialMisuses");
 }
 
 export function getDatasetDescription(state) {

--- a/src/helpers/datasetDetails.js
+++ b/src/helpers/datasetDetails.js
@@ -1,3 +1,5 @@
+import I18n from "../i18n";
+
 /* Helper functions for getting information about the selected dataset. */
 
 export function getDatasetDetails(state) {
@@ -6,17 +8,67 @@ export function getDatasetDetails(state) {
   datasetDetails.description = getDatasetDescription(state);
   datasetDetails.numRows = state.data.length;
   datasetDetails.isUserUploaded = isUserUploadedDataset(state);
+  datasetDetails.potentialUses = getPotentialUses(state);
+  datasetDetails.potentialMisuses = getPotentialMisuses(state);
   return datasetDetails;
+}
+
+function getPotentialUses(state) {
+  if (
+    state.metadata &&
+    state.metadata.name &&
+    state.metadata.card &&
+    state.metadata.card.context &&
+    state.metadata.card.context.potentialUses
+  ) {
+    const datasetId = state.metadata.name;
+    const fallback = state.metadata.card.context.potentialUses;
+    return I18n.t("potentialUses",
+      {
+        scope: ["datasets", datasetId, "card", "context"],
+        default: fallback
+      }
+    );
+  }
+  return undefined;
+}
+
+function getPotentialMisuses(state) {
+  if (
+    state.metadata &&
+    state.metadata.name &&
+    state.metadata.card &&
+    state.metadata.card.context &&
+    state.metadata.card.context.potentialMisuses
+  ) {
+    const datasetId = state.metadata.name;
+    const fallback = state.metadata.card.context.potentialMisuses;
+    return I18n.t("potentialMisuses",
+      {
+        scope: ["datasets", datasetId, "card", "context"],
+        default: fallback
+      }
+    );
+  }
+  return undefined;
 }
 
 export function getDatasetDescription(state) {
   // If this a dataset from the internal collection that already has a description, use that.
   if (
     state.metadata &&
+    state.metadata.name &&
     state.metadata.card &&
     state.metadata.card.description
   ) {
-    return state.metadata.card.description;
+    const datasetId = state.metadata.name;
+    const fallback = state.metadata.card.description;
+    return I18n.t("description",
+      {
+        scope: ["datasets", datasetId, "card"],
+        default: fallback
+      }
+    );
   } else if (
     state.trainedModelDetails &&
     state.trainedModelDetails.datasetDescription
@@ -26,7 +78,6 @@ export function getDatasetDescription(state) {
     return undefined;
   }
 }
-
 
 export function isUserUploadedDataset(state) {
   // The csvfile for internally curated datasets are strings; those uploaded by

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,4 +1,4 @@
-import data from './i18n/ailab.json';
+import uiStrings from './i18n/ailab.json';
 import MessageFormat from 'messageformat'
 
 let messages;
@@ -6,13 +6,16 @@ let messages;
 const initI18n = (i18n = {}) => {
   // For now, use English pluralization rules.
   const mf = new MessageFormat('en');
-  messages = {...mf.compile(data), ...i18n};
+  messages = {...mf.compile(uiStrings), ...i18n};
 };
 
 const t = (key, options) => {
   if (!messages) {
     throw "I18n must be initialized before calling t";
   }
+  // The default value to return if no string is found for the given key
+  const defaultValue = options["default"];
+
   const scope = options["scope"] || [];
   let scopedMessages = messages;
   scope.forEach(s => {
@@ -23,14 +26,14 @@ const t = (key, options) => {
 
   if (scopedMessages === undefined) {
     console.warn("Couldn't find string for given key", key, options, scopedMessages);
-    return undefined;
+    return defaultValue;
   }
 
   // All strings should be represented by a Function. If it isn't, the scope probaly needs to be
   // defined.
   if (!(scopedMessages[key] instanceof Function)) {
     console.warn("Given key doesn't point to a single string", key, options, scopedMessages);
-    return undefined;
+    return defaultValue;
   }
 
   return scopedMessages[key](options);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -28,7 +28,7 @@ const t = (key, options = {}) => {
     return defaultValue;
   }
 
-  // All strings should be represented by a Function. If it isn't, the scope probaly needs to be
+  // All strings should be represented by a Function. If it isn't, the scope probably needs to be
   // defined.
   if (!(scopedMessages[key] instanceof Function)) {
     return defaultValue;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -13,7 +13,27 @@ const t = (key, options) => {
   if (!messages) {
     throw "I18n must be initialized before calling t";
   }
-  return messages[key](options);
+  const scope = options["scope"] || [];
+  let scopedMessages = messages;
+  scope.forEach(s => {
+    if (scopedMessages !== undefined) {
+      scopedMessages = scopedMessages[s]
+    }
+  });
+
+  if (scopedMessages === undefined) {
+    console.warn("Couldn't find string for given key", key, options, scopedMessages);
+    return undefined;
+  }
+
+  // All strings should be represented by a Function. If it isn't, the scope probaly needs to be
+  // defined.
+  if (!(scopedMessages[key] instanceof Function)) {
+    console.warn("Given key doesn't point to a single string", key, options, scopedMessages);
+    return undefined;
+  }
+
+  return scopedMessages[key](options);
 };
 
 /*

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,6 +9,15 @@ const initI18n = (i18n = {}) => {
   messages = {...mf.compile(uiStrings), ...i18n};
 };
 
+/**
+ *
+ * @param key {string} The ID of the translated string to return.
+ * @param options {Object} Contains options for modifying the lookup of the string.
+ * @param options["default"] {string} The string to return if no translation is found.
+ * @param options["scope"] {string[]} If the key is in a nested structure, you must define the path
+ * to it.
+ * @returns {string} The translated string. undefined if not found.
+ */
 const t = (key, options = {}) => {
   if (!messages) {
     throw "I18n must be initialized before calling t";
@@ -20,7 +29,7 @@ const t = (key, options = {}) => {
   let scopedMessages = messages;
   scope.forEach(s => {
     if (scopedMessages !== undefined) {
-      scopedMessages = scopedMessages[s]
+      scopedMessages = scopedMessages[s];
     }
   });
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -9,7 +9,7 @@ const initI18n = (i18n = {}) => {
   messages = {...mf.compile(uiStrings), ...i18n};
 };
 
-const t = (key, options) => {
+const t = (key, options = {}) => {
   if (!messages) {
     throw "I18n must be initialized before calling t";
   }
@@ -25,14 +25,12 @@ const t = (key, options) => {
   });
 
   if (scopedMessages === undefined) {
-    console.warn("Couldn't find string for given key", key, options, scopedMessages);
     return defaultValue;
   }
 
   // All strings should be represented by a Function. If it isn't, the scope probaly needs to be
   // defined.
   if (!(scopedMessages[key] instanceof Function)) {
-    console.warn("Given key doesn't point to a single string", key, options, scopedMessages);
     return defaultValue;
   }
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -15,7 +15,6 @@ export const getLabelColumn = state => state.labelColumn;
 export const getMetadata = state => state.metadata;
 export const getDatasetId = state => state.metadata.name;
 export const getTrainedModelDetails = state => state.trainedModelDetails;
-import { getLocalizedColumnName } from "./helpers/columnDetails.js";
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -99,8 +98,7 @@ export const getSelectedColumnsDescriptions = createSelector(
           column,
           metadata,
           trainedModelDetails
-        ),
-        localizedName: getLocalizedColumnName(metadata.name, column)
+        )
       };
     });
   }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -15,6 +15,7 @@ export const getLabelColumn = state => state.labelColumn;
 export const getMetadata = state => state.metadata;
 export const getDatasetId = state => state.metadata.name;
 export const getTrainedModelDetails = state => state.trainedModelDetails;
+import { getLocalizedColumnName } from "./helpers/columnDetails.js";
 
 export const getCategoricalColumns = createSelector(
   [getColumnsByDataType],
@@ -98,7 +99,8 @@ export const getSelectedColumnsDescriptions = createSelector(
           column,
           metadata,
           trainedModelDetails
-        )
+        ),
+        localizedName: getLocalizedColumnName(metadata.name, column)
       };
     });
   }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -13,6 +13,7 @@ export const getColumnsByDataType = state => state.columnsByDataType;
 const getSelectedFeatures = state => state.selectedFeatures;
 export const getLabelColumn = state => state.labelColumn;
 export const getMetadata = state => state.metadata;
+export const getDatasetId = state => state.metadata.name;
 export const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCategoricalColumns = createSelector(

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -13,7 +13,7 @@ export const getColumnsByDataType = state => state.columnsByDataType;
 const getSelectedFeatures = state => state.selectedFeatures;
 export const getLabelColumn = state => state.labelColumn;
 export const getMetadata = state => state.metadata;
-export const getDatasetId = state => state.metadata.name;
+export const getDatasetId = state => state.metadata && state.metadata.name;
 export const getTrainedModelDetails = state => state.trainedModelDetails;
 
 export const getCategoricalColumns = createSelector(

--- a/src/selectors/visualizationSelectors.js
+++ b/src/selectors/visualizationSelectors.js
@@ -1,11 +1,11 @@
 import { createSelector } from 'reselect';
-import { getLabelColumn, getData, getColumnsByDataType } from "../selectors.js";
+import {getLabelColumn, getData, getColumnsByDataType, getDatasetId} from "../selectors.js";
 import {
   getCurrentColumn,
   currentColumnIsCategorical,
   currentColumnIsNumerical
 } from './currentColumnSelectors.js';
-import { getUniqueOptions } from "../helpers/columnDetails.js";
+import { getUniqueOptions, getLocalizedColumnName } from "../helpers/columnDetails.js";
 import { areArraysEqual } from "../helpers/utils.js";
 import { ColumnTypes } from "../constants.js";
 
@@ -15,14 +15,16 @@ export const getScatterPlotData = createSelector(
     (state, props) => labelColumnIsNumerical(state, props),
     getCurrentColumn,
     currentColumnIsNumerical,
-    getData
+    getData,
+    getDatasetId
   ],
   (
     labelColumn,
     labelColumnIsNumerical,
     currentColumn,
     currentColumnIsNumerical,
-    data
+    data,
+    datasetId
   ) => {
     if (!labelColumn || !currentColumn) {
       return null;
@@ -42,8 +44,8 @@ export const getScatterPlotData = createSelector(
       coordinates.push({ x: row[currentColumn], y: row[labelColumn] });
     }
 
-    const label = labelColumn;
-    const feature = currentColumn;
+    const label = getLocalizedColumnName(datasetId, labelColumn);
+    const feature = getLocalizedColumnName(datasetId, currentColumn);
 
     return {
       label,

--- a/src/selectors/visualizationSelectors.js
+++ b/src/selectors/visualizationSelectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import {getLabelColumn, getData, getColumnsByDataType, getDatasetId} from "../selectors.js";
+import { getLabelColumn, getData, getColumnsByDataType, getDatasetId } from "../selectors.js";
 import {
   getCurrentColumn,
   currentColumnIsCategorical,

--- a/src/selectors/visualizationSelectors.js
+++ b/src/selectors/visualizationSelectors.js
@@ -96,7 +96,8 @@ export const getCrossTabData = createSelector(
     getCurrentColumn,
     currentColumnIsCategorical,
     getData,
-    (state, props) => getUniqueOptionsLabelColumn(state, props)
+    (state, props) => getUniqueOptionsLabelColumn(state, props),
+    getDatasetId
   ],
   (
     labelColumn,
@@ -104,7 +105,8 @@ export const getCrossTabData = createSelector(
     currentColumn,
     currentColumnIsCategorical,
     data,
-    uniqueOptionsLabelColumn
+    uniqueOptionsLabelColumn,
+    datasetId
   ) => {
     if (!labelColumn || !currentColumn) {
       return null;
@@ -164,11 +166,13 @@ export const getCrossTabData = createSelector(
     // to generate the header at the top of the CrossTab UI.
     const uniqueLabelValues =  uniqueOptionsLabelColumn;
 
+    const localizedLabelColumn = getLocalizedColumnName(datasetId, labelColumn);
+    const localizedCurrentColumn = getLocalizedColumnName(datasetId, currentColumn);
     return {
       results,
       uniqueLabelValues,
-      featureNames: [currentColumn],
-      labelName: labelColumn
+      featureNames: [localizedCurrentColumn],
+      labelName: localizedLabelColumn
     };
   }
 )

--- a/test/unit/columnDetails.test.js
+++ b/test/unit/columnDetails.test.js
@@ -19,6 +19,8 @@ import {
   mosquitoDescription
 } from './testData';
 import { ColumnTypes, UNIQUE_OPTIONS_MAX } from "../../src/constants.js";
+import I18n from "../../src/i18n";
+import MessageFormat from "messageformat";
 
 describe("column data types", () => {
   test("column is categorical", async () => {
@@ -121,6 +123,29 @@ describe("getColumnDescription", () => {
       {}
     );
     expect(result).toEqual(mosquitoDescription);
+  });
+
+  test("gets localized description", async () => {
+    const localizedDescription = "localizedValue";
+    const testTranslations = new MessageFormat('en').compile({
+      datasets: {
+        bats_eat_mozzies: {
+          fields: {
+            mosquitoCount: {
+              description: localizedDescription
+            }
+          }
+        }
+      }
+    });
+
+    I18n.reset();
+    I18n.initI18n(testTranslations);
+    const result = getColumnDescription(
+      "mosquitoCount",
+      premadeDatasetState.metadata,
+      {});
+    expect(result).toEqual(localizedDescription);
   });
 
   test("no description", async () => {

--- a/test/unit/columnDetails.test.js
+++ b/test/unit/columnDetails.test.js
@@ -16,11 +16,19 @@ import {
   premadeDatasetState,
   mosquitoCountMax,
   mosquitoCountMin,
-  mosquitoDescription
+  mosquitoDescription,
+  premadeDatasetTranslations
 } from './testData';
 import { ColumnTypes, UNIQUE_OPTIONS_MAX } from "../../src/constants.js";
 import I18n from "../../src/i18n";
-import MessageFormat from "messageformat";
+
+beforeEach(() => {
+  I18n.initI18n();
+});
+
+afterEach(() => {
+  I18n.reset();
+});
 
 describe("column data types", () => {
   test("column is categorical", async () => {
@@ -126,26 +134,13 @@ describe("getColumnDescription", () => {
   });
 
   test("gets localized description", async () => {
-    const localizedDescription = "localizedValue";
-    const testTranslations = new MessageFormat('en').compile({
-      datasets: {
-        bats_eat_mozzies: {
-          fields: {
-            mosquitoCount: {
-              description: localizedDescription
-            }
-          }
-        }
-      }
-    });
-
     I18n.reset();
-    I18n.initI18n(testTranslations);
+    I18n.initI18n(premadeDatasetTranslations);
     const result = getColumnDescription(
       "mosquitoCount",
       premadeDatasetState.metadata,
       {});
-    expect(result).toEqual(localizedDescription);
+    expect(result).toEqual("mosquitoCount description");
   });
 
   test("no description", async () => {

--- a/test/unit/datasetDetails.test.js
+++ b/test/unit/datasetDetails.test.js
@@ -8,8 +8,23 @@ import {
   premadeDatasetState,
   playDatasetDescription,
   batDatasetDescription,
-  premadeDatasetName
+  batDatasetDescriptionLocalized,
+  premadeDatasetName,
+  premadeDatasetTranslations,
+  batDatasetUses,
+  batDatasetUsesLocalized,
+  batDatasetMisuses,
+  batDatasetMisusesLocalized
 } from './testData';
+import I18n from "../../src/i18n";
+
+beforeEach(() => {
+  I18n.initI18n();
+});
+
+afterEach(() => {
+  I18n.reset();
+});
 
 describe("isUserUploadedDataset", () => {
   test("user uploaded dataset", async () => {
@@ -31,6 +46,13 @@ describe("getDatasetDescription", () => {
     const description = getDatasetDescription(premadeDatasetState);
     expect(description).toBe(batDatasetDescription);
   });
+
+  test("returns localized description", async () => {
+    I18n.reset();
+    I18n.initI18n(premadeDatasetTranslations);
+    const description = getDatasetDescription(premadeDatasetState);
+    expect(description).toBe(batDatasetDescriptionLocalized);
+  });
 });
 
 describe("getDatasetDetails", () => {
@@ -48,5 +70,17 @@ describe("getDatasetDetails", () => {
     expect(details.description).toBe(batDatasetDescription);
     expect(details.numRows).toBe(premadeDatasetState.data.length);
     expect(details.isUserUploaded).toBe(false);
+    expect(details.potentialUses).toBe(batDatasetUses);
+    expect(details.potentialMisuses).toBe(batDatasetMisuses);
+  });
+
+  test("returns localized strings", async () => {
+    I18n.reset();
+    I18n.initI18n(premadeDatasetTranslations);
+    const details = getDatasetDetails(premadeDatasetState);
+    expect(details.description).toBe(batDatasetDescriptionLocalized);
+    expect(details.potentialUses).toBe(batDatasetUsesLocalized);
+    expect(details.potentialMisuses).toBe(batDatasetMisusesLocalized);
+    I18n.reset();
   });
 });

--- a/test/unit/i18n.test.js
+++ b/test/unit/i18n.test.js
@@ -2,7 +2,14 @@ import I18n from '../../src/i18n';
 import MessageFormat from "messageformat";
 
 let testTranslations = new MessageFormat('en').compile({
-  "hello": "hello {name}"
+  "hello": "hello {name}",
+  "nested": {
+    "one": {
+      "two": {
+        "three": "3"
+      }
+    }
+  }
 });
 
 describe('I18n.t', () => {
@@ -17,5 +24,28 @@ describe('I18n.t', () => {
     I18n.reset();
     I18n.initI18n(testTranslations);
     expect(I18n.t("hello", {"name": "test"})).toEqual("hello test");
+  });
+
+  describe('with scope', () => {
+    test('returns undefined given shallow scope', async () => {
+      I18n.reset();
+      I18n.initI18n(testTranslations);
+      expect(I18n.t("three", {"scope": ["nested", "one"]}))
+        .toEqual(undefined);
+    });
+
+    test('returns undefined given incorrect scope', async () => {
+      I18n.reset();
+      I18n.initI18n(testTranslations);
+      expect(I18n.t("three", {"scope": ["nested", "two", "one"]}))
+        .toEqual(undefined);
+    });
+
+    test('returns "three" given correct scope', async () => {
+      I18n.reset();
+      I18n.initI18n(testTranslations);
+      expect(I18n.t("three", {"scope": ["nested", "one", "two"]}))
+        .toEqual("3");
+    });
   });
 });

--- a/test/unit/i18n.test.js
+++ b/test/unit/i18n.test.js
@@ -3,6 +3,7 @@ import MessageFormat from "messageformat";
 
 let testTranslations = new MessageFormat('en').compile({
   "hello": "hello {name}",
+  "simple": "simpleValue",
   "nested": {
     "one": {
       "two": {
@@ -24,6 +25,22 @@ describe('I18n.t', () => {
     I18n.reset();
     I18n.initI18n(testTranslations);
     expect(I18n.t("hello", {"name": "test"})).toEqual("hello test");
+  });
+
+  describe('with default', () => {
+    test('returns default when string not found', async () => {
+      I18n.reset();
+      I18n.initI18n(testTranslations);
+      expect(I18n.t("keyDoesNotExist", {"default": "testDefault"}))
+        .toEqual("testDefault");
+    });
+
+    test('returns string given good key', async () => {
+      I18n.reset();
+      I18n.initI18n(testTranslations);
+      expect(I18n.t("simple", {"default": "testDefault"}))
+        .toEqual("simpleValue");
+    });
   });
 
   describe('with scope', () => {

--- a/test/unit/testData.js
+++ b/test/unit/testData.js
@@ -1,5 +1,7 @@
 /* Mock state to be used across the testing suite. */
 
+import MessageFormat from "messageformat";
+
 export const regressionState = {
   data: [
     {
@@ -149,7 +151,12 @@ export const allNumericalState = {
 
 export const premadeDatasetName = 'bats_eat_mozzies';
 export const batDatasetDescription = 'Count of bats and mosquitios';
+export const batDatasetDescriptionLocalized = 'Localized How many mosquitoes there are.';
 export const mosquitoDescription = 'How many mosquitoes there are.';
+export const batDatasetUses = 'People can have a fun time learning about bats';
+export const batDatasetUsesLocalized = 'Localized People can have a fun time learning about bats';
+export const batDatasetMisuses = 'Hunters could use this information to avoid bats';
+export const batDatasetMisusesLocalized = 'Localized Hunters could use this information to avoid bats';
 
 export const premadeDatasetState = {
   ...allNumericalState,
@@ -157,7 +164,11 @@ export const premadeDatasetState = {
   metadata: {
     name: premadeDatasetName,
     card: {
-      description: batDatasetDescription
+      description: batDatasetDescription,
+      context: {
+        potentialUses: batDatasetUses,
+        potentialMisuses: batDatasetMisuses
+      }
     },
     defaultLabelColumn: 'mosquitoCount',
     fields: [
@@ -174,6 +185,25 @@ export const premadeDatasetState = {
     ]
   }
 }
+
+export const premadeDatasetTranslations = new MessageFormat('en').compile({
+  datasets: {
+    bats_eat_mozzies: {
+      fields: {
+        mosquitoCount: {
+          description: "mosquitoCount description"
+        }
+      },
+      card: {
+        description: batDatasetDescriptionLocalized,
+        context: {
+          potentialUses: batDatasetUsesLocalized,
+          potentialMisuses: batDatasetMisusesLocalized
+        }
+      }
+    }
+  }
+});
 
 export const playDatasetDescription = "Survey of the weather, temperature and whether it was a good day to play outside.";
 

--- a/test/unit/visualizationSelectors.test.js
+++ b/test/unit/visualizationSelectors.test.js
@@ -10,6 +10,15 @@ import {
   currentColumnIsCategorical
 } from '../../src/selectors/currentColumnSelectors';
 import { allNumericalState, classificationState } from './testData';
+import I18n from "../../src/i18n";
+
+beforeEach(() => {
+  I18n.initI18n();
+});
+
+afterEach(() => {
+  I18n.reset();
+});
 
 describe("getScatterPlotData", () => {
   const expected = {


### PR DESCRIPTION
In AI Lab, we have datasets students can use. These datasets have metadata file with content which is display to the user and needs to be translated. For example: https://github.com/code-dot-org/ml-playground/blob/main/public/datasets/billionaires.json
This metadata is sprinkled all over the app, that's why this PR is so large.

This PR also adds `default` and `scope` to the options in `I18n.t()`.
* `default`: allows a fallback string to be used if a translation isn't found.
* `scope`: allows translation keys to be nested. This makes it easier to translate nested structures like the dataset metadata JSON files.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2096)

## Testing
* `yarn test`
* manually tested on localhost.

## Video
Notes that "!!!" was prepended to all the new features being loaded by the `I18n.t()` method

https://user-images.githubusercontent.com/1372238/201016062-977c2625-c924-4484-92ec-77fb769b8650.mov

## Future work
* A follow PR will add i18n support for the dataset display names. This is being split up into a separate PR because it is outside the dataset metadata file.