### PR TITLE
Bump version again to 0.0.47 due to build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/ml-playground",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "main": "dist/main.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I tried to bump the version of this repo to publish some small changes [in this PR](https://github.com/code-dot-org/ml-playground/pull/301) -- unfortunately, the version I published wasn't built properly (not sure if I built on the wrong branch or what) and didn't contain the changes I expected in the `/dist` directory, which is what is consumed by `code-dot-org`.

I haven't actually published this to npm yet, but I had built/confirmed that the files in the `/dist` directory now reflect what I'd expect (ie, changes to the files changed in the PR above are reflected in `/dist`). I'll publish once someone confirms this seems reasonable.

Side note: helpful beta npm feature that lets you easily inspect exactly what is in your published version helped me see that some changes we had made to datasets weren't in the built version (note the missing top-level `name` property that was added in the PR above):

![image](https://github.com/code-dot-org/ml-playground/assets/25372625/cd6a969b-f910-4134-9e41-6a4cd546d077)
