### PR TITLE
Show filter error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ class PanelButtons extends Component {
     startSaveTrainedModel: PropTypes.func,
     dataToSave: PropTypes.object,
     saveStatus: PropTypes.string,
+    saveData: PropTypes.object,
     isSaveComplete: PropTypes.func,
     shouldDisplaySaveStatus: PropTypes.func
   };
@@ -52,16 +53,38 @@ class PanelButtons extends Component {
     }
   };
 
-  localizedSaveMessage = (saveStatus) => {
-    return I18n.t(`saveStatus_${saveStatus}`)
+  localizedSaveMessage = saveStatus => {
+    return I18n.t(`saveStatus_${saveStatus}`);
+  };
+
+  saveDataMessage = saveData => {
+    // The list of known error types from share_filtering.rb.
+    const errorTypes = ["email", "address", "phone", "profanity"];
+
+    if (!saveData) {
+      return "";
+    }
+
+    const index = errorTypes.indexOf(saveData.type);
+    if (index !== -1) {
+      return ` (${index})`;
+    } else {
+      return "";
+    }
   };
 
   render() {
-    const { panelButtons, saveStatus } = this.props;
+    const { panelButtons, saveStatus, saveData } = this.props;
 
-    let loadSaveStatus= this.props.isSaveComplete(saveStatus)
-      ? this.localizedSaveMessage(saveStatus)
-      : ( <FontAwesomeIcon icon={faSpinner} />);
+    let loadSaveStatus = this.props.isSaveComplete(saveStatus) ? (
+      this.localizedSaveMessage(saveStatus)
+    ) : (
+      <FontAwesomeIcon icon={faSpinner} />
+    );
+
+    let loadSaveData = this.props.isSaveComplete(saveStatus)
+      ? this.saveDataMessage(saveData)
+      : undefined;
 
     return (
       <div style={styles.navigationButtonsContainer}>
@@ -85,7 +108,10 @@ class PanelButtons extends Component {
 
         {this.props.shouldDisplaySaveStatus(saveStatus) &&
           this.props.currentPanel === "saveModel" && (
-            <span style={styles.modelSaveMessage}>{loadSaveStatus}</span>
+            <span style={styles.modelSaveMessage}>
+              {loadSaveStatus}
+              <span style={styles.modelSaveDataMessage}>{loadSaveData}</span>
+            </span>
           )}
 
         {panelButtons.next && (
@@ -157,6 +183,7 @@ class App extends Component {
     startSaveTrainedModel: PropTypes.func,
     dataToSave: PropTypes.object,
     saveStatus: PropTypes.string,
+    saveData: PropTypes.object,
     isSaveComplete: PropTypes.func,
     shouldDisplaySaveStatus: PropTypes.func
   };
@@ -170,7 +197,8 @@ class App extends Component {
       resultsPhase,
       dataToSave,
       startSaveTrainedModel,
-      saveStatus
+      saveStatus,
+      saveData
     } = this.props;
 
     return (
@@ -251,6 +279,7 @@ class App extends Component {
           startSaveTrainedModel={startSaveTrainedModel}
           dataToSave={dataToSave}
           saveStatus={saveStatus}
+          saveData={saveData}
           isSaveComplete={isSaveComplete}
           shouldDisplaySaveStatus={shouldDisplaySaveStatus}
         />
@@ -265,7 +294,8 @@ export default connect(
     currentPanel: state.currentPanel,
     resultsPhase: state.resultsPhase,
     dataToSave: getTrainedModelDataToSave(state),
-    saveStatus: state.saveStatus
+    saveStatus: state.saveStatus,
+    saveData: state.saveData
   }),
   dispatch => ({
     setCurrentPanel(panel) {
@@ -276,6 +306,6 @@ export default connect(
     },
     shouldDisplaySaveStatus(state) {
       dispatch(shouldDisplaySaveStatus(state));
-    },
+    }
   })
 )(App);

--- a/src/App.js
+++ b/src/App.js
@@ -62,14 +62,14 @@ class PanelButtons extends Component {
     const errorTypes = ["email", "address", "phone", "profanity"];
 
     if (!saveResponseData) {
-      return "";
+      return undefined;
     }
 
     const index = errorTypes.indexOf(saveResponseData.type);
     if (index !== -1) {
       return `(${index})`;
     } else {
-      return "";
+      return undefined;
     }
   };
 
@@ -110,9 +110,11 @@ class PanelButtons extends Component {
           this.props.currentPanel === "saveModel" && (
             <div style={styles.modelSaveMessage}>
               {loadSaveStatus}
-              <div style={styles.modelSaveResponseDataMessage}>
-                {loadSaveResponseData}
-              </div>
+              {loadSaveResponseData && (
+                <div style={styles.modelSaveResponseDataMessage}>
+                  {loadSaveResponseData}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ class PanelButtons extends Component {
     startSaveTrainedModel: PropTypes.func,
     dataToSave: PropTypes.object,
     saveStatus: PropTypes.string,
-    saveData: PropTypes.object,
+    saveResponseData: PropTypes.object,
     isSaveComplete: PropTypes.func,
     shouldDisplaySaveStatus: PropTypes.func
   };
@@ -57,15 +57,15 @@ class PanelButtons extends Component {
     return I18n.t(`saveStatus_${saveStatus}`);
   };
 
-  saveDataMessage = saveData => {
+  saveResponseDataMessage = saveResponseData => {
     // The list of known error types from share_filtering.rb.
     const errorTypes = ["email", "address", "phone", "profanity"];
 
-    if (!saveData) {
+    if (!saveResponseData) {
       return "";
     }
 
-    const index = errorTypes.indexOf(saveData.type);
+    const index = errorTypes.indexOf(saveResponseData.type);
     if (index !== -1) {
       return ` (${index})`;
     } else {
@@ -74,7 +74,7 @@ class PanelButtons extends Component {
   };
 
   render() {
-    const { panelButtons, saveStatus, saveData } = this.props;
+    const { panelButtons, saveStatus, saveResponseData } = this.props;
 
     let loadSaveStatus = this.props.isSaveComplete(saveStatus) ? (
       this.localizedSaveMessage(saveStatus)
@@ -82,8 +82,8 @@ class PanelButtons extends Component {
       <FontAwesomeIcon icon={faSpinner} />
     );
 
-    let loadSaveData = this.props.isSaveComplete(saveStatus)
-      ? this.saveDataMessage(saveData)
+    let loadSaveResponseData = this.props.isSaveComplete(saveStatus)
+      ? this.saveResponseDataMessage(saveResponseData)
       : undefined;
 
     return (
@@ -110,7 +110,7 @@ class PanelButtons extends Component {
           this.props.currentPanel === "saveModel" && (
             <span style={styles.modelSaveMessage}>
               {loadSaveStatus}
-              <span style={styles.modelSaveDataMessage}>{loadSaveData}</span>
+              <span style={styles.modelSaveResponseDataMessage}>{loadSaveResponseData}</span>
             </span>
           )}
 
@@ -183,7 +183,7 @@ class App extends Component {
     startSaveTrainedModel: PropTypes.func,
     dataToSave: PropTypes.object,
     saveStatus: PropTypes.string,
-    saveData: PropTypes.object,
+    saveResponseData: PropTypes.object,
     isSaveComplete: PropTypes.func,
     shouldDisplaySaveStatus: PropTypes.func
   };
@@ -198,7 +198,7 @@ class App extends Component {
       dataToSave,
       startSaveTrainedModel,
       saveStatus,
-      saveData
+      saveResponseData
     } = this.props;
 
     return (
@@ -279,7 +279,7 @@ class App extends Component {
           startSaveTrainedModel={startSaveTrainedModel}
           dataToSave={dataToSave}
           saveStatus={saveStatus}
-          saveData={saveData}
+          saveResponseData={saveResponseData}
           isSaveComplete={isSaveComplete}
           shouldDisplaySaveStatus={shouldDisplaySaveStatus}
         />
@@ -295,7 +295,7 @@ export default connect(
     resultsPhase: state.resultsPhase,
     dataToSave: getTrainedModelDataToSave(state),
     saveStatus: state.saveStatus,
-    saveData: state.saveData
+    saveResponseData: state.saveResponseData
   }),
   dispatch => ({
     setCurrentPanel(panel) {

--- a/src/App.js
+++ b/src/App.js
@@ -67,7 +67,7 @@ class PanelButtons extends Component {
 
     const index = errorTypes.indexOf(saveResponseData.type);
     if (index !== -1) {
-      return ` (${index})`;
+      return `(${index})`;
     } else {
       return "";
     }
@@ -108,10 +108,12 @@ class PanelButtons extends Component {
 
         {this.props.shouldDisplaySaveStatus(saveStatus) &&
           this.props.currentPanel === "saveModel" && (
-            <span style={styles.modelSaveMessage}>
+            <div style={styles.modelSaveMessage}>
               {loadSaveStatus}
-              <span style={styles.modelSaveResponseDataMessage}>{loadSaveResponseData}</span>
-            </span>
+              <div style={styles.modelSaveResponseDataMessage}>
+                {loadSaveResponseData}
+              </div>
+            </div>
           )}
 
         {panelButtons.next && (

--- a/src/constants.js
+++ b/src/constants.js
@@ -944,6 +944,7 @@ export const styles = {
   },
 
   modelSaveMessage: {
+    display: "inline-block",
     top: 15,
     zIndex: 1001,
     right: "calc(50% - 250px)",
@@ -953,7 +954,9 @@ export const styles = {
   },
 
   modelSaveResponseDataMessage: {
-    opacity: 0.5
+    display: "inline-block",
+    opacity: 0.5,
+    padding: "0 5px"
   },
 
   navigationButtonsContainer: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -952,6 +952,10 @@ export const styles = {
     width: 500
   },
 
+  modelSaveDataMessage: {
+    opacity: 0.5
+  },
+
   navigationButtonsContainer: {
     position: "relative"
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -952,7 +952,7 @@ export const styles = {
     width: 500
   },
 
-  modelSaveDataMessage: {
+  modelSaveResponseDataMessage: {
     opacity: 0.5
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -98,11 +98,12 @@ const processMode = mode => {
 const startSaveTrainedModel = dataToSave => {
   store.dispatch(setSaveStatus("started"));
   saveTrainedModel(dataToSave, response => {
-    store.dispatch(setSaveStatus(response.status));
+    store.dispatch(setSaveStatus(response.status, response.data));
     if (response.status === "success") {
       store.dispatch(setCurrentPanel("modelSummary"));
     } else {
       store.dispatch(setCurrentPanel("saveModel"));
+      console.log("Save data", response.data);
     }
   });
 };

--- a/src/redux.js
+++ b/src/redux.js
@@ -203,8 +203,8 @@ export function setResultsHighlightRow(highlightRow) {
   return { type: SET_RESULTS_HIGHLIGHT_ROW, highlightRow };
 }
 
-export function setSaveStatus(status) {
-  return { type: SET_SAVE_STATUS, status };
+export function setSaveStatus(status, data) {
+  return { type: SET_SAVE_STATUS, status, data };
 }
 
 export function setHistoricResult(label, features, accuracy) {
@@ -262,6 +262,7 @@ const initialState = {
   // Possible values for saveStatus: "notStarted", "started", "success",
   // "piiProfanity", and "failure".
   saveStatus: "notStarted",
+  saveData: undefined,
   columnRefs: {},
   historicResults: [],
   showResultsDetails: false,
@@ -602,7 +603,8 @@ export default function rootReducer(state = initialState, action) {
   if (action.type === SET_SAVE_STATUS) {
     return {
       ...state,
-      saveStatus: action.status
+      saveStatus: action.status,
+      saveData: action.data
     };
   }
   if (action.type === SET_HISTORIC_RESULT) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -262,7 +262,9 @@ const initialState = {
   // Possible values for saveStatus: "notStarted", "started", "success",
   // "piiProfanity", and "failure".
   saveStatus: "notStarted",
-  saveData: undefined,
+  // Additional data for a failed save response.  Currently contains
+  // details when server-side "share filtering" prevents a save.
+  saveResponseData: undefined,
   columnRefs: {},
   historicResults: [],
   showResultsDetails: false,
@@ -604,7 +606,7 @@ export default function rootReducer(state = initialState, action) {
     return {
       ...state,
       saveStatus: action.status,
-      saveData: action.data
+      saveResponseData: action.data
     };
   }
   if (action.type === SET_HISTORIC_RESULT) {


### PR DESCRIPTION
Now, when we receive a filter error from the server, we show a numerical code so that we can determine the type of error:

<img width="521" alt="Screenshot 2023-04-03 at 12 23 32 PM" src="https://user-images.githubusercontent.com/2205926/229643611-da50bf52-1e11-4e59-90c4-4d6922c827a2.png">

We also log error details to the console:

<img width="358" alt="Screenshot 2023-04-03 at 12 24 22 PM" src="https://user-images.githubusercontent.com/2205926/229643628-51346d09-d803-4522-9cdd-1df3aeba7c57.png">

This change depends on https://github.com/code-dot-org/code-dot-org/pull/51084 on the server.

For now, we are exposing just enough information that we can help out via support ticket.  Going forward, we might well decide to expose more information, and indeed to give actionable feedback so that users can adjust the data on their end.

There is also the broader question of whether we should do some of this filtering at the beginning of the user experience, at least in the cases where it will lead to this model saving.