### PR TITLE
Update toy datasets with missing name property

### DIFF
--- a/public/datasets/club_biased_toy.json
+++ b/public/datasets/club_biased_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "club_biased_toy",
   "card": {
     "name": "Nico's Club Survey",
     "description": "Nico's dad is in a band and sent an email to everyone on their fan club email list. Most people on the email list filled out the form.",

--- a/public/datasets/club_random_toy.json
+++ b/public/datasets/club_random_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "club_random_toy",
   "card": {
     "name": "Isaac's Club Survey",
     "description": "Isaac and his four siblings asked everyone in their classes to fill out the survey. This led to a lot of data from people across many different groups.",

--- a/public/datasets/club_sparse_toy.json
+++ b/public/datasets/club_sparse_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "club_sparse_toy",
   "card": {
     "name": "Zoey's Club Survey",
     "description": "Zoey asked everyone in her English class to complete the survey and they all did!",

--- a/public/datasets/club_specific_toy.json
+++ b/public/datasets/club_specific_toy.json
@@ -1,4 +1,5 @@
 {
+  "name": "club_specific_toy",
   "card": {
     "name": "Kim's Club Survey",
     "description": "Kim asked her older sister what questions she should put in the survey, then sent the survey in an email to her sister's friends at the private university where she goes to school.",


### PR DESCRIPTION
We noticed that descriptions were not showing up for a few datasets -- traced to a missing `name` property.

## Links

- Slack discussion: [link](https://codedotorg.slack.com/archives/C03DBDN67B7/p1681910571638339)

## Testing story

Confirmed by loading these dataset descriptions at `/s/csd7-2022/lessons/19/levels/1` locally in `code-dot-org`, and saw them displaying correctly. Also confirmed they did not load correctly prior to this change.

![image](https://user-images.githubusercontent.com/25372625/233210294-bad47e4d-0d87-4a22-b3e4-d9268a7a4298.png)